### PR TITLE
docs: fix typo in RFC6544 link

### DIFF
--- a/rtc-ice/src/tcp_type/mod.rs
+++ b/rtc-ice/src/tcp_type/mod.rs
@@ -4,7 +4,7 @@ mod tcp_type_test;
 use std::fmt;
 
 // TCPType is the type of ICE TCP candidate as described in
-// ttps://tools.ietf.org/html/rfc6544#section-4.5
+// https://tools.ietf.org/html/rfc6544#section-4.5
 #[derive(Default, PartialEq, Eq, Debug, Copy, Clone)]
 pub enum TcpType {
     /// The default value. For example UDP candidates do not need this field.


### PR DESCRIPTION
Fixes a typo in the RFC6544 reference link:
`ttps://tools.ietf.org/html/rfc6544#section-4.5` -> `https://tools.ietf.org/html/rfc6544#section-4.5`