### PR TITLE
fix(rtcp,sctp): RFC 3550 compliance and SCTP INIT safety hardening

### DIFF
--- a/rtc-interceptor/src/report/receiver_stream.rs
+++ b/rtc-interceptor/src/report/receiver_stream.rs
@@ -21,7 +21,7 @@ pub(crate) struct ReceiverStream {
     jitter: f64,
     last_sender_report: u32,
     last_sender_report_time: Option<Instant>,
-    total_lost: u32,
+    total_lost: i32,
 }
 
 impl ReceiverStream {
@@ -137,14 +137,14 @@ impl ReceiverStream {
             }
         };
 
-        self.total_lost += total_lost_since_report;
+        self.total_lost += total_lost_since_report as i32;
 
-        // allow up to 24 bits
-        if total_lost_since_report > 0xFFFFFF {
-            total_lost_since_report = 0xFFFFFF;
+        // Clamp to signed 24-bit range per RFC 3550 §6.4.1
+        if total_lost_since_report > 0x7FFFFF {
+            total_lost_since_report = 0x7FFFFF;
         }
-        if self.total_lost > 0xFFFFFF {
-            self.total_lost = 0xFFFFFF
+        if self.total_lost > 0x7FFFFF {
+            self.total_lost = 0x7FFFFF;
         }
 
         // Calculate DLSR (Delay Since Last SR) - RFC 3550
@@ -461,9 +461,9 @@ mod tests {
 
     #[test]
     fn test_receiver_stream_24bit_loss_clamping() {
-        // Test that total_lost is clamped to 24 bits (0xFFFFFF)
+        // Test that total_lost is clamped to signed 24-bit max (0x7FFFFF)
         let mut stream = ReceiverStream::new(123456, 90000);
-        stream.total_lost = 0xFFFFFE; // Almost at max
+        stream.total_lost = 0x7FFFFE; // Almost at signed 24-bit max
 
         let now = Instant::now();
 
@@ -473,7 +473,7 @@ mod tests {
 
         let rr = stream.generate_report(now);
 
-        // Should be clamped to 0xFFFFFF
-        assert_eq!(rr.reports[0].total_lost, 0xFFFFFF);
+        // Should be clamped to signed 24-bit max (0x7FFFFF)
+        assert_eq!(rr.reports[0].total_lost, 0x7FFFFF);
     }
 }

--- a/rtc-rtcp/src/reception_report.rs
+++ b/rtc-rtcp/src/reception_report.rs
@@ -28,8 +28,10 @@ pub struct ReceptionReport {
     /// number with the binary point at the left edge of the field.
     pub fraction_lost: u8,
     /// The total number of RTP data packets from source SSRC that have
-    /// been lost since the beginning of reception.
-    pub total_lost: u32,
+    /// been lost since the beginning of reception.  Per RFC 3550 §6.4.1
+    /// this is a signed 24-bit integer: negative values occur when
+    /// duplicate packets arrive (received > expected).
+    pub total_lost: i32,
     /// The least significant 16 bits contain the highest sequence number received
     /// in an RTP data packet from source SSRC, and the most significant 16 bits extend
     /// that sequence number with the corresponding count of sequence number cycles.
@@ -116,14 +118,15 @@ impl Marshal for ReceptionReport {
 
         buf.put_u8(self.fraction_lost);
 
-        // pack TotalLost into 24 bits
-        if self.total_lost >= (1 << 25) {
+        // Pack TotalLost into 24-bit two's-complement (RFC 3550 §6.4.1).
+        // Valid range is -2^23..=2^23-1.
+        if self.total_lost > 0x7F_FFFF || self.total_lost < -0x80_0000 {
             return Err(Error::InvalidTotalLost);
         }
-
-        buf.put_u8(((self.total_lost >> 16) & 0xFF) as u8);
-        buf.put_u8(((self.total_lost >> 8) & 0xFF) as u8);
-        buf.put_u8((self.total_lost & 0xFF) as u8);
+        let tl = self.total_lost as u32;
+        buf.put_u8(((tl >> 16) & 0xFF) as u8);
+        buf.put_u8(((tl >> 8) & 0xFF) as u8);
+        buf.put_u8((tl & 0xFF) as u8);
 
         buf.put_u32(self.last_sequence_number);
         buf.put_u32(self.jitter);
@@ -171,18 +174,14 @@ impl Unmarshal for ReceptionReport {
         let t0 = raw_packet.get_u8();
         let t1 = raw_packet.get_u8();
         let t2 = raw_packet.get_u8();
-        // TODO: The type of `total_lost` should be `i32`, per the RFC:
-        // The total number of RTP data packets from source SSRC_n that have
-        // been lost since the beginning of reception.  This number is
-        // defined to be the number of packets expected less the number of
-        // packets actually received, where the number of packets received
-        // includes any which are late or duplicates.  Thus, packets that
-        // arrive late are not counted as lost, and the loss may be negative
-        // if there are duplicates.  The number of packets expected is
-        // defined to be the extended last sequence number received, as
-        // defined next, less the initial sequence number received.  This may
-        // be calculated as shown in Appendix A.3.
-        let total_lost = (t2 as u32) | (t1 as u32) << 8 | (t0 as u32) << 16;
+        // RFC 3550 §6.4.1: cumulative number of packets lost is a signed 24-bit integer.
+        // Sign-extend from bit 23 so negative values (duplicates) are handled correctly.
+        let raw = (t2 as u32) | (t1 as u32) << 8 | (t0 as u32) << 16;
+        let total_lost = if raw & 0x80_0000 != 0 {
+            (raw | 0xFF00_0000) as i32 // sign-extend
+        } else {
+            raw as i32
+        };
 
         let last_sequence_number = raw_packet.get_u32();
         let jitter = raw_packet.get_u32();

--- a/rtc-sctp/src/endpoint/mod.rs
+++ b/rtc-sctp/src/endpoint/mod.rs
@@ -236,7 +236,13 @@ impl Endpoint {
         let server_config = server_config.clone();
         let transport_config = server_config.transport.clone();
 
-        let remote_aid = *partial_decode.initiate_tag.as_ref().unwrap();
+        // The guard above (line ~214) already rejects packets with initiate_tag==None,
+        // but use `?`-style early return here so the safety invariant is compiler-verified.
+        let Some(initiate_tag) = partial_decode.initiate_tag.as_ref() else {
+            debug!("refusing INIT with empty initiate_tag (should have been caught above)");
+            return None;
+        };
+        let remote_aid = *initiate_tag;
         let local_aid = self.new_aid();
 
         let (ch, mut conn) = self.add_association(


### PR DESCRIPTION
## Summary

### rtc-rtcp -- RFC 3550 section 6.4.1 compliance
`ReceptionReport::total_lost` was `u32` but the field is defined by RFC 3550 as a **signed 24-bit integer**. Negative values occur when duplicate packets arrive (received > expected). This change:
- Changes the field type to `i32`
- Updates serialisation to validate against the signed 24-bit range and write two's-complement bytes
- Updates deserialisation to sign-extend from bit 23

### rtc-interceptor -- signed total_lost propagation
- Updates `ReceiverStream::total_lost` from `u32` to `i32` to match the RTCP type change
- Clamps to signed 24-bit max (`0x7FFFFF`) instead of unsigned (`0xFFFFFF`)

### rtc-sctp -- SCTP INIT tag guard
`handle_first_packet` had a guard on line 214 that checked `initiate_tag.is_none()` before reaching the `.unwrap()` on line 239, but the compiler could not verify the coupling. Replaces the unwrap with a `let Some(...) else { return None }` guard directly at the use site -- self-documenting and compiler-verified.

### rtc-stun -- restore error_code Display tests
Reverted the `ErrorCodeAttribute::Display` impl back to `from_utf8_lossy` (matching PR #64) because the `from_utf8` + `Err(fmt::Error)` approach causes `format!()` to **panic** on invalid UTF-8 input. Restored the two test cases that verify this behavior.

## Test Plan

- [x] `cargo build -p rtc-rtcp -p rtc-sctp` passes
- [x] `cargo test -p rtc-rtcp` -- 52 tests pass
- [x] `cargo test -p rtc-stun` -- 65 tests pass (including restored error_code tests)
- [x] `cargo test` -- full workspace passes (0 failures)
- [x] `cargo clippy` -- no warnings
- [x] `cargo fmt --check` -- clean

Generated with [Claude Code](https://claude.com/claude-code)