### PR TITLE
fix(rtp_transceiver): trigger renegotiation on set_direction (closes #51)

### DIFF
--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -846,8 +846,14 @@ where
         Err(Error::ErrMaxDataChannelID)
     }
 
+    /// Called by `RTCRtpTransceiver::set_direction` when the direction changes,
+    /// per W3C WebRTC §5.5.
+    pub(crate) fn on_transceiver_direction_changed(&mut self) {
+        self.trigger_negotiation_needed();
+    }
+
     /// Helper to trigger a negotiation needed.
-    pub(crate) fn trigger_negotiation_needed(&mut self) {
+    pub(super) fn trigger_negotiation_needed(&mut self) {
         if !self.do_negotiation_needed() {
             return;
         }

--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -847,7 +847,7 @@ where
     }
 
     /// Helper to trigger a negotiation needed.
-    pub(super) fn trigger_negotiation_needed(&mut self) {
+    pub(crate) fn trigger_negotiation_needed(&mut self) {
         if !self.do_negotiation_needed() {
             return;
         }

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -672,6 +672,12 @@ impl<I> RTCPeerConnection<I>
 where
     I: Interceptor,
 {
+    /// Reset negotiation state for testing purposes.
+    #[cfg(test)]
+    pub(crate) fn reset_negotiation_state(&mut self) {
+        self.negotiation_needed_state = NegotiationNeededState::Empty;
+        self.is_negotiation_ongoing = false;
+    }
     /// Creates an SDP offer to start a new WebRTC connection to a remote peer.
     ///
     /// The offer includes information about the attached media tracks, codecs and options supported

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -672,12 +672,6 @@ impl<I> RTCPeerConnection<I>
 where
     I: Interceptor,
 {
-    /// Reset negotiation state for testing purposes.
-    #[cfg(test)]
-    pub(crate) fn reset_negotiation_state(&mut self) {
-        self.negotiation_needed_state = NegotiationNeededState::Empty;
-        self.is_negotiation_ongoing = false;
-    }
     /// Creates an SDP offer to start a new WebRTC connection to a remote peer.
     ///
     /// The offer includes information about the attached media tracks, codecs and options supported

--- a/rtc/src/rtp_transceiver/internal.rs
+++ b/rtc/src/rtp_transceiver/internal.rs
@@ -155,9 +155,6 @@ where
 
         if direction != previous_direction {
             trace!("Changing direction of transceiver from {previous_direction} to {direction}");
-
-            //TODO: https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction
-            // Update the negotiation-needed flag for connection.
         }
     }
 

--- a/rtc/src/rtp_transceiver/internal.rs
+++ b/rtc/src/rtp_transceiver/internal.rs
@@ -149,13 +149,7 @@ where
     ///
     /// See [RTCRtpTransceiver.direction](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction).
     pub(crate) fn set_direction(&mut self, direction: RTCRtpTransceiverDirection) {
-        let previous_direction: RTCRtpTransceiverDirection = self.direction;
-
         self.direction = direction;
-
-        if direction != previous_direction {
-            trace!("Changing direction of transceiver from {previous_direction} to {direction}");
-        }
     }
 
     /// Returns the negotiated direction of the transceiver.

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -289,7 +289,12 @@ where
     pub fn set_direction(&mut self, direction: RTCRtpTransceiverDirection) {
         // peer_connection is mutable borrow, its rtp_transceivers won't be resized,
         // so, [self.id] here is safe.
+        let previous = self.peer_connection.rtp_transceivers[self.id].direction();
         self.peer_connection.rtp_transceivers[self.id].set_direction(direction);
+        // Per W3C WebRTC §5.5: changing direction must trigger renegotiation.
+        if direction != previous {
+            self.peer_connection.trigger_negotiation_needed();
+        }
     }
 
     /// Returns the negotiated direction of the transceiver.

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -296,7 +296,7 @@ where
         // Per W3C WebRTC §5.5: changing direction must trigger renegotiation.
         if direction != previous {
             trace!("Changing direction of transceiver from {previous} to {direction}");
-            self.peer_connection.trigger_negotiation_needed();
+            self.peer_connection.on_transceiver_direction_changed();
         }
     }
 
@@ -349,5 +349,64 @@ where
         // so, [self.id] here is safe.
         self.peer_connection.rtp_transceivers[self.id]
             .set_codec_preferences(codecs, &self.peer_connection.media_engine)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::peer_connection::RTCPeerConnectionBuilder;
+    use crate::peer_connection::event::RTCPeerConnectionEvent;
+    use crate::rtp_transceiver::direction::RTCRtpTransceiverDirection;
+    use crate::rtp_transceiver::rtp_sender::rtp_codec::RtpCodecKind;
+
+    #[test]
+    fn test_set_direction_triggers_negotiation_on_change() {
+        let mut pc = RTCPeerConnectionBuilder::new().build().unwrap();
+        let tid = pc
+            .add_transceiver_from_kind(RtpCodecKind::Audio, None)
+            .unwrap();
+
+        // Reset negotiation state machine after add_transceiver triggered it
+        pc.pipeline_context.event_outs.clear();
+        pc.reset_negotiation_state();
+
+        // Changing direction should trigger negotiation
+        let mut t = pc.rtp_transceiver(tid).unwrap();
+        t.set_direction(RTCRtpTransceiverDirection::Sendonly);
+        drop(t);
+
+        assert!(
+            pc.pipeline_context
+                .event_outs
+                .iter()
+                .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent)),
+            "changing direction should trigger OnNegotiationNeededEvent"
+        );
+    }
+
+    #[test]
+    fn test_set_direction_noop_when_unchanged() {
+        let mut pc = RTCPeerConnectionBuilder::new().build().unwrap();
+        let tid = pc
+            .add_transceiver_from_kind(RtpCodecKind::Audio, None)
+            .unwrap();
+
+        // Reset negotiation state machine after add_transceiver triggered it
+        pc.pipeline_context.event_outs.clear();
+        pc.reset_negotiation_state();
+
+        // Setting the same direction should NOT trigger negotiation
+        let current = pc.rtp_transceivers[tid].direction();
+        let mut t = pc.rtp_transceiver(tid).unwrap();
+        t.set_direction(current);
+        drop(t);
+
+        assert!(
+            !pc.pipeline_context
+                .event_outs
+                .iter()
+                .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent)),
+            "setting the same direction should not trigger OnNegotiationNeededEvent"
+        );
     }
 }

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -352,59 +352,162 @@ where
 
 #[cfg(test)]
 mod tests {
+    use sansio::Protocol;
+
     use crate::peer_connection::RTCPeerConnectionBuilder;
+    use crate::peer_connection::configuration::RTCConfigurationBuilder;
+    use crate::peer_connection::configuration::media_engine::{MIME_TYPE_OPUS, MediaEngine};
     use crate::peer_connection::event::RTCPeerConnectionEvent;
+    use crate::peer_connection::transport::{
+        CandidateConfig, CandidateHostConfig, RTCIceCandidate, RTCIceServer,
+    };
     use crate::rtp_transceiver::direction::RTCRtpTransceiverDirection;
+    use crate::rtp_transceiver::rtp_sender::rtp_codec::RTCRtpCodec;
     use crate::rtp_transceiver::rtp_sender::rtp_codec::RtpCodecKind;
+    use crate::rtp_transceiver::rtp_sender::rtp_codec_parameters::RTCRtpCodecParameters;
+
+    /// Bind a UDP socket to `127.0.0.1:0` and return the OS-assigned port.
+    fn ephemeral_port() -> u16 {
+        std::net::UdpSocket::bind("127.0.0.1:0")
+            .expect("bind ephemeral UDP port")
+            .local_addr()
+            .expect("local_addr")
+            .port()
+    }
+
+    fn make_media_engine() -> MediaEngine {
+        let mut me = MediaEngine::default();
+        me.register_codec(
+            RTCRtpCodecParameters {
+                rtp_codec: RTCRtpCodec {
+                    mime_type: MIME_TYPE_OPUS.to_owned(),
+                    clock_rate: 48000,
+                    channels: 2,
+                    sdp_fmtp_line: "".to_owned(),
+                    rtcp_feedback: vec![],
+                },
+                payload_type: 111,
+                ..Default::default()
+            },
+            RtpCodecKind::Audio,
+        )
+        .unwrap();
+        me
+    }
+
+    fn build_pc() -> crate::peer_connection::RTCPeerConnection {
+        let config = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+                ..Default::default()
+            }])
+            .build();
+        let mut pc = RTCPeerConnectionBuilder::new()
+            .with_configuration(config)
+            .with_media_engine(make_media_engine())
+            .build()
+            .unwrap();
+
+        let candidate = CandidateHostConfig {
+            base_config: CandidateConfig {
+                network: "udp".to_owned(),
+                address: "127.0.0.1".to_owned(),
+                port: ephemeral_port(),
+                component: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .new_candidate_host()
+        .unwrap();
+        pc.add_local_candidate(RTCIceCandidate::from(&candidate).to_json().unwrap())
+            .unwrap();
+
+        pc
+    }
+
+    /// Drain all pending events from a peer connection via the public API.
+    fn drain_events(
+        pc: &mut crate::peer_connection::RTCPeerConnection,
+    ) -> Vec<RTCPeerConnectionEvent> {
+        let mut events = vec![];
+        while let Some(e) = pc.poll_event() {
+            events.push(e);
+        }
+        events
+    }
+
+    fn has_negotiation_needed(events: &[RTCPeerConnectionEvent]) -> bool {
+        events
+            .iter()
+            .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent))
+    }
 
     #[test]
     fn test_set_direction_triggers_negotiation_on_change() {
-        let mut pc = RTCPeerConnectionBuilder::new().build().unwrap();
-        let tid = pc
+        let mut offer_pc = build_pc();
+        let mut answer_pc = build_pc();
+
+        let tid = offer_pc
             .add_transceiver_from_kind(RtpCodecKind::Audio, None)
             .unwrap();
 
-        // Reset negotiation state machine after add_transceiver triggered it
-        pc.pipeline_context.event_outs.clear();
-        pc.reset_negotiation_state();
+        // Complete an offer/answer cycle to reach Stable signaling state,
+        // which clears is_negotiation_ongoing via the normal state machine.
+        let offer = offer_pc.create_offer(None).unwrap();
+        offer_pc.set_local_description(offer.clone()).unwrap();
+        answer_pc.set_remote_description(offer).unwrap();
+        let answer = answer_pc.create_answer(None).unwrap();
+        answer_pc.set_local_description(answer.clone()).unwrap();
+        offer_pc.set_remote_description(answer).unwrap();
+
+        // Drain all events from the initial negotiation.
+        drain_events(&mut offer_pc);
 
         // Changing direction should trigger negotiation
-        let mut t = pc.rtp_transceiver(tid).unwrap();
-        t.set_direction(RTCRtpTransceiverDirection::Sendonly);
-        drop(t);
+        {
+            let mut t = offer_pc.rtp_transceiver(tid).unwrap();
+            t.set_direction(RTCRtpTransceiverDirection::Sendonly);
+        }
 
+        let events = drain_events(&mut offer_pc);
         assert!(
-            pc.pipeline_context
-                .event_outs
-                .iter()
-                .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent)),
-            "changing direction should trigger OnNegotiationNeededEvent"
+            has_negotiation_needed(&events),
+            "changing direction should trigger OnNegotiationNeededEvent, but got: {events:?}"
         );
     }
 
     #[test]
     fn test_set_direction_noop_when_unchanged() {
-        let mut pc = RTCPeerConnectionBuilder::new().build().unwrap();
-        let tid = pc
+        let mut offer_pc = build_pc();
+        let mut answer_pc = build_pc();
+
+        let tid = offer_pc
             .add_transceiver_from_kind(RtpCodecKind::Audio, None)
             .unwrap();
 
-        // Reset negotiation state machine after add_transceiver triggered it
-        pc.pipeline_context.event_outs.clear();
-        pc.reset_negotiation_state();
+        // Complete an offer/answer cycle to reach Stable signaling state.
+        let offer = offer_pc.create_offer(None).unwrap();
+        offer_pc.set_local_description(offer.clone()).unwrap();
+        answer_pc.set_remote_description(offer).unwrap();
+        let answer = answer_pc.create_answer(None).unwrap();
+        answer_pc.set_local_description(answer.clone()).unwrap();
+        offer_pc.set_remote_description(answer).unwrap();
+
+        // Drain all events from the initial negotiation.
+        drain_events(&mut offer_pc);
 
         // Setting the same direction should NOT trigger negotiation
-        let current = pc.rtp_transceivers[tid].direction();
-        let mut t = pc.rtp_transceiver(tid).unwrap();
-        t.set_direction(current);
-        drop(t);
+        let current = offer_pc.rtp_transceivers[tid].direction();
+        {
+            let mut t = offer_pc.rtp_transceiver(tid).unwrap();
+            t.set_direction(current);
+        }
 
+        let events = drain_events(&mut offer_pc);
         assert!(
-            !pc.pipeline_context
-                .event_outs
-                .iter()
-                .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent)),
-            "setting the same direction should not trigger OnNegotiationNeededEvent"
+            !has_negotiation_needed(&events),
+            "setting the same direction should not trigger OnNegotiationNeededEvent, but got: {events:?}"
         );
     }
 }

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -293,9 +293,10 @@ where
         // so, [self.id] here is safe.
         let previous = self.peer_connection.rtp_transceivers[self.id].direction();
         self.peer_connection.rtp_transceivers[self.id].set_direction(direction);
+        let current = self.peer_connection.rtp_transceivers[self.id].direction();
         // Per W3C WebRTC §5.5: changing direction must trigger renegotiation.
-        if direction != previous {
-            trace!("Changing direction of transceiver from {previous} to {direction}");
+        if current != previous {
+            trace!("Changing direction of transceiver from {previous} to {current}");
             self.peer_connection.on_transceiver_direction_changed();
         }
     }

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -96,9 +96,6 @@
 //!
 //! See [RTCRtpTransceiver](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver) in the W3C WebRTC specification.
 
-//TODO: #[cfg(test)]
-//mod rtp_transceiver_test;
-
 use log::trace;
 
 use crate::media_stream::MediaStreamId;

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -99,6 +99,8 @@
 //TODO: #[cfg(test)]
 //mod rtp_transceiver_test;
 
+use log::trace;
+
 use crate::media_stream::MediaStreamId;
 use crate::peer_connection::RTCPeerConnection;
 use crate::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
@@ -293,6 +295,7 @@ where
         self.peer_connection.rtp_transceivers[self.id].set_direction(direction);
         // Per W3C WebRTC §5.5: changing direction must trigger renegotiation.
         if direction != previous {
+            trace!("Changing direction of transceiver from {previous} to {direction}");
             self.peer_connection.trigger_negotiation_needed();
         }
     }

--- a/rtc/tests/renegotiation_set_direction.rs
+++ b/rtc/tests/renegotiation_set_direction.rs
@@ -15,7 +15,7 @@ use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
 use rtc::rtp_transceiver::rtp_sender::RTCRtpCodec;
 use rtc::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
 use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
-use sansio::Protocol;
+use rtc::sansio::Protocol;
 
 fn drain_events(pc: &mut rtc::peer_connection::RTCPeerConnection) -> Vec<RTCPeerConnectionEvent> {
     let mut events = vec![];
@@ -51,11 +51,16 @@ fn make_media_engine() -> MediaEngine {
     me
 }
 
-fn build_pc(
-    dtls_role: RTCDtlsRole,
-    addr: &str,
-    port: u16,
-) -> rtc::peer_connection::RTCPeerConnection {
+/// Bind a UDP socket to `127.0.0.1:0` and return the OS-assigned port.
+fn ephemeral_port() -> u16 {
+    std::net::UdpSocket::bind("127.0.0.1:0")
+        .expect("bind ephemeral UDP port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+fn build_pc(dtls_role: RTCDtlsRole, port: u16) -> rtc::peer_connection::RTCPeerConnection {
     let mut se = SettingEngine::default();
     se.set_answering_dtls_role(dtls_role).unwrap();
 
@@ -76,7 +81,7 @@ fn build_pc(
     let candidate = CandidateHostConfig {
         base_config: CandidateConfig {
             network: "udp".to_owned(),
-            address: addr.to_owned(),
+            address: "127.0.0.1".to_owned(),
             port,
             component: 1,
             ..Default::default()
@@ -93,8 +98,8 @@ fn build_pc(
 
 #[test]
 fn test_set_direction_change_triggers_renegotiation() {
-    let mut offer_pc = build_pc(RTCDtlsRole::Server, "127.0.0.1", 10000);
-    let mut answer_pc = build_pc(RTCDtlsRole::Client, "127.0.0.1", 10001);
+    let mut offer_pc = build_pc(RTCDtlsRole::Server, ephemeral_port());
+    let mut answer_pc = build_pc(RTCDtlsRole::Client, ephemeral_port());
 
     // Add a recvonly audio transceiver on the offer side.
     let tid = offer_pc

--- a/rtc/tests/renegotiation_set_direction.rs
+++ b/rtc/tests/renegotiation_set_direction.rs
@@ -1,0 +1,147 @@
+/// Integration test: verify that changing a transceiver's direction triggers
+/// an `OnNegotiationNeededEvent`, and that setting the same direction does not.
+///
+/// Per W3C WebRTC §5.5, mutating the direction property MUST update the
+/// negotiation-needed flag, causing the peer connection to fire the event.
+use rtc::peer_connection::RTCPeerConnectionBuilder;
+use rtc::peer_connection::configuration::RTCConfigurationBuilder;
+use rtc::peer_connection::configuration::media_engine::{MIME_TYPE_OPUS, MediaEngine};
+use rtc::peer_connection::configuration::setting_engine::SettingEngine;
+use rtc::peer_connection::event::RTCPeerConnectionEvent;
+use rtc::peer_connection::transport::{
+    CandidateConfig, CandidateHostConfig, RTCDtlsRole, RTCIceCandidate, RTCIceServer,
+};
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::rtp_sender::RTCRtpCodec;
+use rtc::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use sansio::Protocol;
+
+fn drain_events(pc: &mut rtc::peer_connection::RTCPeerConnection) -> Vec<RTCPeerConnectionEvent> {
+    let mut events = vec![];
+    while let Some(e) = pc.poll_event() {
+        events.push(e);
+    }
+    events
+}
+
+fn has_negotiation_needed(events: &[RTCPeerConnectionEvent]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, RTCPeerConnectionEvent::OnNegotiationNeededEvent))
+}
+
+fn make_media_engine() -> MediaEngine {
+    let mut me = MediaEngine::default();
+    me.register_codec(
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: MIME_TYPE_OPUS.to_owned(),
+                clock_rate: 48000,
+                channels: 2,
+                sdp_fmtp_line: "".to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type: 111,
+            ..Default::default()
+        },
+        RtpCodecKind::Audio,
+    )
+    .unwrap();
+    me
+}
+
+fn build_pc(
+    dtls_role: RTCDtlsRole,
+    addr: &str,
+    port: u16,
+) -> rtc::peer_connection::RTCPeerConnection {
+    let mut se = SettingEngine::default();
+    se.set_answering_dtls_role(dtls_role).unwrap();
+
+    let config = RTCConfigurationBuilder::new()
+        .with_ice_servers(vec![RTCIceServer {
+            urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+            ..Default::default()
+        }])
+        .build();
+
+    let mut pc = RTCPeerConnectionBuilder::new()
+        .with_configuration(config)
+        .with_media_engine(make_media_engine())
+        .with_setting_engine(se)
+        .build()
+        .unwrap();
+
+    let candidate = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: addr.to_owned(),
+            port,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()
+    .unwrap();
+    pc.add_local_candidate(RTCIceCandidate::from(&candidate).to_json().unwrap())
+        .unwrap();
+
+    pc
+}
+
+#[test]
+fn test_set_direction_change_triggers_renegotiation() {
+    let mut offer_pc = build_pc(RTCDtlsRole::Server, "127.0.0.1", 10000);
+    let mut answer_pc = build_pc(RTCDtlsRole::Client, "127.0.0.1", 10001);
+
+    // Add a recvonly audio transceiver on the offer side.
+    let tid = offer_pc
+        .add_transceiver_from_kind(RtpCodecKind::Audio, None)
+        .unwrap();
+
+    // Complete an initial offer/answer cycle to clear is_negotiation_ongoing.
+    let offer = offer_pc.create_offer(None).unwrap();
+    offer_pc.set_local_description(offer.clone()).unwrap();
+    answer_pc.set_remote_description(offer).unwrap();
+    let answer = answer_pc.create_answer(None).unwrap();
+    answer_pc.set_local_description(answer.clone()).unwrap();
+    offer_pc.set_remote_description(answer).unwrap();
+
+    // Drain all events from the initial negotiation.
+    drain_events(&mut offer_pc);
+
+    // --- Test 1: changing direction triggers OnNegotiationNeededEvent ---
+    {
+        let mut t = offer_pc.rtp_transceiver(tid).unwrap();
+        assert_eq!(
+            t.direction(),
+            RTCRtpTransceiverDirection::Recvonly,
+            "precondition: direction should be Recvonly"
+        );
+        t.set_direction(RTCRtpTransceiverDirection::Inactive);
+    }
+
+    let events = drain_events(&mut offer_pc);
+    assert!(
+        has_negotiation_needed(&events),
+        "changing direction from Recvonly to Inactive should trigger OnNegotiationNeededEvent, \
+         but got: {:?}",
+        events
+    );
+
+    // --- Test 2: setting the same direction is a no-op ---
+    drain_events(&mut offer_pc);
+    {
+        let mut t = offer_pc.rtp_transceiver(tid).unwrap();
+        t.set_direction(RTCRtpTransceiverDirection::Inactive);
+    }
+    let events = drain_events(&mut offer_pc);
+    assert!(
+        !has_negotiation_needed(&events),
+        "setting the same direction (Inactive -> Inactive) should NOT trigger \
+         OnNegotiationNeededEvent, but got: {:?}",
+        events
+    );
+}


### PR DESCRIPTION
## Summary

- `RTCRtpTransceiver::set_direction()` now calls `trigger_negotiation_needed()` on the peer connection when the direction actually changes, per [W3C WebRTC §5.5](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction)
- The fix uses a narrow `pub(crate) on_transceiver_direction_changed()` method to keep `trigger_negotiation_needed` at `pub(super)` visibility
- Compares the transceiver's effective direction after the setter (not the input value) for robustness against future normalization
- The `trace!` log is moved from `internal.rs` to `mod.rs` where the negotiation logic lives
- The now-unnecessary `previous_direction` variable in `internal.rs` is removed
- Removed obsolete `//TODO: #[cfg(test)] mod rtp_transceiver_test;` comment since inline tests now exist

## Review feedback addressed

- [x] **rainliu**: Move `trace!` from internal `set_direction` to public `set_direction` (commit 731341b5)
- [x] **rainliu**: Add unit test and integration test (commits 539b9354, e17adf6f)
- [x] **Copilot**: Compare effective direction after `set_direction`, not input (commit e17adf6f)
- [x] **Copilot**: Narrow `pub(crate)` exposure via `on_transceiver_direction_changed()` (commit 2252d20e)
- [x] **Copilot**: Remove misleading TODO comment for `rtp_transceiver_test` module (commit 8d816eb7)

## Test plan

- [x] `cargo build -p rtc` passes
- [x] `cargo test -p rtc` passes (246 lib tests + 28 integration tests, 0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] Unit test: `test_set_direction_triggers_negotiation_on_change` — verifies `OnNegotiationNeededEvent` is emitted when direction changes
- [x] Unit test: `test_set_direction_noop_when_unchanged` — verifies no event when setting the same direction
- [x] Integration test: `test_set_direction_change_triggers_renegotiation` — full offer/answer cycle via public `Protocol` API with Opus codecs, STUN server, and host candidates; asserts `poll_event()` returns `OnNegotiationNeededEvent` on direction change and no event on same-direction set

Generated with [Claude Code](https://claude.com/claude-code)