### PR TITLE
chore: resolve actionable TODO/FIXME comments

### DIFF
--- a/rtc-sctp/src/endpoint/mod.rs
+++ b/rtc-sctp/src/endpoint/mod.rs
@@ -130,7 +130,11 @@ impl Endpoint {
         let known_ch = if dst_cid > 0 {
             self.association_ids.get(&dst_cid).cloned()
         } else {
-            //TODO: improve INIT handling for DoS attack
+            // INIT packets arrive with verification_tag=0 (per RFC 4960 §8.5.1).
+            // Full DoS hardening would require per-source-address rate limiting or
+            // stateless cookie exchange (RFC 4960 §5.1.3); the global
+            // server_config.concurrent_associations limit in handle_first_packet()
+            // provides coarse-grained protection in the meantime.
             if partial_decode.first_chunk_type == CT_INIT {
                 if let Some(dst_cid) = partial_decode.initiate_tag {
                     self.association_ids.get(&dst_cid).cloned()

--- a/rtc-sctp/src/endpoint/mod.rs
+++ b/rtc-sctp/src/endpoint/mod.rs
@@ -133,8 +133,9 @@ impl Endpoint {
             // INIT packets arrive with verification_tag=0 (per RFC 4960 §8.5.1).
             // Full DoS hardening would require per-source-address rate limiting or
             // stateless cookie exchange (RFC 4960 §5.1.3); the global
-            // server_config.concurrent_associations limit in handle_first_packet()
-            // provides coarse-grained protection in the meantime.
+            // server_config.concurrent_associations limit enforced during
+            // first-packet handling provides coarse-grained protection in the
+            // meantime.
             if partial_decode.first_chunk_type == CT_INIT {
                 if let Some(dst_cid) = partial_decode.initiate_tag {
                     self.association_ids.get(&dst_cid).cloned()

--- a/rtc-turn/src/proto/evenport.rs
+++ b/rtc-turn/src/proto/evenport.rs
@@ -34,7 +34,9 @@ impl fmt::Display for EvenPort {
 }
 
 const EVEN_PORT_SIZE: usize = 1;
-const FIRST_BIT_SET: u8 = 0b10000000; //FIXME? (1 << 8) - 1;
+// RFC 5766 §14.6: only the most-significant bit (R flag) is meaningful;
+// remaining bits are reserved and must be zero.  0b10000000 = 1 << 7 is correct.
+const FIRST_BIT_SET: u8 = 0b10000000;
 
 impl Setter for EvenPort {
     /// Adds `EVEN-PORT` to message.

--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -172,7 +172,9 @@ impl Default for MulticastDNS {
     fn default() -> Self {
         Self {
             timeout: Some(Duration::from_secs(10)),
-            mode: MulticastDnsMode::Disabled, //TODO: Re-enable it to QueryOnly
+            // mDNS is opt-in: callers enable it via set_multicast_dns_mode().
+            // The async wrapper also requires with_mdns_mode() to create the multicast socket.
+            mode: MulticastDnsMode::Disabled,
             local_name: "".to_string(),
             local_ip: None,
         }

--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -173,7 +173,7 @@ impl Default for MulticastDNS {
         Self {
             timeout: Some(Duration::from_secs(10)),
             // mDNS is opt-in: callers enable it via set_multicast_dns_mode().
-            // The async wrapper also requires with_mdns_mode() to create the multicast socket.
+            // Any async wrapper must also be configured to create and bind the multicast socket.
             mode: MulticastDnsMode::Disabled,
             local_name: "".to_string(),
             local_ip: None,

--- a/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -142,8 +142,6 @@ pub(crate) fn codec_parameters_fuzzy_search(
 ) -> (RTCRtpCodecParameters, CodecMatch) {
     let needle_fmtp = fmtp::parse(&needle_rtp_codec.mime_type, &needle_rtp_codec.sdp_fmtp_line);
 
-    //TODO: add unicode case-folding equal support
-
     // First attempt to match on mime_type + sdpfmtp_line
     for c in haystack {
         let cfmpt = fmtp::parse(&c.rtp_codec.mime_type, &c.rtp_codec.sdp_fmtp_line);
@@ -154,7 +152,8 @@ pub(crate) fn codec_parameters_fuzzy_search(
 
     // Fallback to just mime_type
     for c in haystack {
-        if c.rtp_codec.mime_type.to_uppercase() == needle_rtp_codec.mime_type.to_uppercase() {
+        // MIME types are ASCII-only; eq_ignore_ascii_case is sufficient and allocation-free.
+        if c.rtp_codec.mime_type.eq_ignore_ascii_case(&needle_rtp_codec.mime_type) {
             return (c.clone(), CodecMatch::Partial);
         }
     }

--- a/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -153,7 +153,10 @@ pub(crate) fn codec_parameters_fuzzy_search(
     // Fallback to just mime_type
     for c in haystack {
         // MIME types are ASCII-only; eq_ignore_ascii_case is sufficient and allocation-free.
-        if c.rtp_codec.mime_type.eq_ignore_ascii_case(&needle_rtp_codec.mime_type) {
+        if c.rtp_codec
+            .mime_type
+            .eq_ignore_ascii_case(&needle_rtp_codec.mime_type)
+        {
             return (c.clone(), CodecMatch::Partial);
         }
     }


### PR DESCRIPTION
## Summary

Cleans up four concrete TODO/FIXME items found in a codebase-wide audit:

| File | Change |
|------|--------|
| `rtc-turn/src/proto/evenport.rs:37` | `FIXME? (1 << 8) - 1` -- the existing `0b10000000` value is correct per RFC 5766 §14.6 (only the MSB is the R flag); replaced the FIXME with an explanatory comment |
| `rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs:145` | Replace `TODO: unicode case-folding` + `.to_uppercase()` with `eq_ignore_ascii_case()` -- allocation-free and correct for ASCII-only MIME types |
| `rtc-sctp/src/endpoint/mod.rs:133` | Replace DoS TODO with a comment documenting the existing `concurrent_associations` protection and referencing RFC 4960 §5.1.3 for a future stateless cookie implementation |
| `rtc/src/peer_connection/configuration/setting_engine.rs:175` | Replace misleading `Re-enable it to QueryOnly` TODO with a comment explaining the opt-in design (both the core and the async wrapper require explicit configuration) |

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p rtc` passes (246 tests)
- [x] `cargo test -p rtc-sctp` passes
- [x] `cargo test -p rtc-turn` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes

Generated with [Claude Code](https://claude.com/claude-code)