### PR TITLE
fix(sctp): correct PR-SCTP max_retransmits abandonment condition

### DIFF
--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -460,3 +460,88 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for the PR-SCTP max_retransmits off-by-one fix.
+///
+/// `check_partial_reliability_status` uses `nsent > reliability_value` (not
+/// `>=`).  `nsent` counts total sends and `reliability_value` equals
+/// `max_retransmits`.  With `>=`, a chunk with `max_retransmits=0` would be
+/// abandoned even at `nsent=0` (before being sent at all), and one with
+/// `max_retransmits=1` would be abandoned after only the initial send.
+/// This test encodes the correct boundary so the off-by-one cannot regress.
+#[test]
+fn test_check_partial_reliability_rexmit_boundary() {
+    let now = Instant::now();
+    let side = Side::Client;
+
+    // Build a streams map with a single stream using Rexmit reliability.
+    let make_streams = |reliability_value: u32| -> HashMap<u16, StreamState> {
+        let mut streams = HashMap::new();
+        let mut ss = StreamState::new(side, 0, 1400, PayloadProtocolIdentifier::Binary);
+        ss.reliability_type = ReliabilityType::Rexmit;
+        ss.reliability_value = reliability_value;
+        streams.insert(0, ss);
+        streams
+    };
+
+    // --- max_retransmits = 0 ---
+    // With `>`, abandon when nsent > 0, i.e. after at least one send.
+    // With `>=` (the bug), abandon when nsent >= 0, i.e. always -- even before sending.
+    let streams = make_streams(0);
+
+    // nsent=0: not yet sent at all. Must NOT be abandoned.
+    // This is the critical assertion that fails with `>=`.
+    let mut c = ChunkPayloadData {
+        stream_identifier: 0,
+        nsent: 0,
+        ..Default::default()
+    };
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        !c.abandoned,
+        "max_retransmits=0, nsent=0: must not abandon before any send"
+    );
+
+    // nsent=1: sent once (the initial transmission). nsent(1) > 0 is true, so
+    // the chunk is now eligible for abandonment.
+    let mut c = ChunkPayloadData {
+        stream_identifier: 0,
+        nsent: 1,
+        ..Default::default()
+    };
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        c.abandoned,
+        "max_retransmits=0, nsent=1: must abandon (no retransmissions allowed)"
+    );
+
+    // --- max_retransmits = 1 ---
+    // With `>`, abandon when nsent > 1, i.e. after two or more sends.
+    // With `>=` (the bug), abandon when nsent >= 1, i.e. after just the initial send.
+    let streams = make_streams(1);
+
+    // nsent=1: initial send only. Must NOT be abandoned.
+    // This assertion fails with `>=`.
+    let mut c = ChunkPayloadData {
+        stream_identifier: 0,
+        nsent: 1,
+        ..Default::default()
+    };
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        !c.abandoned,
+        "max_retransmits=1, nsent=1: must not abandon (only initial send so far)"
+    );
+
+    // nsent=2: initial + 1 retransmission. nsent(2) > 1 is true, abandon.
+    let mut c = ChunkPayloadData {
+        stream_identifier: 0,
+        nsent: 2,
+        ..Default::default()
+    };
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        c.abandoned,
+        "max_retransmits=1, nsent=2: must abandon (retransmission limit exceeded)"
+    );
+}

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -461,14 +461,24 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
     Ok(())
 }
 
-/// Regression test for the PR-SCTP max_retransmits off-by-one fix.
+/// Regression test for the PR-SCTP `max_retransmits` off-by-one fix.
 ///
-/// `check_partial_reliability_status` uses `nsent > reliability_value` (not
-/// `>=`).  `nsent` counts total sends and `reliability_value` equals
-/// `max_retransmits`.  With `>=`, a chunk with `max_retransmits=0` would be
-/// abandoned even at `nsent=0` (before being sent at all), and one with
-/// `max_retransmits=1` would be abandoned after only the initial send.
-/// This test encodes the correct boundary so the off-by-one cannot regress.
+/// In production code, `nsent` is set to 1 on the initial send and incremented
+/// before each retransmission, so it always represents the total number of
+/// transmissions (initial + retransmissions).  `reliability_value` equals
+/// `max_retransmits`, which is a *retransmission* cap (not a total-send cap).
+///
+/// The correct comparison is `nsent > reliability_value`:
+///   - `max_retransmits=0` (fire-and-forget): abandon when nsent > 0,
+///     i.e. immediately after the initial send (nsent=1).  No retransmissions.
+///   - `max_retransmits=1`: abandon when nsent > 1, i.e. after the initial
+///     send plus one retransmission (nsent=2).
+///
+/// The old `>=` comparison abandoned one send too early: with
+/// `max_retransmits=1`, the chunk was abandoned at nsent=1 (the initial send),
+/// preventing the one permitted retransmission.
+///
+/// All `nsent` values used here mirror real call-site values (nsent >= 1).
 #[test]
 fn test_check_partial_reliability_rexmit_boundary() {
     let now = Instant::now();
@@ -484,64 +494,128 @@ fn test_check_partial_reliability_rexmit_boundary() {
         streams
     };
 
-    // --- max_retransmits = 0 ---
-    // With `>`, abandon when nsent > 0, i.e. after at least one send.
-    // With `>=` (the bug), abandon when nsent >= 0, i.e. always -- even before sending.
+    // Helper: create a chunk with the given nsent value (mirrors production
+    // where nsent is always >= 1 when check_partial_reliability_status is
+    // called).
+    let make_chunk = |nsent: u32| -> ChunkPayloadData {
+        ChunkPayloadData {
+            stream_identifier: 0,
+            nsent,
+            ..Default::default()
+        }
+    };
+
+    // --- max_retransmits = 0 (fire-and-forget) ---
+    // Abandon when nsent > 0.  The initial send (nsent=1) already exceeds the
+    // limit, so the chunk is abandoned immediately -- no retransmissions.
     let streams = make_streams(0);
 
-    // nsent=0: not yet sent at all. Must NOT be abandoned.
-    // This is the critical assertion that fails with `>=`.
-    let mut c = ChunkPayloadData {
-        stream_identifier: 0,
-        nsent: 0,
-        ..Default::default()
-    };
-    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
-    assert!(
-        !c.abandoned,
-        "max_retransmits=0, nsent=0: must not abandon before any send"
-    );
-
-    // nsent=1: sent once (the initial transmission). nsent(1) > 0 is true, so
-    // the chunk is now eligible for abandonment.
-    let mut c = ChunkPayloadData {
-        stream_identifier: 0,
-        nsent: 1,
-        ..Default::default()
-    };
+    // nsent=1: initial send.  1 > 0 is true → abandoned.
+    let mut c = make_chunk(1);
     Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
     assert!(
         c.abandoned,
-        "max_retransmits=0, nsent=1: must abandon (no retransmissions allowed)"
+        "max_retransmits=0, nsent=1: must abandon (fire-and-forget, no retransmissions)"
     );
 
     // --- max_retransmits = 1 ---
-    // With `>`, abandon when nsent > 1, i.e. after two or more sends.
-    // With `>=` (the bug), abandon when nsent >= 1, i.e. after just the initial send.
+    // Abandon when nsent > 1.  The initial send is allowed, plus one
+    // retransmission, so abandonment happens at nsent=2.
     let streams = make_streams(1);
 
-    // nsent=1: initial send only. Must NOT be abandoned.
-    // This assertion fails with `>=`.
+    // nsent=1: initial send only.  1 > 1 is false → NOT abandoned.
+    // KEY REGRESSION ASSERTION: with `>=`, this would be 1 >= 1 → true,
+    // incorrectly abandoning before the permitted retransmission.
+    let mut c = make_chunk(1);
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        !c.abandoned,
+        "max_retransmits=1, nsent=1: must NOT abandon (initial send, retransmission still allowed)"
+    );
+
+    // nsent=2: initial + 1 retransmission.  2 > 1 is true → abandoned.
+    let mut c = make_chunk(2);
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        c.abandoned,
+        "max_retransmits=1, nsent=2: must abandon (retransmission limit reached)"
+    );
+
+    // --- max_retransmits = 2 ---
+    // Abandon when nsent > 2.  Verify the boundary at nsent=2 and nsent=3.
+    let streams = make_streams(2);
+
+    // nsent=1: initial send.  1 > 2 is false → NOT abandoned.
+    let mut c = make_chunk(1);
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        !c.abandoned,
+        "max_retransmits=2, nsent=1: must NOT abandon (initial send)"
+    );
+
+    // nsent=2: initial + 1 retransmission.  2 > 2 is false → NOT abandoned.
+    // With `>=` this would incorrectly abandon (2 >= 2).
+    let mut c = make_chunk(2);
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        !c.abandoned,
+        "max_retransmits=2, nsent=2: must NOT abandon (one more retransmission allowed)"
+    );
+
+    // nsent=3: initial + 2 retransmissions.  3 > 2 is true → abandoned.
+    let mut c = make_chunk(3);
+    Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
+    assert!(
+        c.abandoned,
+        "max_retransmits=2, nsent=3: must abandon (retransmission limit reached)"
+    );
+}
+
+/// Verify that non-Rexmit reliability types and edge cases (missing stream,
+/// DCEP payload) do not trigger abandonment via the Rexmit path.
+#[test]
+fn test_check_partial_reliability_rexmit_no_false_abandon() {
+    let now = Instant::now();
+    let side = Side::Client;
+
+    // Stream with Rexmit reliability, max_retransmits = 0.
+    let mut streams = HashMap::new();
+    let mut ss = StreamState::new(side, 0, 1400, PayloadProtocolIdentifier::Binary);
+    ss.reliability_type = ReliabilityType::Rexmit;
+    ss.reliability_value = 0;
+    streams.insert(0, ss);
+
+    // DCEP chunks are never abandoned regardless of nsent.
     let mut c = ChunkPayloadData {
         stream_identifier: 0,
-        nsent: 1,
+        nsent: 100,
+        payload_type: PayloadProtocolIdentifier::Dcep,
         ..Default::default()
     };
     Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
     assert!(
         !c.abandoned,
-        "max_retransmits=1, nsent=1: must not abandon (only initial send so far)"
+        "DCEP payload must never be abandoned by partial reliability"
     );
 
-    // nsent=2: initial + 1 retransmission. nsent(2) > 1 is true, abandon.
+    // use_forward_tsn=false disables PR-SCTP entirely.
     let mut c = ChunkPayloadData {
         stream_identifier: 0,
-        nsent: 2,
+        nsent: 100,
+        ..Default::default()
+    };
+    Association::check_partial_reliability_status(&mut c, now, false, side, &streams);
+    assert!(
+        !c.abandoned,
+        "use_forward_tsn=false: partial reliability is disabled"
+    );
+
+    // Chunk referencing a non-existent stream should not panic or abandon.
+    let mut c = ChunkPayloadData {
+        stream_identifier: 999,
+        nsent: 100,
         ..Default::default()
     };
     Association::check_partial_reliability_status(&mut c, now, true, side, &streams);
-    assert!(
-        c.abandoned,
-        "max_retransmits=1, nsent=2: must abandon (retransmission limit exceeded)"
-    );
+    assert!(!c.abandoned, "missing stream must not cause abandonment");
 }

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2522,7 +2522,12 @@ impl Association {
             let reliability_value = s.reliability_value;
 
             if reliability_type == ReliabilityType::Rexmit {
-                if c.nsent >= reliability_value {
+                // RFC 3758 §5.3.1: abandon when transmitted MORE THAN max_retransmits times.
+                // Use `>` not `>=`: with max_retransmits=N the chunk may be sent N+1 times total
+                // (1 initial + N retransmissions), so abandon when nsent > N (reliability_value).
+                // Using `>=` would incorrectly abandon after only N total sends (one too few).
+                // Fixes: webrtc-rs/webrtc#776
+                if c.nsent > reliability_value {
                     c.set_abandoned(true);
                     trace!(
                         "[{}] marked as abandoned: tsn={} ppi={} (remix: {})",

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2522,10 +2522,11 @@ impl Association {
             let reliability_value = s.reliability_value;
 
             if reliability_type == ReliabilityType::Rexmit {
-                // RFC 3758 §5.3.1: abandon when transmitted MORE THAN max_retransmits times.
-                // Use `>` not `>=`: with max_retransmits=N the chunk may be sent N+1 times total
-                // (1 initial + N retransmissions), so abandon when nsent > N (reliability_value).
-                // Using `>=` would incorrectly abandon after only N total sends (one too few).
+                // RFC 3758 §5.3.1: `max_retransmits` / `reliability_value` is a retransmission
+                // limit, while `c.nsent` counts total sends including the initial transmission.
+                // Therefore with max_retransmits = N, the chunk may be sent N + 1 times total
+                // (1 initial send + N retransmissions), and should be abandoned only once
+                // `c.nsent > reliability_value`. Using `>=` would abandon one send too early.
                 // Fixes: webrtc-rs/webrtc#776
                 if c.nsent > reliability_value {
                     c.set_abandoned(true);

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2522,11 +2522,27 @@ impl Association {
             let reliability_value = s.reliability_value;
 
             if reliability_type == ReliabilityType::Rexmit {
-                // RFC 3758 §5.3.1: `max_retransmits` / `reliability_value` is a retransmission
-                // limit, while `c.nsent` counts total sends including the initial transmission.
-                // Therefore with max_retransmits = N, the chunk may be sent N + 1 times total
-                // (1 initial send + N retransmissions), and should be abandoned only once
-                // `c.nsent > reliability_value`. Using `>=` would abandon one send too early.
+                // RFC 3758 §3.1 – `reliability_value` is the maximum number of
+                // *retransmissions* (not total transmissions).  `c.nsent` counts
+                // every transmission including the initial one, so the number of
+                // retransmissions so far is `nsent - 1`.  A chunk should be
+                // abandoned once `nsent - 1 > reliability_value`, which simplifies
+                // to `nsent > reliability_value + 1` – but because
+                // `reliability_value` is the retransmission cap we can equivalently
+                // compare `nsent > reliability_value` when `nsent` starts at 1
+                // (one initial send counts as zero retransmissions).
+                //
+                // Example: max_retransmits = 0  →  abandon when nsent > 0
+                //   • nsent 1 (initial send): 1 > 0 → abandoned (fire-and-forget)
+                //
+                // Example: max_retransmits = 1  →  abandon when nsent > 1
+                //   • nsent 1 (initial send): 1 > 1 → NOT abandoned
+                //   • nsent 2 (1st retransmit): 2 > 1 → abandoned
+                //
+                // Using `>=` instead of `>` would abandon one send too early:
+                // a chunk with max_retransmits = 1 would be abandoned on the
+                // initial send (nsent 1 >= 1), losing one permitted retransmission.
+                //
                 // Fixes: webrtc-rs/webrtc#776
                 if c.nsent > reliability_value {
                     c.set_abandoned(true);


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in the PR-SCTP partial reliability abandonment check (closes webrtc-rs/webrtc#776).

- Changed `>= reliability_value` to `> reliability_value` so a stream configured with `max_retransmits(N)` correctly allows N retransmissions before abandoning.
- Rewrote the inline comment with concrete examples showing how `nsent` (total sends including initial) relates to `reliability_value` (retransmission cap), and why `>` is correct while `>=` abandons one send too early.
- Rewrote regression test to use only realistic `nsent` values (>= 1), matching actual call-site behavior where `nsent` is set to 1 on initial send.
- Added boundary tests for `max_retransmits` = 0, 1, and 2.
- Added `test_check_partial_reliability_rexmit_no_false_abandon` covering DCEP payload, `use_forward_tsn=false`, and missing stream edge cases.

## Test plan

- [x] `cargo check -p rtc-sctp` passes
- [x] `cargo clippy -p rtc-sctp` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test -p rtc-sctp` passes (105/105 tests, including new regression tests)
- [x] Regression test uses realistic `nsent` values (>= 1) matching production call sites
- [x] Regression test validates boundary for `max_retransmits` = 0, 1, and 2
- [x] Key regression assertion: `max_retransmits=1, nsent=1` must NOT abandon (fails with `>=`, passes with `>`)
- [x] Edge case test covers DCEP, disabled forward-TSN, and missing stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)