### PR TITLE
docs: replace misleading TODO comments on disabled tests with clear explanations

### DIFF
--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -3,11 +3,11 @@ mod candidate_pair_test;
 #[cfg(test)]
 mod candidate_test;
 
-//TODO: #[cfg(test)]
-//TODO: mod candidate_relay_test;
-/*TODO: #[cfg(test)]
-TODO: mod candidate_server_reflexive_test;
-*/
+// candidate_relay_test and candidate_server_reflexive_test use turn::auth / turn::server /
+// turn::relay APIs from a different TURN library than rtc-turn. Enabling them requires porting
+// to the rtc-turn API — deferred to a dedicated porting effort.
+// #[cfg(test)] mod candidate_relay_test;
+// #[cfg(test)] mod candidate_server_reflexive_test;
 
 pub mod candidate_host;
 pub mod candidate_pair;

--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -3,9 +3,10 @@ mod candidate_pair_test;
 #[cfg(test)]
 mod candidate_test;
 
-// candidate_relay_test and candidate_server_reflexive_test use turn::auth / turn::server /
-// turn::relay APIs from a different TURN library than rtc-turn. Enabling them requires porting
-// to the rtc-turn API — deferred to a dedicated porting effort.
+// candidate_relay_test and candidate_server_reflexive_test use `turn::auth`,
+// `turn::server`, and `turn::relay` APIs from a different TURN library than
+// rtc-turn. Enabling them requires porting to the rtc-turn API — deferred to a
+// dedicated porting effort.
 // #[cfg(test)] mod candidate_relay_test;
 // #[cfg(test)] mod candidate_server_reflexive_test;
 

--- a/rtc/src/peer_connection/configuration/media_engine.rs
+++ b/rtc/src/peer_connection/configuration/media_engine.rs
@@ -77,8 +77,8 @@
 //! # }
 //! ```
 
-//TODO:#[cfg(test)]
-//mod media_engine_test;
+// media_engine_test.rs does not exist — it was never created for this sans-IO crate.
+// #[cfg(test)] mod media_engine_test;
 
 use crate::peer_connection::sdp::{
     codecs_from_media_description, rtp_extensions_from_media_description,

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -749,41 +749,7 @@ mod test {
         }
     }
 
-    /*TODO:#[test] fn test_configuration_json() {
-
-         let j = r#"
-            {
-                "iceServers": [{"URLs": ["turn:turn.example.org"],
-                                "username": "jch",
-                                "credential": "topsecret"
-                              }],
-                "iceTransportPolicy": "relay",
-                "bundlePolicy": "balanced",
-                "rtcpMuxPolicy": "require"
-            }"#;
-
-        conf := Configuration{
-            ICEServers: []ICEServer{
-                {
-                    URLs:       []string{"turn:turn.example.org"},
-                    Username:   "jch",
-                    Credential: "topsecret",
-                },
-            },
-            ICETransportPolicy: ICETransportPolicyRelay,
-            BundlePolicy:       BundlePolicyBalanced,
-            RTCPMuxPolicy:      RTCPMuxPolicyRequire,
-        }
-
-        var conf2 Configuration
-        assert.NoError(t, json.Unmarshal([]byte(j), &conf2))
-        assert.Equal(t, conf, conf2)
-
-        j2, err := json.Marshal(conf2)
-        assert.NoError(t, err)
-
-        var conf3 Configuration
-        assert.NoError(t, json.Unmarshal(j2, &conf3))
-        assert.Equal(t, conf2, conf3)
-    }*/
+    // test_configuration_json was Go code that was never ported to Rust.
+    // A Rust equivalent would deserialize RTCConfiguration from JSON and round-trip it.
+    // This can be added as a proper #[test] if JSON serialization is a desired feature.
 }

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -750,6 +750,7 @@ mod test {
     }
 
     // test_configuration_json was Go code that was never ported to Rust.
-    // A Rust equivalent would deserialize RTCConfiguration from JSON and round-trip it.
+    // A Rust equivalent would deserialize the Rust `RTCConfiguration` type used in this
+    // module from JSON and round-trip it.
     // This can be added as a proper #[test] if JSON serialization is a desired feature.
 }

--- a/rtc/src/peer_connection/sdp/mod.rs
+++ b/rtc/src/peer_connection/sdp/mod.rs
@@ -144,8 +144,9 @@
 //! [RFC 8829]: https://datatracker.ietf.org/doc/html/rfc8829
 //! [W3C WebRTC Specification]: https://w3c.github.io/webrtc-pc/#session-description-model
 
-//TODO: #[cfg(test)]
-//TODO: mod sdp_test;
+// sdp_test.rs imports crate::api::APIBuilder which belongs to the old async API and does not
+// exist in this sans-IO crate. Enabling it requires porting the test file to the new API.
+// #[cfg(test)] mod sdp_test;
 
 pub(crate) mod sdp_type;
 pub(crate) mod session_description;


### PR DESCRIPTION
## Summary

Several disabled tests had misleading TODO comments suggesting they just needed more work. This replaces those with clear comments explaining exactly why each test is disabled and what would be needed to re-enable it.

- `candidate_relay_test` and `candidate_server_reflexive_test`: document that they depend on `turn::auth`, `turn::server`, and `turn::relay` APIs from a different TURN library than rtc-turn, requiring a porting effort
- `sdp_test`: documents dependency on `crate::api::APIBuilder` from the old async API, which does not exist in this sans-IO crate; enabling it requires porting the test to the new API
- `configuration/mod.rs` JSON test: clarifies the Go stub was never ported and a Rust `RTCConfiguration` round-trip test can be added if needed
- `media_engine_test`: clarifies the referenced test module file does not exist yet

## Test plan

- [x] No functional changes — docs/comments only
- [x] `cargo fmt --check` passes
- [x] `cargo check` passes
- [x] `cargo clippy` passes