### PR TITLE
feat(config): add serde Serialize/Deserialize to RTCConfiguration

### DIFF
--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -3,11 +3,11 @@ mod candidate_pair_test;
 #[cfg(test)]
 mod candidate_test;
 
-//TODO: #[cfg(test)]
-//TODO: mod candidate_relay_test;
-/*TODO: #[cfg(test)]
-TODO: mod candidate_server_reflexive_test;
-*/
+// candidate_relay_test and candidate_server_reflexive_test use turn::auth / turn::server /
+// turn::relay APIs from a different TURN library than rtc-turn. Enabling them requires porting
+// to the rtc-turn API — deferred to a dedicated porting effort.
+// #[cfg(test)] mod candidate_relay_test;
+// #[cfg(test)] mod candidate_server_reflexive_test;
 
 pub mod candidate_host;
 pub mod candidate_pair;

--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -3,9 +3,10 @@ mod candidate_pair_test;
 #[cfg(test)]
 mod candidate_test;
 
-// candidate_relay_test and candidate_server_reflexive_test use turn::auth / turn::server /
-// turn::relay APIs from a different TURN library than rtc-turn. Enabling them requires porting
-// to the rtc-turn API — deferred to a dedicated porting effort.
+// candidate_relay_test and candidate_server_reflexive_test use `turn::auth`,
+// `turn::server`, and `turn::relay` APIs from a different TURN library than
+// rtc-turn. Enabling them requires porting to the rtc-turn API — deferred to a
+// dedicated porting effort.
 // #[cfg(test)] mod candidate_relay_test;
 // #[cfg(test)] mod candidate_server_reflexive_test;
 

--- a/rtc/src/peer_connection/configuration/media_engine.rs
+++ b/rtc/src/peer_connection/configuration/media_engine.rs
@@ -77,8 +77,8 @@
 //! # }
 //! ```
 
-//TODO:#[cfg(test)]
-//mod media_engine_test;
+// media_engine_test.rs does not exist — it was never created for this sans-IO crate.
+// #[cfg(test)] mod media_engine_test;
 
 use crate::peer_connection::sdp::{
     codecs_from_media_description, rtp_extensions_from_media_description,

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -749,41 +749,7 @@ mod test {
         }
     }
 
-    /*TODO:#[test] fn test_configuration_json() {
-
-         let j = r#"
-            {
-                "iceServers": [{"URLs": ["turn:turn.example.org"],
-                                "username": "jch",
-                                "credential": "topsecret"
-                              }],
-                "iceTransportPolicy": "relay",
-                "bundlePolicy": "balanced",
-                "rtcpMuxPolicy": "require"
-            }"#;
-
-        conf := Configuration{
-            ICEServers: []ICEServer{
-                {
-                    URLs:       []string{"turn:turn.example.org"},
-                    Username:   "jch",
-                    Credential: "topsecret",
-                },
-            },
-            ICETransportPolicy: ICETransportPolicyRelay,
-            BundlePolicy:       BundlePolicyBalanced,
-            RTCPMuxPolicy:      RTCPMuxPolicyRequire,
-        }
-
-        var conf2 Configuration
-        assert.NoError(t, json.Unmarshal([]byte(j), &conf2))
-        assert.Equal(t, conf, conf2)
-
-        j2, err := json.Marshal(conf2)
-        assert.NoError(t, err)
-
-        var conf3 Configuration
-        assert.NoError(t, json.Unmarshal(j2, &conf3))
-        assert.Equal(t, conf2, conf3)
-    }*/
+    // test_configuration_json was Go code that was never ported to Rust.
+    // A Rust equivalent would deserialize RTCConfiguration from JSON and round-trip it.
+    // This can be added as a proper #[test] if JSON serialization is a desired feature.
 }

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -247,7 +247,7 @@ pub(crate) const UNSPECIFIED_STR: &str = "Unspecified";
 /// [`RTCCertificate::serialize_pem`] / [`RTCCertificate::from_pem`] to
 /// persist them separately and re-attach via [`RTCConfigurationBuilder::with_certificates`].
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 pub struct RTCConfiguration {
     /// ice_servers defines a slice describing servers available to be used by
     /// ICE, such as STUN and TURN servers.
@@ -764,16 +764,58 @@ mod test {
             .build();
 
         let json = serde_json::to_string(&original).expect("serialize");
-        assert!(json.contains("iceServers"), "camelCase key expected");
-        assert!(json.contains("stun:stun.l.google.com:19302"));
 
+        // Validate camelCase keys and values via structured parsing
+        let value: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+        assert_eq!(
+            value["iceServers"][0]["urls"][0],
+            serde_json::Value::String("stun:stun.l.google.com:19302".to_owned())
+        );
+        assert_eq!(
+            value["iceTransportPolicy"],
+            serde_json::Value::String("all".to_owned())
+        );
+        assert_eq!(
+            value["bundlePolicy"],
+            serde_json::Value::String("max-bundle".to_owned())
+        );
+        assert_eq!(
+            value["rtcpMuxPolicy"],
+            serde_json::Value::String("require".to_owned())
+        );
+
+        // Deserialize back and verify round-trip fidelity
         let restored: RTCConfiguration = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(restored.ice_servers.len(), 1);
-        assert_eq!(restored.ice_servers[0].urls[0], "stun:stun.l.google.com:19302");
+        assert_eq!(
+            restored.ice_servers[0].urls[0],
+            "stun:stun.l.google.com:19302"
+        );
         assert_eq!(restored.ice_transport_policy, RTCIceTransportPolicy::All);
         assert_eq!(restored.bundle_policy, RTCBundlePolicy::MaxBundle);
         assert_eq!(restored.rtcp_mux_policy, RTCRtcpMuxPolicy::Require);
         // certificates are skipped — restored config gets empty Vec
         assert!(restored.certificates.is_empty());
+    }
+
+    #[test]
+    fn test_configuration_json_partial_deserialize() {
+        // Only iceServers provided — all other fields should get defaults
+        let json = r#"{"iceServers":[{"urls":["stun:stun.l.google.com:19302"]}]}"#;
+        let config: RTCConfiguration = serde_json::from_str(json).expect("partial deserialize");
+        assert_eq!(config.ice_servers.len(), 1);
+        assert_eq!(
+            config.ice_servers[0].urls[0],
+            "stun:stun.l.google.com:19302"
+        );
+        // Fields not present in JSON should be their Default values
+        assert_eq!(
+            config.ice_transport_policy,
+            RTCIceTransportPolicy::Unspecified
+        );
+        assert_eq!(config.bundle_policy, RTCBundlePolicy::Unspecified);
+        assert_eq!(config.rtcp_mux_policy, RTCRtcpMuxPolicy::Unspecified);
+        assert!(config.certificates.is_empty());
+        assert_eq!(config.ice_candidate_pool_size, 0);
     }
 }

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -206,6 +206,7 @@
 use crate::peer_connection::certificate::RTCCertificate;
 pub use crate::peer_connection::transport::ice::server::RTCIceServer;
 use rcgen::KeyPair;
+use serde::{Deserialize, Serialize};
 use shared::error::{Error, Result};
 use std::time::SystemTime;
 
@@ -237,7 +238,16 @@ pub(crate) const UNSPECIFIED_STR: &str = "Unspecified";
 /// * [W3C]
 ///
 /// [W3C]: https://w3c.github.io/webrtc-pc/#rtcconfiguration-dictionary
-#[derive(Default, Clone, Debug)]
+/// A Configuration defines how peer-to-peer communication via PeerConnection
+/// is established or re-established.
+///
+/// Serialization follows the W3C RTCConfiguration dictionary naming
+/// (`iceServers`, `iceTransportPolicy`, etc.).  Certificates are **excluded**
+/// from serialization because they contain private-key material; use
+/// [`RTCCertificate::serialize_pem`] / [`RTCCertificate::from_pem`] to
+/// persist them separately and re-attach via [`RTCConfigurationBuilder::with_certificates`].
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RTCConfiguration {
     /// ice_servers defines a slice describing servers available to be used by
     /// ICE, such as STUN and TURN servers.
@@ -260,17 +270,9 @@ pub struct RTCConfiguration {
     /// unless it can be successfully authenticated with the provided name.
     pub(crate) peer_identity: String,
 
-    /// certificates describes a set of certificates that the PeerConnection
-    /// uses to authenticate. Valid values for this parameter are created
-    /// through calls to the generate_certificate function. Although any given
-    /// DTLS connection will use only one certificate, this attribute allows the
-    /// caller to provide multiple certificates that support different
-    /// algorithms. The final certificate will be selected based on the DTLS
-    /// handshake, which establishes which certificates are allowed. The
-    /// PeerConnection implementation selects which of the certificates is
-    /// used for a given connection; how certificates are selected is outside
-    /// the scope of this specification. If this value is absent, then a default
-    /// set of certificates is generated for each PeerConnection instance.
+    /// Certificates are excluded from serialization because they contain private-key
+    /// material. Persist them separately with RTCCertificate::serialize_pem().
+    #[serde(skip)]
     pub(crate) certificates: Vec<RTCCertificate>,
 
     /// ice_candidate_pool_size describes the size of the prefetched ICE pool.
@@ -749,8 +751,29 @@ mod test {
         }
     }
 
-    // test_configuration_json was Go code that was never ported to Rust.
-    // A Rust equivalent would deserialize the Rust `RTCConfiguration` type used in this
-    // module from JSON and round-trip it.
-    // This can be added as a proper #[test] if JSON serialization is a desired feature.
+    #[test]
+    fn test_configuration_json_round_trip() {
+        let original = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+                ..Default::default()
+            }])
+            .with_ice_transport_policy(RTCIceTransportPolicy::All)
+            .with_bundle_policy(RTCBundlePolicy::MaxBundle)
+            .with_rtcp_mux_policy(RTCRtcpMuxPolicy::Require)
+            .build();
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        assert!(json.contains("iceServers"), "camelCase key expected");
+        assert!(json.contains("stun:stun.l.google.com:19302"));
+
+        let restored: RTCConfiguration = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.ice_servers.len(), 1);
+        assert_eq!(restored.ice_servers[0].urls[0], "stun:stun.l.google.com:19302");
+        assert_eq!(restored.ice_transport_policy, RTCIceTransportPolicy::All);
+        assert_eq!(restored.bundle_policy, RTCBundlePolicy::MaxBundle);
+        assert_eq!(restored.rtcp_mux_policy, RTCRtcpMuxPolicy::Require);
+        // certificates are skipped — restored config gets empty Vec
+        assert!(restored.certificates.is_empty());
+    }
 }

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -238,8 +238,6 @@ pub(crate) const UNSPECIFIED_STR: &str = "Unspecified";
 /// * [W3C]
 ///
 /// [W3C]: https://w3c.github.io/webrtc-pc/#rtcconfiguration-dictionary
-/// A Configuration defines how peer-to-peer communication via PeerConnection
-/// is established or re-established.
 ///
 /// Serialization follows the W3C RTCConfiguration dictionary naming
 /// (`iceServers`, `iceTransportPolicy`, etc.).  Certificates are **excluded**
@@ -270,8 +268,10 @@ pub struct RTCConfiguration {
     /// unless it can be successfully authenticated with the provided name.
     pub(crate) peer_identity: String,
 
-    /// Certificates are excluded from serialization because they contain private-key
-    /// material. Persist them separately with RTCCertificate::serialize_pem().
+    /// Certificates are excluded from both serialization and deserialization because
+    /// they contain private-key material.  Persist them separately with
+    /// `RTCCertificate::serialize_pem()` / `RTCCertificate::from_pem()` and re-attach
+    /// via [`RTCConfigurationBuilder::with_certificates`].
     #[serde(skip)]
     pub(crate) certificates: Vec<RTCCertificate>,
 
@@ -753,6 +753,11 @@ mod test {
 
     #[test]
     fn test_configuration_json_round_trip() {
+        // Build a config with a non-empty certificates vec so we can prove
+        // that serde(skip) actually omits them from the JSON output.
+        let kp = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).expect("generate key pair");
+        let cert = RTCCertificate::from_key_pair(kp).expect("create certificate");
+
         let original = RTCConfigurationBuilder::new()
             .with_ice_servers(vec![RTCIceServer {
                 urls: vec!["stun:stun.l.google.com:19302".to_owned()],
@@ -761,7 +766,11 @@ mod test {
             .with_ice_transport_policy(RTCIceTransportPolicy::All)
             .with_bundle_policy(RTCBundlePolicy::MaxBundle)
             .with_rtcp_mux_policy(RTCRtcpMuxPolicy::Require)
+            .with_certificates(vec![cert])
             .build();
+
+        // Confirm our original actually carries a certificate
+        assert_eq!(original.certificates.len(), 1);
 
         let json = serde_json::to_string(&original).expect("serialize");
 
@@ -784,6 +793,12 @@ mod test {
             serde_json::Value::String("require".to_owned())
         );
 
+        // Certificates must NOT appear in the serialized JSON
+        assert!(
+            value.get("certificates").is_none(),
+            "certificates should be omitted from JSON (serde skip)"
+        );
+
         // Deserialize back and verify round-trip fidelity
         let restored: RTCConfiguration = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(restored.ice_servers.len(), 1);
@@ -794,7 +809,7 @@ mod test {
         assert_eq!(restored.ice_transport_policy, RTCIceTransportPolicy::All);
         assert_eq!(restored.bundle_policy, RTCBundlePolicy::MaxBundle);
         assert_eq!(restored.rtcp_mux_policy, RTCRtcpMuxPolicy::Require);
-        // certificates are skipped — restored config gets empty Vec
+        // certificates are skipped during both serialization and deserialization
         assert!(restored.certificates.is_empty());
     }
 

--- a/rtc/src/peer_connection/configuration/mod.rs
+++ b/rtc/src/peer_connection/configuration/mod.rs
@@ -750,6 +750,7 @@ mod test {
     }
 
     // test_configuration_json was Go code that was never ported to Rust.
-    // A Rust equivalent would deserialize RTCConfiguration from JSON and round-trip it.
+    // A Rust equivalent would deserialize the Rust `RTCConfiguration` type used in this
+    // module from JSON and round-trip it.
     // This can be added as a proper #[test] if JSON serialization is a desired feature.
 }

--- a/rtc/src/peer_connection/sdp/mod.rs
+++ b/rtc/src/peer_connection/sdp/mod.rs
@@ -144,8 +144,9 @@
 //! [RFC 8829]: https://datatracker.ietf.org/doc/html/rfc8829
 //! [W3C WebRTC Specification]: https://w3c.github.io/webrtc-pc/#session-description-model
 
-//TODO: #[cfg(test)]
-//TODO: mod sdp_test;
+// sdp_test.rs imports crate::api::APIBuilder which belongs to the old async API and does not
+// exist in this sans-IO crate. Enabling it requires porting the test file to the new API.
+// #[cfg(test)] mod sdp_test;
 
 pub(crate) mod sdp_type;
 pub(crate) mod session_description;

--- a/rtc/src/peer_connection/transport/ice/server.rs
+++ b/rtc/src/peer_connection/transport/ice/server.rs
@@ -11,6 +11,7 @@ use shared::error::{Error, Result};
 ///
 /// [W3C]: https://w3c.github.io/webrtc-pc/#dom-rtciceserver
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(default)]
 pub struct RTCIceServer {
     pub urls: Vec<String>,
     pub username: String,


### PR DESCRIPTION
## Summary

- Add `#[derive(Serialize, Deserialize)]` with `#[serde(rename_all = "camelCase")]` to `RTCConfiguration`
- Add `#[serde(default)]` to `RTCConfiguration` and `RTCIceServer` for partial JSON deserialization (e.g. only providing `iceServers`)
- Skip `certificates` field during both serialization and deserialization to avoid persisting private-key material
- Replace old commented-out TODO test with structured round-trip JSON test using `serde_json::Value` assertions
- Add partial deserialization test to verify defaults for omitted fields
- Enables JavaScript/JSON config interoperability with W3C camelCase naming

Note: serde is already a hard dependency used across 44+ files in the crate, so no feature gate is needed.

## Test plan
- [x] `cargo test -p rtc test_configuration_json_round_trip`
- [x] `cargo test -p rtc test_configuration_json_partial_deserialize`
- [x] Verify camelCase keys (`iceServers`, `iceTransportPolicy`, etc.) in serialized output
- [x] Verify deserialization from camelCase JSON
- [x] Verify partial JSON (only `iceServers`) deserializes with defaults
- [x] Verify certificates with non-empty vec are omitted from serialized JSON
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p rtc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)