### PR TITLE
feat(turn): add TCP TURN client example and expose server/local addr

### DIFF
--- a/rtc-turn/Cargo.toml
+++ b/rtc-turn/Cargo.toml
@@ -39,3 +39,8 @@ harness = false
 name = "turn_client_udp"
 path = "examples/turn_client_udp.rs"
 bench = false
+
+[[example]]
+name = "turn_client_tcp"
+path = "examples/turn_client_tcp.rs"
+bench = false

--- a/rtc-turn/examples/turn_client_tcp.rs
+++ b/rtc-turn/examples/turn_client_tcp.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 
 #[derive(Parser)]
 #[command(name = "TURN Client TCP")]
-#[command(author = "Brainwires <brainwires@github>")]
+#[command(author = "Brainwires <brainwires@github.com>")]
 #[command(version = "0.1.0")]
 #[command(about = "An example of TURN Client over TCP (RFC 6062)", long_about = None)]
 struct Cli {
@@ -82,9 +82,10 @@ fn main() -> Result<()> {
 
     println!("TCP connected: {} → {}", local_addr, peer_addr);
 
-    // Configure the TCP stream for non-blocking reads in the polling loop.
-    stream.set_nonblocking(true)?;
+    // Use a cloned handle for writes (blocking with timeout) and non-blocking for reads.
     let mut stream_write = stream.try_clone()?;
+    stream_write.set_write_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_nonblocking(true)?;
 
     let cfg = ClientConfig {
         stun_serv_addr: turn_server_addr.clone(),
@@ -187,7 +188,7 @@ fn main() -> Result<()> {
         // Non-blocking read from TCP socket.
         // RFC 4571: each TURN message is prefixed with a 2-byte big-endian length.
         match read_tcp_input(&mut stream, &mut buf, &mut decoder) {
-            Some(data) => {
+            Ok(Some(data)) => {
                 trace!("tcp.recv {} bytes from {}", data.len(), peer_addr);
                 let msg = TransportMessage {
                     now: Instant::now(),
@@ -201,11 +202,15 @@ fn main() -> Result<()> {
                 };
                 client.handle_read(msg)?;
             }
-            None => {
+            Ok(None) => {
                 // No complete frame yet — sleep briefly to avoid busy-polling.
                 if !delay_from_now.is_zero() {
                     std::thread::sleep(std::cmp::min(delay_from_now, Duration::from_millis(5)));
                 }
+            }
+            Err(e) => {
+                eprintln!("TCP connection closed: {e}");
+                break;
             }
         }
 
@@ -217,24 +222,26 @@ fn main() -> Result<()> {
 }
 
 /// Read from a non-blocking TCP stream, decode RFC 4571 frames.
-/// Returns the next complete TURN message payload (without the 2-byte length header),
-/// or `None` if no complete frame is available yet.
+/// Returns `Ok(Some(data))` with the next complete TURN message payload,
+/// `Ok(None)` if no complete frame is available yet, or `Err` on EOF / fatal error.
 fn read_tcp_input(
     stream: &mut TcpStream,
     buf: &mut Vec<u8>,
     decoder: &mut TcpFrameDecoder,
-) -> Option<Vec<u8>> {
+) -> std::result::Result<Option<Vec<u8>>, std::io::Error> {
     // Drain available bytes into the decoder.
     loop {
         match stream.read(buf.as_mut_slice()) {
-            Ok(0) => break, // EOF
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    ErrorKind::ConnectionReset,
+                    "TCP connection closed by peer (EOF)",
+                ));
+            }
             Ok(n) => decoder.extend_from_slice(&buf[..n]),
             Err(e) if e.kind() == ErrorKind::WouldBlock => break,
-            Err(e) => {
-                eprintln!("TCP read error: {e}");
-                break;
-            }
+            Err(e) => return Err(e),
         }
     }
-    decoder.next_packet()
+    Ok(decoder.next_packet())
 }

--- a/rtc-turn/examples/turn_client_tcp.rs
+++ b/rtc-turn/examples/turn_client_tcp.rs
@@ -46,7 +46,8 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     if cli.debug {
-        let log_level = log::LevelFilter::from_str(&cli.log_level).unwrap();
+        let log_level = log::LevelFilter::from_str(&cli.log_level)
+            .map_err(|e| Error::Other(format!("invalid log level '{}': {e}", cli.log_level)))?;
         env_logger::Builder::new()
             .format(|buf, record| {
                 writeln!(
@@ -66,7 +67,9 @@ fn main() -> Result<()> {
     let host = cli.host;
     let port = cli.port;
     let user = cli.user;
-    let cred: Vec<&str> = user.splitn(2, '=').collect();
+    let (username, password) = user.split_once('=').ok_or_else(|| {
+        Error::Other("invalid --user format: expected 'username=password'".to_string())
+    })?;
     let realm = cli.realm;
 
     let turn_server_addr = format!("{host}:{port}");
@@ -88,8 +91,8 @@ fn main() -> Result<()> {
         turn_serv_addr: turn_server_addr,
         local_addr,
         transport_protocol: TransportProtocol::TCP,
-        username: cred[0].to_string(),
-        password: cred[1].to_string(),
+        username: username.to_string(),
+        password: password.to_string(),
         realm: realm.to_string(),
         software: String::new(),
         rto_in_ms: 0,
@@ -101,17 +104,12 @@ fn main() -> Result<()> {
     let allocate_tid = client.allocate()?;
     let mut relayed_addr = None;
 
-    let (stop_tx, stop_rx) = crossbeam_channel::bounded::<()>(1);
+    let (stop_tx, stop_rx) = crossbeam_channel::unbounded::<()>();
     println!("Press Ctrl-C to stop");
-    std::thread::spawn(move || {
-        let mut stop_tx = Some(stop_tx);
-        ctrlc::set_handler(move || {
-            if let Some(stop_tx) = stop_tx.take() {
-                let _ = stop_tx.send(());
-            }
-        })
-        .expect("Error setting Ctrl-C handler");
-    });
+    ctrlc::set_handler(move || {
+        let _ = stop_tx.send(());
+    })
+    .expect("Error setting Ctrl-C handler");
 
     // RFC 4571 decoder for inbound TCP frames.
     let mut decoder = TcpFrameDecoder::new();
@@ -159,7 +157,10 @@ fn main() -> Result<()> {
                 }
                 Event::AllocateError(_, err) => return Err(err),
                 Event::CreatePermissionResponse(tid, peer_addr) => {
-                    println!("CreatePermission for peer addr {} is granted (tid={:?})", peer_addr, tid);
+                    println!(
+                        "CreatePermission for peer addr {} is granted (tid={:?})",
+                        peer_addr, tid
+                    );
                 }
                 Event::CreatePermissionError(_, err) => return Err(err),
                 Event::DataIndicationOrChannelData(_, from, data) => {
@@ -187,11 +188,7 @@ fn main() -> Result<()> {
         // RFC 4571: each TURN message is prefixed with a 2-byte big-endian length.
         match read_tcp_input(&mut stream, &mut buf, &mut decoder) {
             Some(data) => {
-                trace!(
-                    "tcp.recv {} bytes from {}",
-                    data.len(),
-                    peer_addr
-                );
+                trace!("tcp.recv {} bytes from {}", data.len(), peer_addr);
                 let msg = TransportMessage {
                     now: Instant::now(),
                     transport: TransportContext {
@@ -207,10 +204,7 @@ fn main() -> Result<()> {
             None => {
                 // No complete frame yet — sleep briefly to avoid busy-polling.
                 if !delay_from_now.is_zero() {
-                    std::thread::sleep(std::cmp::min(
-                        delay_from_now,
-                        Duration::from_millis(5),
-                    ));
+                    std::thread::sleep(std::cmp::min(delay_from_now, Duration::from_millis(5)));
                 }
             }
         }

--- a/rtc-turn/examples/turn_client_tcp.rs
+++ b/rtc-turn/examples/turn_client_tcp.rs
@@ -1,0 +1,246 @@
+use bytes::BytesMut;
+use clap::Parser;
+use log::trace;
+use rtc_turn::client::*;
+use sansio::Protocol;
+use shared::error::{Error, Result};
+use shared::tcp_framing::{TcpFrameDecoder, frame_packet};
+use shared::{TransportContext, TransportMessage, TransportProtocol};
+use std::io::{ErrorKind, Read, Write};
+use std::net::TcpStream;
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+// First, start turn server with TCP support:
+//
+// Option 1: webrtc-rs/webrtc/turn/examples/turn_server_tcp:
+//  RUST_LOG=trace cargo run --color=always --package turn --example turn_server_tcp -- --public-ip 127.0.0.1 --users user=pass
+//
+// Option 2: coturn (reference TURN server):
+//  turnserver --lt-cred-mech --user user:pass --realm webrtc.rs --no-dtls --no-tls
+//
+// Then, start this example:
+//   RUST_LOG=trace cargo run --color=always --package rtc-turn --example turn_client_tcp -- --host 127.0.0.1 --user user=pass
+
+#[derive(Parser)]
+#[command(name = "TURN Client TCP")]
+#[command(author = "Brainwires <brainwires@github>")]
+#[command(version = "0.1.0")]
+#[command(about = "An example of TURN Client over TCP (RFC 6062)", long_about = None)]
+struct Cli {
+    #[arg(long, default_value_t = format!("127.0.0.1"))]
+    host: String,
+    #[arg(long, default_value_t = 3478)]
+    port: u16,
+    #[arg(long)]
+    user: String,
+    #[arg(long, default_value_t = format!("webrtc.rs"))]
+    realm: String,
+
+    #[arg(short, long)]
+    debug: bool,
+    #[arg(long, default_value_t = format!("INFO"))]
+    log_level: String,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    if cli.debug {
+        let log_level = log::LevelFilter::from_str(&cli.log_level).unwrap();
+        env_logger::Builder::new()
+            .format(|buf, record| {
+                writeln!(
+                    buf,
+                    "{}:{} [{}] {} - {}",
+                    record.file().unwrap_or("unknown"),
+                    record.line().unwrap_or(0),
+                    record.level(),
+                    chrono::Local::now().format("%H:%M:%S.%6f"),
+                    record.args()
+                )
+            })
+            .filter(None, log_level)
+            .init();
+    }
+
+    let host = cli.host;
+    let port = cli.port;
+    let user = cli.user;
+    let cred: Vec<&str> = user.splitn(2, '=').collect();
+    let realm = cli.realm;
+
+    let turn_server_addr = format!("{host}:{port}");
+
+    // Connect a TCP socket to the TURN server.
+    // Unlike UDP, the TURN client over TCP uses a single persistent connection.
+    let mut stream = TcpStream::connect(&turn_server_addr)?;
+    let local_addr = stream.local_addr()?;
+    let peer_addr = stream.peer_addr()?;
+
+    println!("TCP connected: {} → {}", local_addr, peer_addr);
+
+    // Configure the TCP stream for non-blocking reads in the polling loop.
+    stream.set_nonblocking(true)?;
+    let mut stream_write = stream.try_clone()?;
+
+    let cfg = ClientConfig {
+        stun_serv_addr: turn_server_addr.clone(),
+        turn_serv_addr: turn_server_addr,
+        local_addr,
+        transport_protocol: TransportProtocol::TCP,
+        username: cred[0].to_string(),
+        password: cred[1].to_string(),
+        realm: realm.to_string(),
+        software: String::new(),
+        rto_in_ms: 0,
+    };
+
+    let mut client = Client::new(cfg)?;
+
+    // Allocate a relay socket on the TURN server (over TCP).
+    let allocate_tid = client.allocate()?;
+    let mut relayed_addr = None;
+
+    let (stop_tx, stop_rx) = crossbeam_channel::bounded::<()>(1);
+    println!("Press Ctrl-C to stop");
+    std::thread::spawn(move || {
+        let mut stop_tx = Some(stop_tx);
+        ctrlc::set_handler(move || {
+            if let Some(stop_tx) = stop_tx.take() {
+                let _ = stop_tx.send(());
+            }
+        })
+        .expect("Error setting Ctrl-C handler");
+    });
+
+    // RFC 4571 decoder for inbound TCP frames.
+    let mut decoder = TcpFrameDecoder::new();
+    let mut buf = vec![0u8; 4096];
+
+    loop {
+        match stop_rx.try_recv() {
+            Ok(_) => break,
+            Err(err) => {
+                if err.is_disconnected() {
+                    break;
+                }
+            }
+        };
+
+        // Flush outbound TURN messages (each wrapped in a 2-byte length prefix per RFC 4571).
+        while let Some(transmit) = client.poll_write() {
+            let framed = frame_packet(&transmit.message);
+            stream_write.write_all(&framed)?;
+            trace!(
+                "tcp.sent {} bytes to {}",
+                transmit.message.len(),
+                transmit.transport.peer_addr
+            );
+        }
+
+        // Process TURN events.
+        while let Some(event) = client.poll_event() {
+            match event {
+                Event::TransactionTimeout(_) => return Err(Error::ErrTimeout),
+                Event::BindingResponse(_, reflexive_addr) => {
+                    println!("reflexive address {}", reflexive_addr);
+                }
+                Event::BindingError(_, err) => return Err(err),
+                Event::AllocateResponse(tid, addr) => {
+                    println!("relayed address {}", addr);
+                    if relayed_addr.is_none() {
+                        assert_eq!(tid, allocate_tid);
+                        relayed_addr = Some(addr);
+                        println!(
+                            "TURN relay allocated over TCP: {}  (refresh will keep it alive)",
+                            addr
+                        );
+                    }
+                }
+                Event::AllocateError(_, err) => return Err(err),
+                Event::CreatePermissionResponse(tid, peer_addr) => {
+                    println!("CreatePermission for peer addr {} is granted (tid={:?})", peer_addr, tid);
+                }
+                Event::CreatePermissionError(_, err) => return Err(err),
+                Event::DataIndicationOrChannelData(_, from, data) => {
+                    println!("relay read: {:?} from {}", &data[..], from);
+                    // Echo back
+                    if let Some(&relay_addr) = relayed_addr.as_ref() {
+                        client.relay(relay_addr)?.send_to(&data[..], from)?;
+                    }
+                }
+            }
+        }
+
+        // Compute next timeout.
+        let mut eto = Instant::now() + Duration::from_millis(100);
+        if let Some(to) = client.poll_timeout() {
+            if to < eto {
+                eto = to;
+            }
+        }
+        let delay_from_now = eto
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::from_secs(0));
+
+        // Non-blocking read from TCP socket.
+        // RFC 4571: each TURN message is prefixed with a 2-byte big-endian length.
+        match read_tcp_input(&mut stream, &mut buf, &mut decoder) {
+            Some(data) => {
+                trace!(
+                    "tcp.recv {} bytes from {}",
+                    data.len(),
+                    peer_addr
+                );
+                let msg = TransportMessage {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr,
+                        peer_addr,
+                        transport_protocol: TransportProtocol::TCP,
+                        ecn: None,
+                    },
+                    message: BytesMut::from(data.as_slice()),
+                };
+                client.handle_read(msg)?;
+            }
+            None => {
+                // No complete frame yet — sleep briefly to avoid busy-polling.
+                if !delay_from_now.is_zero() {
+                    std::thread::sleep(std::cmp::min(
+                        delay_from_now,
+                        Duration::from_millis(5),
+                    ));
+                }
+            }
+        }
+
+        // Drive time forward.
+        client.handle_timeout(Instant::now())?;
+    }
+
+    client.close()
+}
+
+/// Read from a non-blocking TCP stream, decode RFC 4571 frames.
+/// Returns the next complete TURN message payload (without the 2-byte length header),
+/// or `None` if no complete frame is available yet.
+fn read_tcp_input(
+    stream: &mut TcpStream,
+    buf: &mut Vec<u8>,
+    decoder: &mut TcpFrameDecoder,
+) -> Option<Vec<u8>> {
+    // Drain available bytes into the decoder.
+    loop {
+        match stream.read(buf.as_mut_slice()) {
+            Ok(0) => break, // EOF
+            Ok(n) => decoder.extend_from_slice(&buf[..n]),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => break,
+            Err(e) => {
+                eprintln!("TCP read error: {e}");
+                break;
+            }
+        }
+    }
+    decoder.next_packet()
+}

--- a/rtc-turn/src/client/client_test.rs
+++ b/rtc-turn/src/client/client_test.rs
@@ -3,6 +3,24 @@ use sansio::Protocol;
 use std::collections::HashSet;
 use std::net::UdpSocket;
 
+fn create_test_client_with_turn_server() -> Result<(UdpSocket, Client)> {
+    let udp_socket = UdpSocket::bind("127.0.0.1:0")?;
+
+    let client = Client::new(ClientConfig {
+        stun_serv_addr: String::new(),
+        turn_serv_addr: format!("127.0.0.1:{}", udp_socket.local_addr()?.port()),
+        local_addr: udp_socket.local_addr()?,
+        transport_protocol: TransportProtocol::UDP,
+        username: "user".to_string(),
+        password: "pass".to_string(),
+        realm: "test".to_string(),
+        software: "TEST SOFTWARE".to_owned(),
+        rto_in_ms: 0,
+    })?;
+
+    Ok((udp_socket, client))
+}
+
 fn create_listening_test_client(rto_in_ms: u64) -> Result<(UdpSocket, Client)> {
     let udp_socket = UdpSocket::bind("0.0.0.0:0")?;
 
@@ -158,5 +176,63 @@ fn test_client_with_stun_send_binding_request_to_timeout() -> Result<()> {
         assert!(false);
     }
 
+    client.close()
+}
+
+#[test]
+fn test_turn_server_addr_returns_some_when_configured() -> Result<()> {
+    let (_conn, mut client) = create_test_client_with_turn_server()?;
+    let addr = client.turn_server_addr();
+    assert!(
+        addr.is_some(),
+        "turn_server_addr should return Some when configured"
+    );
+    assert_eq!(addr.unwrap().ip(), std::net::IpAddr::from([127, 0, 0, 1]));
+    client.close()
+}
+
+#[test]
+fn test_turn_server_addr_returns_none_when_not_configured() -> Result<()> {
+    let (_conn, mut client) = create_listening_test_client(0)?;
+    let addr = client.turn_server_addr();
+    assert!(
+        addr.is_none(),
+        "turn_server_addr should return None when not configured"
+    );
+    client.close()
+}
+
+#[test]
+fn test_turn_server_addr_or_err_returns_ok_when_configured() -> Result<()> {
+    let (_conn, mut client) = create_test_client_with_turn_server()?;
+    let result = client.turn_server_addr_or_err();
+    assert!(
+        result.is_ok(),
+        "turn_server_addr_or_err should return Ok when configured"
+    );
+    client.close()
+}
+
+#[test]
+fn test_turn_server_addr_or_err_returns_err_when_not_configured() -> Result<()> {
+    let (_conn, mut client) = create_listening_test_client(0)?;
+    let result = client.turn_server_addr_or_err();
+    assert!(
+        result.is_err(),
+        "turn_server_addr_or_err should return Err when not configured"
+    );
+    assert_eq!(result.unwrap_err(), Error::ErrNilTurnSocket);
+    client.close()
+}
+
+#[test]
+fn test_local_addr_returns_bound_address() -> Result<()> {
+    let (conn, mut client) = create_test_client_with_turn_server()?;
+    let expected = conn.local_addr()?;
+    assert_eq!(
+        client.local_addr(),
+        expected,
+        "local_addr should match the configured address"
+    );
     client.close()
 }

--- a/rtc-turn/src/client/mod.rs
+++ b/rtc-turn/src/client/mod.rs
@@ -448,7 +448,7 @@ impl Client {
         debug!("client.Allocate call PerformTransaction 1");
         let mut tid = self.perform_transaction(
             &msg,
-            self.turn_server_addr()?,
+            self.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
             TransactionType::AllocateAttempt,
         );
         tid.0[TRANSACTION_ID_SIZE - 1] = tid.0[TRANSACTION_ID_SIZE - 1].wrapping_add(1);
@@ -514,7 +514,7 @@ impl Client {
                 debug!("client.Allocate call PerformTransaction 2");
                 self.perform_transaction(
                     &msg,
-                    self.turn_server_addr()?,
+                    self.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
                     TransactionType::AllocateRequest(nonce),
                 );
             }
@@ -554,9 +554,14 @@ impl Client {
         Ok(())
     }
 
-    /// turn_server_addr return the TURN server address
-    fn turn_server_addr(&self) -> Result<SocketAddr> {
-        self.turn_serv_addr.ok_or(Error::ErrNilTurnSocket)
+    /// Returns the TURN server address, if configured.
+    pub fn turn_server_addr(&self) -> Option<SocketAddr> {
+        self.turn_serv_addr
+    }
+
+    /// Returns the local address this client is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 
     /// username returns username

--- a/rtc-turn/src/client/mod.rs
+++ b/rtc-turn/src/client/mod.rs
@@ -448,7 +448,7 @@ impl Client {
         debug!("client.Allocate call PerformTransaction 1");
         let mut tid = self.perform_transaction(
             &msg,
-            self.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
+            self.turn_server_addr_or_err()?,
             TransactionType::AllocateAttempt,
         );
         tid.0[TRANSACTION_ID_SIZE - 1] = tid.0[TRANSACTION_ID_SIZE - 1].wrapping_add(1);
@@ -514,7 +514,7 @@ impl Client {
                 debug!("client.Allocate call PerformTransaction 2");
                 self.perform_transaction(
                     &msg,
-                    self.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
+                    self.turn_server_addr_or_err()?,
                     TransactionType::AllocateRequest(nonce),
                 );
             }
@@ -557,6 +557,11 @@ impl Client {
     /// Returns the TURN server address, if configured.
     pub fn turn_server_addr(&self) -> Option<SocketAddr> {
         self.turn_serv_addr
+    }
+
+    /// Returns the TURN server address or an error if not configured.
+    fn turn_server_addr_or_err(&self) -> Result<SocketAddr> {
+        self.turn_serv_addr.ok_or(Error::ErrNilTurnSocket)
     }
 
     /// Returns the local address this client is bound to.

--- a/rtc-turn/src/client/relay.rs
+++ b/rtc-turn/src/client/relay.rs
@@ -207,7 +207,7 @@ impl Relay<'_> {
 
                 // indication has no transaction (fire-and-forget)
                 self.client
-                    .write_to(&msg.raw, self.client.turn_server_addr()?);
+                    .write_to(&msg.raw, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?);
                 return Ok(());
             }
 
@@ -271,7 +271,7 @@ impl Relay<'_> {
 
             Ok(self.client.perform_transaction(
                 &msg,
-                self.client.turn_server_addr()?,
+                self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
                 TransactionType::CreatePermissionRequest(self.relayed_addr, peer_addr_opt),
             ))
         } else {
@@ -337,7 +337,7 @@ impl Relay<'_> {
 
             let _ = self.client.perform_transaction(
                 &msg,
-                self.client.turn_server_addr()?,
+                self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
                 TransactionType::RefreshRequest(self.relayed_addr),
             );
 
@@ -418,7 +418,7 @@ impl Relay<'_> {
             let mut msg = Message::new();
             msg.build(&setters)?;
 
-            (msg, self.client.turn_server_addr()?)
+            (msg, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?)
         };
 
         debug!("UDPConn.bind call PerformTransaction 1");
@@ -483,7 +483,7 @@ impl Relay<'_> {
         ch_data.encode();
 
         self.client
-            .write_to(&ch_data.raw, self.client.turn_server_addr()?);
+            .write_to(&ch_data.raw, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?);
 
         Ok(())
     }

--- a/rtc-turn/src/client/relay.rs
+++ b/rtc-turn/src/client/relay.rs
@@ -207,7 +207,7 @@ impl Relay<'_> {
 
                 // indication has no transaction (fire-and-forget)
                 self.client
-                    .write_to(&msg.raw, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?);
+                    .write_to(&msg.raw, self.client.turn_server_addr_or_err()?);
                 return Ok(());
             }
 
@@ -271,7 +271,7 @@ impl Relay<'_> {
 
             Ok(self.client.perform_transaction(
                 &msg,
-                self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
+                self.client.turn_server_addr_or_err()?,
                 TransactionType::CreatePermissionRequest(self.relayed_addr, peer_addr_opt),
             ))
         } else {
@@ -337,7 +337,7 @@ impl Relay<'_> {
 
             let _ = self.client.perform_transaction(
                 &msg,
-                self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?,
+                self.client.turn_server_addr_or_err()?,
                 TransactionType::RefreshRequest(self.relayed_addr),
             );
 
@@ -418,7 +418,7 @@ impl Relay<'_> {
             let mut msg = Message::new();
             msg.build(&setters)?;
 
-            (msg, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?)
+            (msg, self.client.turn_server_addr_or_err()?)
         };
 
         debug!("UDPConn.bind call PerformTransaction 1");
@@ -483,7 +483,7 @@ impl Relay<'_> {
         ch_data.encode();
 
         self.client
-            .write_to(&ch_data.raw, self.client.turn_server_addr().ok_or(Error::ErrNilTurnSocket)?);
+            .write_to(&ch_data.raw, self.client.turn_server_addr_or_err()?);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add `examples/turn_client_tcp.rs` demonstrating TURN relay over TCP
- Expose `turn_server_addr()` and `local_addr()` accessors on the TURN client
- Enables TCP fallback when UDP TURN is blocked (common in corporate firewalls)

## Review feedback addressed
- [x] Replace `unwrap()` on `--log-level` parse with friendly error
- [x] Use `split_once('=')` for `--user` to avoid panic on malformed input
- [x] Simplify `ctrlc` handler: unbounded channel, no thread wrapper
- [x] Extract `turn_server_addr_or_err()` helper to deduplicate repeated pattern
- [x] `cargo fmt` / `cargo clippy` pass clean
- [x] Fix invalid email TLD in clap author metadata
- [x] Fix non-blocking `write_all()` WouldBlock risk: use blocking writes with timeout
- [x] Fix EOF handling: `read_tcp_input()` now returns `Err` on EOF to break main loop
- [x] Add unit tests for `turn_server_addr()`, `turn_server_addr_or_err()`, `local_addr()`

## Test plan
- [x] `cargo build --example turn_client_tcp -p rtc-turn`
- [x] `cargo test -p rtc-turn` (39 tests pass, including 5 new accessor tests)
- [ ] Run against a TURN server with TCP support

Generated with [Claude Code](https://claude.com/claude-code)