### PR TITLE
fix(ice): always send STUN consent checks (RFC 7675)

### DIFF
--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2486,3 +2486,76 @@ fn test_candidate_type_filtering() -> Result<()> {
     agent.close()?;
     Ok(())
 }
+
+// Verify that check_keepalive sends a STUN ping even when media traffic has
+// recently updated the candidate timestamps (RFC 7675).
+#[test]
+fn test_keepalive_sent_during_media_flow() -> Result<()> {
+    let mut a = Agent::new(Arc::new(AgentConfig::default()))?;
+
+    // Set up a selected pair
+    let host_local = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.1.1".to_owned(),
+            port: 19216,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_local_candidate(host_local)?;
+
+    let relay_remote = CandidateRelayConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "1.2.3.4".to_owned(),
+            port: 12340,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "4.3.2.1".to_owned(),
+        rel_port: 43210,
+        ..Default::default()
+    }
+    .new_candidate_relay()?;
+    a.add_remote_candidate(relay_remote)?;
+
+    a.ufrag_pwd.remote_credentials = Some(Credentials {
+        ufrag: "remoteufrag".to_string(),
+        pwd: "remotepwd".to_string(),
+    });
+    a.is_controlling = true;
+
+    a.add_pair(0, 0);
+    a.set_selected_pair(Some(0));
+
+    // Simulate recent media activity on both candidates
+    a.local_candidates[0].seen(true);
+    a.remote_candidates[0].seen(false);
+
+    // Pretend the last consent ping was long ago such that the interval has elapsed
+    a.last_consent_sent = Instant::now() - Duration::from_secs(10);
+
+    // Drain any events/writes from setup
+    a.write_outs.clear();
+
+    // First call should send a consent ping immediately
+    a.check_keepalive();
+    assert!(
+        !a.write_outs.is_empty(),
+        "check_keepalive must send a STUN ping even when media timestamps are fresh"
+    );
+
+    // Drain and call again; interval hasn't elapsed, so no second ping
+    a.write_outs.clear();
+    a.check_keepalive();
+    assert!(
+        a.write_outs.is_empty(),
+        "check_keepalive must not send again before keepalive_interval elapses"
+    );
+
+    a.close()?;
+    Ok(())
+}

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -134,6 +134,8 @@ pub struct Agent {
     // How often should we send keepalive packets?
     // 0 means never
     pub(crate) keepalive_interval: Duration,
+    // When the last STUN consent ping was sent.
+    pub(crate) last_consent_sent: Instant,
     // How often should we run our internal taskLoop to check for state changes when connecting
     pub(crate) check_interval: Duration,
     pub(crate) checking_duration: Instant,
@@ -179,6 +181,7 @@ impl Default for Agent {
             disconnected_timeout: Default::default(),
             failed_timeout: Default::default(),
             keepalive_interval: Default::default(),
+            last_consent_sent: Instant::now(),
             check_interval: Default::default(),
             checking_duration: Instant::now(),
             last_checking_time: Instant::now(),
@@ -322,6 +325,7 @@ impl Agent {
             } else {
                 config.check_interval
             },
+            last_consent_sent: Instant::now(),
             checking_duration: Instant::now(),
             last_checking_time: Instant::now(),
             last_connection_state: ConnectionState::Unspecified,
@@ -875,9 +879,8 @@ impl Agent {
         valid
     }
 
-    /// Sends STUN Binding Indications to the selected pair.
-    /// if no packet has been sent on that pair in the last keepaliveInterval.
-    /// Note: the caller should hold the agent lock.
+    /// Sends STUN Binding Requests to the selected pair at `keepalive_interval` to
+    /// maintain consent freshness (RFC 7675).
     pub(crate) fn check_keepalive(&mut self) {
         let (local_index, remote_index, pair_index) = {
             self.selected_pair
@@ -890,23 +893,12 @@ impl Agent {
 
         if let (Some(local_index), Some(remote_index), Some(pair_index)) =
             (local_index, remote_index, pair_index)
+            && self.keepalive_interval != Duration::from_secs(0)
+            && self.last_consent_sent.elapsed() >= self.keepalive_interval
         {
-            let last_sent =
-                Instant::now().duration_since(self.local_candidates[local_index].last_sent());
-
-            let last_received =
-                Instant::now().duration_since(self.remote_candidates[remote_index].last_received());
-
-            if (self.keepalive_interval != Duration::from_secs(0))
-                && ((last_sent > self.keepalive_interval)
-                    || (last_received > self.keepalive_interval))
-            {
-                // we use binding request instead of indication to support refresh consent schemas
-                // see https://tools.ietf.org/html/rfc7675
-                // Track consent request sent
-                self.candidate_pairs[pair_index].on_consent_request_sent();
-                self.ping_candidate(local_index, remote_index);
-            }
+            self.last_consent_sent = Instant::now();
+            self.candidate_pairs[pair_index].on_consent_request_sent();
+            self.ping_candidate(local_index, remote_index);
         }
     }
 


### PR DESCRIPTION
## Summary
Previously, `check_keepalive()` gated STUN Binding Requests on `Candidate::last_sent`/`last_received`, which were updated by all traffic including SRTP. When media is flowing, the timestamps are always fresh and consent pings never fire. Remote peers enforcing [RFC 7675](https://datatracker.ietf.org/doc/html/rfc7675) tear down the connection after 30s of STUN silence.

Same bug fixed in Go upstream: https://github.com/pion/ice/pull/767.

This change:
- Adds `last_consent_sent: Instant` to `Agent`, tracking when the last STUN consent ping was sent independently of media timestamps
- Replaces the `last_sent`/`last_received` guard with an elapsed check against `last_consent_sent`

## Test plan
- [x] `cargo check -p rtc-ice`
- [x] `cargo clippy -p rtc-ice`
- [x] `cargo test -p rtc-ice`