### PR TITLE
Expose configuration for ice connection attempts

### DIFF
--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -447,7 +447,7 @@ impl SettingEngine {
     pub fn set_ice_connection_attempts(
         &mut self,
         check_interval: Option<Duration>,
-        max_binding_requests: Option<u16>
+        max_binding_requests: Option<u16>,
     ) {
         self.timeout.ice_check_interval = check_interval;
         self.timeout.ice_max_binding_requests = max_binding_requests

--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -141,6 +141,18 @@ pub struct Timeout {
     /// Default: 2 seconds. If media is flowing, no keepalives are sent.
     pub ice_keepalive_interval: Option<Duration>,
 
+    /// Controls how often ICE sends binding requests for a candidate pair.
+    /// When combined with `ice_max_binding_requests`, controls how long ICE will attempt
+    /// to connect a candidate.
+    pub ice_check_interval: Option<Duration>,
+
+    /// The max amount of binding requests ICE will send over a candidate pair for validation
+    /// or nomination, if after max_binding_requests the candidate is yet to answer a binding
+    /// request or a nomination we set the pair as failed.
+    /// When combined with `ice_check_interval`, controls how long ICE will attempt
+    /// to connect a candidate.
+    pub ice_max_binding_requests: Option<u16>,
+
     /// Minimum wait time before accepting host candidates.
     pub ice_host_acceptance_min_wait: Option<Duration>,
 
@@ -421,6 +433,24 @@ impl SettingEngine {
         self.timeout.ice_disconnected_timeout = disconnected_timeout;
         self.timeout.ice_failed_timeout = failed_timeout;
         self.timeout.ice_keepalive_interval = keep_alive_interval;
+    }
+
+    /// Configures ICE connection attempt behavior, including number of connection attempts
+    /// per candidate, and the amount of time between connection attempts.
+    ///
+    /// The default settings configure ICE to attempt to connect a candidate for up to 1.4 seconds.
+    ///
+    /// # Parameters
+    ///
+    /// * `check_interval` - The delay between each connection attempt (default: 200 ms)
+    /// * `max_binding_requests` - Maximum number of connection attempts per candidate (default: 7)
+    pub fn set_ice_connection_attempts(
+        &mut self,
+        check_interval: Option<Duration>,
+        max_binding_requests: Option<u16>
+    ) {
+        self.timeout.ice_check_interval = check_interval;
+        self.timeout.ice_max_binding_requests = max_binding_requests
     }
 
     /// Sets minimum wait time before accepting host candidates.

--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -63,6 +63,8 @@ where
             keepalive_interval: setting_engine.timeout.ice_keepalive_interval,
             candidate_types,
             network_types,
+            check_interval: setting_engine.timeout.ice_check_interval.unwrap_or(std::time::Duration::from_millis(0)),
+            max_binding_requests: setting_engine.timeout.ice_max_binding_requests,
             host_acceptance_min_wait: setting_engine.timeout.ice_host_acceptance_min_wait,
             srflx_acceptance_min_wait: setting_engine.timeout.ice_srflx_acceptance_min_wait,
             prflx_acceptance_min_wait: setting_engine.timeout.ice_prflx_acceptance_min_wait,

--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -63,7 +63,10 @@ where
             keepalive_interval: setting_engine.timeout.ice_keepalive_interval,
             candidate_types,
             network_types,
-            check_interval: setting_engine.timeout.ice_check_interval.unwrap_or(std::time::Duration::from_millis(0)),
+            check_interval: setting_engine
+                .timeout
+                .ice_check_interval
+                .unwrap_or(std::time::Duration::from_millis(0)),
             max_binding_requests: setting_engine.timeout.ice_max_binding_requests,
             host_acceptance_min_wait: setting_engine.timeout.ice_host_acceptance_min_wait,
             srflx_acceptance_min_wait: setting_engine.timeout.ice_srflx_acceptance_min_wait,


### PR DESCRIPTION
If my analysis is right, the default ICE configuration allows ICE to attempt to connect a candidate for up to 1.4 seconds before marking the candidate as failed. In my app, I'd like to allocate more time to connection attempts. This PR exposes the configuration options that allow re-configuring that behavior, to allow longer connection attempt times.

I think the `ice_interval` setting was intended to be an internal implementation detail? But considering the effect of this setting on ICE connection attempts, this PR promotes it to public configuration. Maybe that's not something you want? Or maybe my analysis is wrong? Let me know what you think of these changes.

Thanks,
Jeff
