### PR TITLE
Implement outgoing_queues_empty for PeerConnection

### DIFF
--- a/rtc-datachannel/src/data_channel/mod.rs
+++ b/rtc-datachannel/src/data_channel/mod.rs
@@ -388,3 +388,9 @@ impl sansio::Protocol<DataChannelMessage, DataChannelMessage, ()> for DataChanne
         self.write_data_channel_close()
     }
 }
+
+impl shared::WriteQueueQuiescence for DataChannel {
+    fn is_write_queue_empty(&self) -> bool {
+        self.write_outs.is_empty()
+    }
+}

--- a/rtc-interceptor-derive/src/lib.rs
+++ b/rtc-interceptor-derive/src/lib.rs
@@ -128,6 +128,13 @@ pub fn derive_interceptor(input: TokenStream) -> TokenStream {
             fn __interceptor_inner_mut(&mut self) -> &mut #next_type {
                 &mut self.#next_name
             }
+
+            /// Hidden accessor for the next interceptor (used by #[interceptor] macro)
+            #[doc(hidden)]
+            #[inline(always)]
+            fn __interceptor_inner(&self) -> &#next_type {
+                &self.#next_name
+            }
         }
     };
 
@@ -215,6 +222,7 @@ pub fn interceptor(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate Protocol methods that are NOT overridden (using accessor method)
     let protocol_methods = generate_protocol_methods(&override_methods);
     let interceptor_methods = generate_interceptor_methods(&override_methods);
+    let quiescence_methods = generate_quiescence_methods(&override_methods);
 
     // Protocol method names
     let protocol_method_names = [
@@ -235,6 +243,11 @@ pub fn interceptor(_attr: TokenStream, item: TokenStream) -> TokenStream {
         "unbind_local_stream",
         "bind_remote_stream",
         "unbind_remote_stream",
+    ];
+
+    // Quiescence method names
+    let quiescence_method_names = [
+        "is_write_queue_empty"
     ];
 
     // Extract Protocol overridden methods
@@ -267,6 +280,21 @@ pub fn interceptor(_attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect();
 
+    // Extract Quiescence overridden methods
+    let quiescence_override_items: Vec<_> = input
+        .items
+        .iter()
+        .filter(|item| {
+            if let ImplItem::Fn(method) = item {
+                let name = method.sig.ident.to_string();
+                override_methods.contains(&method.sig.ident)
+                    && quiescence_method_names.contains(&name.as_str())
+            } else {
+                false
+            }
+        })
+        .collect();
+
     let expanded = quote! {
         impl #impl_generics sansio::Protocol<
             TaggedPacket,
@@ -286,6 +314,11 @@ pub fn interceptor(_attr: TokenStream, item: TokenStream) -> TokenStream {
         impl #impl_generics Interceptor for #self_ty #where_clause {
             #interceptor_methods
             #(#interceptor_override_items)*
+        }
+
+        impl #impl_generics shared::WriteQueueQuiescence for #self_ty #where_clause {
+            #quiescence_methods
+            #(#quiescence_override_items)*
         }
     };
 
@@ -443,6 +476,21 @@ fn generate_interceptor_methods(override_methods: &[Ident]) -> proc_macro2::Toke
         methods.extend(quote! {
             fn unbind_remote_stream(&mut self, info: &StreamInfo) {
                 self.__interceptor_inner_mut().unbind_remote_stream(info);
+            }
+        });
+    }
+
+    methods
+}
+
+/// Generate Quiescence methods that delegate to inner, excluding overridden ones
+fn generate_quiescence_methods(override_methods: &[Ident]) -> proc_macro2::TokenStream {
+    let mut methods = proc_macro2::TokenStream::new();
+
+    if !override_methods.iter().any(|m| m == "is_write_queue_empty") {
+        methods.extend(quote! {
+            fn is_write_queue_empty(&self) -> bool {
+                self.__interceptor_inner().is_write_queue_empty()
             }
         });
     }

--- a/rtc-interceptor/src/lib.rs
+++ b/rtc-interceptor/src/lib.rs
@@ -314,6 +314,7 @@ pub trait Interceptor:
         Time = Instant,
         Error = shared::error::Error,
     > + Sized
+    + shared::WriteQueueQuiescence
     + Send
     + Sync
     + 'static

--- a/rtc-interceptor/src/noop.rs
+++ b/rtc-interceptor/src/noop.rs
@@ -102,6 +102,13 @@ impl Interceptor for NoopInterceptor {
     fn unbind_remote_stream(&mut self, _info: &StreamInfo) {}
 }
 
+impl shared::WriteQueueQuiescence for NoopInterceptor {
+    fn is_write_queue_empty(&self) -> bool {
+        self.write_queue.is_empty()
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rtc-interceptor/src/registry.rs
+++ b/rtc-interceptor/src/registry.rs
@@ -197,6 +197,12 @@ mod tests {
         }
     }
 
+    impl<P: Interceptor> shared::WriteQueueQuiescence for TestInterceptor<P> {
+        fn is_write_queue_empty(&self) -> bool {
+            self.inner.is_write_queue_empty()
+        }
+    }
+
     impl<P: Interceptor> Interceptor for TestInterceptor<P> {
         fn bind_local_stream(&mut self, info: &crate::StreamInfo) {
             self.inner.bind_local_stream(info);

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2869,3 +2869,13 @@ impl Association {
             .is_none()
     }
 }
+
+
+impl shared::WriteQueueQuiescence for Association {
+    fn is_write_queue_empty(&self) -> bool {
+
+        // only look at the pending queue,
+        // since those are messages that haven't been sent to the write_outs yet
+        self.pending_queue.is_empty()
+    }
+}

--- a/rtc-shared/src/lib.rs
+++ b/rtc-shared/src/lib.rs
@@ -26,5 +26,5 @@ pub mod util;
 
 pub use transport::{
     EcnCodepoint, FiveTuple, FourTuple, TaggedBytesMut, TransportContext, TransportMessage,
-    TransportProtocol,
+    TransportProtocol, WriteQueueQuiescence
 };

--- a/rtc-shared/src/transport.rs
+++ b/rtc-shared/src/transport.rs
@@ -136,3 +136,9 @@ impl From<TransportContext> for FiveTuple {
         }
     }
 }
+
+
+/// Used to check if write queues are empty before shutting down the event loop
+pub trait WriteQueueQuiescence {
+    fn is_write_queue_empty(&self) -> bool;
+}

--- a/rtc/src/peer_connection/handler/datachannel.rs
+++ b/rtc/src/peer_connection/handler/datachannel.rs
@@ -332,3 +332,20 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
         Ok(())
     }
 }
+
+impl<'a> shared::WriteQueueQuiescence for DataChannelHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+        
+        // check all the data channels
+        for data_channel in self.data_channels.values() {
+            if let Some(data_channel) = data_channel.data_channel.as_ref() {
+                if !data_channel.is_write_queue_empty() {
+                    return false;
+                }
+            }
+        }
+
+        // finally, check the pipeline stage output queue
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/demuxer.rs
+++ b/rtc/src/peer_connection/handler/demuxer.rs
@@ -161,3 +161,12 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
         Ok(())
     }
 }
+
+impl<'a> shared::WriteQueueQuiescence for DemuxerHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+        // can't filter out STUN messages anymore,
+        // and nothing sits in this queue for long anyway,
+        // so say it's always empty
+        true
+    }
+}

--- a/rtc/src/peer_connection/handler/demuxer.rs
+++ b/rtc/src/peer_connection/handler/demuxer.rs
@@ -164,9 +164,6 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
 
 impl<'a> shared::WriteQueueQuiescence for DemuxerHandler<'a> {
     fn is_write_queue_empty(&self) -> bool {
-        // can't filter out STUN messages anymore,
-        // and nothing sits in this queue for long anyway,
-        // so say it's always empty
-        true
+        self.ctx.write_outs.is_empty()
     }
 }

--- a/rtc/src/peer_connection/handler/dtls.rs
+++ b/rtc/src/peer_connection/handler/dtls.rs
@@ -433,3 +433,9 @@ impl<'a> DtlsHandler<'a> {
         Ok((local_context, remote_context))
     }
 }
+
+impl<'a> shared::WriteQueueQuiescence for DtlsHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/endpoint.rs
+++ b/rtc/src/peer_connection/handler/endpoint.rs
@@ -649,3 +649,12 @@ where
         Some((mid, rid, rrid))
     }
 }
+
+impl<'a, I> shared::WriteQueueQuiescence for EndpointHandler<'a, I>
+where
+    I: Interceptor,
+{
+    fn is_write_queue_empty(&self) -> bool {
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/ice.rs
+++ b/rtc/src/peer_connection/handler/ice.rs
@@ -206,3 +206,9 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
         self.ctx.ice_transport.agent.close()
     }
 }
+
+impl<'a> shared::WriteQueueQuiescence for IceHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/interceptor.rs
+++ b/rtc/src/peer_connection/handler/interceptor.rs
@@ -311,3 +311,13 @@ where
         self.interceptor.close()
     }
 }
+
+impl<'a, I> shared::WriteQueueQuiescence for InterceptorHandler<'a, I>
+where
+    I: Interceptor,
+{
+    fn is_write_queue_empty(&self) -> bool {
+        self.interceptor.is_write_queue_empty()
+            && self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/mod.rs
+++ b/rtc/src/peer_connection/handler/mod.rs
@@ -31,7 +31,7 @@ use crate::statistics::accumulator::RTCStatsAccumulator;
 use ::interceptor::Interceptor;
 use ::interceptor::Packet;
 use log::warn;
-use shared::TaggedBytesMut;
+use shared::{TaggedBytesMut, WriteQueueQuiescence};
 use shared::error::{Error, flatten_errs};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
@@ -187,6 +187,23 @@ where
             &mut self.interceptor,
             &mut self.pipeline_context.stats,
         )
+    }
+
+    pub(crate) fn pipeline_write_queue_empty(&mut self) -> bool {
+
+        // check each pipeline stage
+        #[allow(unused_mut)] // yes, we don't actually need mut here, but the handler APIs force mut
+        {
+            for_each_handler!(forward: process_handler!(self, handler, {
+                if !handler.is_write_queue_empty() {
+                    return false;
+                }
+            }));
+        }
+
+        // finally, check the pipeline output itself,
+        // even though a caller can already see if it's empty or not anyway
+        self.pipeline_context.write_outs.is_empty()
     }
 }
 

--- a/rtc/src/peer_connection/handler/sctp.rs
+++ b/rtc/src/peer_connection/handler/sctp.rs
@@ -485,3 +485,17 @@ fn split_transmit(transmit: TransportMessage<Payload>) -> Vec<TransportMessage<P
 
     transmits
 }
+
+impl<'a> shared::WriteQueueQuiescence for SctpHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+
+        // check the SCTP associations
+        for association in self.ctx.sctp_transport.sctp_associations.values() {
+            if !association.is_write_queue_empty() {
+                return false;
+            }
+        }
+
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/handler/srtp.rs
+++ b/rtc/src/peer_connection/handler/srtp.rs
@@ -193,3 +193,9 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
         Ok(())
     }
 }
+
+impl<'a> shared::WriteQueueQuiescence for SrtpHandler<'a> {
+    fn is_write_queue_empty(&self) -> bool {
+        self.ctx.write_outs.is_empty()
+    }
+}

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -2234,4 +2234,13 @@ where
             .stats
             .snapshot_with_selector(now, selector)
     }
+
+    /// Returns true if there are no more data channel messages currently sitting in
+    /// internal outgoing queues.
+    ///
+    /// Call to make sure all outgoing data channel messages have been made available for sending
+    /// (via `poll_write`) before closing this peer connection.
+    pub fn outgoing_queues_empty(&mut self) -> bool {
+        self.pipeline_write_queue_empty()
+    }
 }


### PR DESCRIPTION
To provide a signal for when it's safe to tear down the event loop driving the connection after sending messages over a data channel.

This is another attempt at fixing the issue originally behind #63 that works by adding a new `WriteQueueQuiescence` trait providing a `is_write_queue_empty` function for all stages in the peer connection pipeline. If all stages report empty, then it should be safe for the caller of the peer connection to tear down the event loop.

This was a bit tricky to implement because the ICE layer generates a ton of STUN messages that generate a lot of false positive signals. Also, hopefully I actually found all the internal queues where messages can hide.

And the interceptor layer needed special attention because it looks like it's based on a proc macro system. These changes affect the external API requirements for custom interceptors as well.

Let me know what you think.

Thanks,
Jeff