### PR TITLE
feat(dtls): add CustomSigner trait for external signing providers

### DIFF
--- a/rtc-dtls/src/config.rs
+++ b/rtc-dtls/src/config.rs
@@ -272,6 +272,7 @@ impl ConfigBuilder {
             match cert.private_key.kind {
                 CryptoPrivateKeyKind::Ed25519(_) => {}
                 CryptoPrivateKeyKind::Ecdsa256(_) => {}
+                CryptoPrivateKeyKind::Custom(_) => {}
                 _ => return Err(Error::ErrInvalidPrivateKey),
             }
         }

--- a/rtc-dtls/src/config.rs
+++ b/rtc-dtls/src/config.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod config_test;
+
 use crate::cipher_suite::*;
 use crate::conn::{DEFAULT_REPLAY_PROTECTION_WINDOW, INITIAL_TICKER_INTERVAL};
 use crate::crypto::*;

--- a/rtc-dtls/src/config/config_test.rs
+++ b/rtc-dtls/src/config/config_test.rs
@@ -1,0 +1,37 @@
+use super::*;
+use shared::error::Result;
+
+#[derive(Debug)]
+struct MockSigner;
+
+impl CustomSigner for MockSigner {
+    fn sign(&self, _message: &[u8]) -> std::result::Result<Vec<u8>, String> {
+        Ok(vec![])
+    }
+
+    fn clone_box(&self) -> Box<dyn CustomSigner> {
+        Box::new(MockSigner)
+    }
+}
+
+#[test]
+fn test_config_accepts_custom_signer() -> Result<()> {
+    let cert = Certificate {
+        certificate: vec![],
+        private_key: CryptoPrivateKey {
+            kind: CryptoPrivateKeyKind::Custom(Box::new(MockSigner)),
+            serialized_der: vec![],
+        },
+    };
+
+    let handshake = ConfigBuilder::default()
+        .with_certificates(vec![cert])
+        .build(false, None)?;
+
+    assert!(matches!(
+        handshake.local_certificates[0].private_key.kind,
+        CryptoPrivateKeyKind::Custom(_)
+    ));
+
+    Ok(())
+}

--- a/rtc-dtls/src/crypto/crypto_test.rs
+++ b/rtc-dtls/src/crypto/crypto_test.rs
@@ -220,7 +220,6 @@ fn test_certificate_verify() -> Result<()> {
     Ok(())
 }
 
-
 #[derive(Debug)]
 struct MockSigner {
     call_count: std::sync::Arc<std::sync::Mutex<usize>>,

--- a/rtc-dtls/src/crypto/crypto_test.rs
+++ b/rtc-dtls/src/crypto/crypto_test.rs
@@ -219,3 +219,71 @@ fn test_certificate_verify() -> Result<()> {
 
     Ok(())
 }
+
+
+#[derive(Debug)]
+struct MockSigner {
+    call_count: std::sync::Arc<std::sync::Mutex<usize>>,
+    last_message: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    signature: Vec<u8>,
+}
+
+impl CustomSigner for MockSigner {
+    fn sign(&self, message: &[u8]) -> std::result::Result<Vec<u8>, String> {
+        *self.call_count.lock().unwrap() += 1;
+        *self.last_message.lock().unwrap() = message.to_vec();
+        Ok(self.signature.clone())
+    }
+
+    fn clone_box(&self) -> Box<dyn CustomSigner> {
+        Box::new(MockSigner {
+            call_count: std::sync::Arc::clone(&self.call_count),
+            last_message: std::sync::Arc::clone(&self.last_message),
+            signature: self.signature.clone(),
+        })
+    }
+}
+
+#[test]
+fn test_custom_signer_is_invoked_for_signing() -> Result<()> {
+    let expected_signature = vec![0xca, 0xfe, 0xba, 0xbe];
+    let call_count = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+    let last_message = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    let private_key = CryptoPrivateKey {
+        kind: CryptoPrivateKeyKind::Custom(Box::new(MockSigner {
+            call_count: std::sync::Arc::clone(&call_count),
+            last_message: std::sync::Arc::clone(&last_message),
+            signature: expected_signature.clone(),
+        })),
+        serialized_der: vec![],
+    };
+
+    let client_random = [0x01u8, 0x02, 0x03, 0x04];
+    let server_random = [0x05u8, 0x06, 0x07, 0x08];
+    let public_key = [0x09u8, 0x0a, 0x0b];
+    let named_curve = NamedCurve::X25519;
+    let expected_key_message =
+        value_key_message(&client_random, &server_random, &public_key, named_curve);
+
+    let key_signature = generate_key_signature(
+        &client_random,
+        &server_random,
+        &public_key,
+        named_curve,
+        &private_key,
+    )?;
+
+    assert_eq!(*call_count.lock().unwrap(), 1);
+    assert_eq!(&*last_message.lock().unwrap(), &expected_key_message);
+    assert_eq!(key_signature, expected_signature);
+
+    let handshake_bodies = b"certificate-verify-handshake-bodies";
+    let cert_verify = generate_certificate_verify(handshake_bodies, &private_key)?;
+
+    assert_eq!(*call_count.lock().unwrap(), 2);
+    assert_eq!(&*last_message.lock().unwrap(), handshake_bodies);
+    assert_eq!(cert_verify, expected_signature);
+
+    Ok(())
+}

--- a/rtc-dtls/src/crypto/mod.rs
+++ b/rtc-dtls/src/crypto/mod.rs
@@ -138,12 +138,29 @@ pub(crate) fn value_key_message(
     plaintext
 }
 
-/// Either ED25519, ECDSA or RSA keypair.
+/// Trait for delegating signing to an external service (e.g., HSM, TPM, cloud KMS).
+///
+/// Implementations must be thread-safe and cloneable. Each DTLS handshake may
+/// clone the signer, so `clone_box` must return a fresh instance that signs
+/// with the same key.
+pub trait CustomSigner: Send + Sync + std::fmt::Debug {
+    /// Sign the given message and return the raw signature bytes.
+    fn sign(&self, message: &[u8]) -> std::result::Result<Vec<u8>, String>;
+
+    /// Clone this signer into a new boxed instance.
+    fn clone_box(&self) -> Box<dyn CustomSigner>;
+}
+
+/// Either ED25519, ECDSA, RSA keypair, or a custom external signer.
 #[derive(Debug)]
 pub enum CryptoPrivateKeyKind {
     Ed25519(Ed25519KeyPair),
     Ecdsa256(EcdsaKeyPair),
     Rsa256(ring::rsa::KeyPair),
+    /// Delegate signing to an external provider. The signer receives the raw
+    /// message bytes and must return a signature in the format expected by the
+    /// negotiated signature algorithm (e.g., ASN.1 DER for ECDSA).
+    Custom(Box<dyn CustomSigner>),
 }
 
 /// Private key.
@@ -172,6 +189,9 @@ impl PartialEq for CryptoPrivateKey {
             ) | (
                 CryptoPrivateKeyKind::Ed25519(_),
                 CryptoPrivateKeyKind::Ed25519(_)
+            ) | (
+                CryptoPrivateKeyKind::Custom(_),
+                CryptoPrivateKeyKind::Custom(_)
             )
         )
     }
@@ -201,6 +221,10 @@ impl Clone for CryptoPrivateKey {
                 kind: CryptoPrivateKeyKind::Rsa256(
                     ring::rsa::KeyPair::from_pkcs8(&self.serialized_der).unwrap(),
                 ),
+                serialized_der: self.serialized_der.clone(),
+            },
+            CryptoPrivateKeyKind::Custom(ref signer) => CryptoPrivateKey {
+                kind: CryptoPrivateKeyKind::Custom(signer.clone_box()),
                 serialized_der: self.serialized_der.clone(),
             },
         }
@@ -286,6 +310,9 @@ pub(crate) fn generate_key_signature(
             .map_err(|e| Error::Other(e.to_string()))?;
 
             signature
+        }
+        CryptoPrivateKeyKind::Custom(signer) => {
+            signer.sign(&msg).map_err(Error::Other)?
         }
     };
 
@@ -408,6 +435,9 @@ pub(crate) fn generate_certificate_verify(
             .map_err(|e| Error::Other(e.to_string()))?;
 
             signature
+        }
+        CryptoPrivateKeyKind::Custom(signer) => {
+            signer.sign(handshake_bodies).map_err(Error::Other)?
         }
     };
 

--- a/rtc-dtls/src/crypto/mod.rs
+++ b/rtc-dtls/src/crypto/mod.rs
@@ -311,9 +311,7 @@ pub(crate) fn generate_key_signature(
 
             signature
         }
-        CryptoPrivateKeyKind::Custom(signer) => {
-            signer.sign(&msg).map_err(Error::Other)?
-        }
+        CryptoPrivateKeyKind::Custom(signer) => signer.sign(&msg).map_err(Error::Other)?,
     };
 
     Ok(signature)

--- a/rtc-dtls/src/signature_hash_algorithm/mod.rs
+++ b/rtc-dtls/src/signature_hash_algorithm/mod.rs
@@ -100,6 +100,7 @@ impl SignatureHashAlgorithm {
             CryptoPrivateKeyKind::Ed25519(_) => self.signature == SignatureAlgorithm::Ed25519,
             CryptoPrivateKeyKind::Ecdsa256(_) => self.signature == SignatureAlgorithm::Ecdsa,
             CryptoPrivateKeyKind::Rsa256(_) => self.signature == SignatureAlgorithm::Rsa,
+            CryptoPrivateKeyKind::Custom(_) => true,
         }
     }
 }


### PR DESCRIPTION
## Summary

Add a `CustomSigner` trait to `CryptoPrivateKeyKind` that allows delegating DTLS signing operations to an external provider instead of requiring raw private key bytes in memory.

## Motivation

Hardware security modules (HSMs), TPMs, and cloud KMS services expose signing APIs but do not allow extracting the raw private key. The current `CryptoPrivateKeyKind` enum requires a `ring` key pair constructed from raw key bytes, making it impossible to use these external signing providers for DTLS.

This is a common requirement for IoT devices with TPM-backed device certificates, cloud services using AWS KMS or GCP Cloud HSM, and any environment where private keys must remain in hardware.

## Changes

- **New `CustomSigner` trait** in `rtc-dtls/src/crypto/mod.rs` with `sign()` and `clone_box()` methods
- **New `Custom` variant** in `CryptoPrivateKeyKind` enum
- **Match arms** added in `generate_key_signature` and `generate_certificate_verify` to delegate signing to the custom signer
- **Config validation** updated to accept `Custom` key type
- **Signature scheme compatibility** returns `true` for `Custom` (the signer is responsible for producing the correct format)

## Usage

\`\`\`rust
use rtc_dtls::crypto::{CustomSigner, Certificate, CryptoPrivateKey, CryptoPrivateKeyKind};

#[derive(Debug)]
struct MySigner { /* HSM handle, API client, etc. */ }

impl CustomSigner for MySigner {
    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, String> {
        // Call your HSM/TPM/KMS signing API
        // Return signature in the format expected by the negotiated algorithm
        // (e.g., ASN.1 DER for ECDSA)
        todo!()
    }

    fn clone_box(&self) -> Box<dyn CustomSigner> {
        Box::new(MySigner { /* ... */ })
    }
}

let cert = Certificate {
    certificate: vec![/* DER-encoded cert chain */],
    private_key: CryptoPrivateKey {
        kind: CryptoPrivateKeyKind::Custom(Box::new(MySigner {})),
        serialized_der: Vec::new(), // No key material needed
    },
};
\`\`\`

## Notes

- The `Custom` signer must return signatures in the wire format expected by the peer (e.g., ASN.1 DER for ECDSA, PKCS#1 for RSA). The library does not perform format conversion.
- `clone_box()` is required because the DTLS listener clones the certificate config for each incoming connection.
- `is_compatible()` returns `true` for all signature schemes when using a `Custom` signer — the caller is responsible for ensuring their signer supports the negotiated algorithm.