### PR TITLE
 fix(ice): network type ipv4 and ipv6 

### DIFF
--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2564,6 +2564,7 @@ fn test_keepalive_sent_during_media_flow() -> Result<()> {
 fn test_pair_network_type_mismatch() -> Result<()> {
     let mut a = Agent::new(Arc::new(AgentConfig::default()))?;
 
+    // UDP: IPv4 local should not pair with IPv6 remote.
     let local_v4 = CandidateHostConfig {
         base_config: CandidateConfig {
             network: "udp".to_owned(),
@@ -2595,6 +2596,7 @@ fn test_pair_network_type_mismatch() -> Result<()> {
         "IPv4 local and IPv6 remote candidates should not be paired"
     );
 
+    // UDP: matching IPv4 should pair.
     let remote_v4 = CandidateHostConfig {
         base_config: CandidateConfig {
             network: "udp".to_owned(),
@@ -2612,6 +2614,59 @@ fn test_pair_network_type_mismatch() -> Result<()> {
         a.candidate_pairs.len(),
         1,
         "IPv4 local and IPv4 remote candidates should form exactly one pair"
+    );
+
+    // TCP: IPv4 active local should not pair with IPv6 passive remote.
+    let local_tcp4_active = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "tcp".to_owned(),
+            address: "192.168.1.3".to_owned(),
+            port: 7778,
+            component: 1,
+            ..Default::default()
+        },
+        tcp_type: TcpType::Active,
+    }
+    .new_candidate_host()?;
+    a.add_local_candidate(local_tcp4_active)?;
+
+    let remote_tcp6_passive = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "tcp".to_owned(),
+            address: "2001:db8::2".to_owned(),
+            port: 8889,
+            component: 1,
+            ..Default::default()
+        },
+        tcp_type: TcpType::Passive,
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(remote_tcp6_passive)?;
+
+    assert_eq!(
+        a.candidate_pairs.len(),
+        1,
+        "TCP4 active local and TCP6 passive remote should not create an additional pair"
+    );
+
+    // TCP: matching IPv4 active/passive should pair.
+    let remote_tcp4_passive = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "tcp".to_owned(),
+            address: "192.168.1.4".to_owned(),
+            port: 8890,
+            component: 1,
+            ..Default::default()
+        },
+        tcp_type: TcpType::Passive,
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(remote_tcp4_passive)?;
+
+    assert_eq!(
+        a.candidate_pairs.len(),
+        2,
+        "TCP4 active local and TCP4 passive remote should form exactly one pair"
     );
 
     a.close()?;

--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2559,3 +2559,61 @@ fn test_keepalive_sent_during_media_flow() -> Result<()> {
     a.close()?;
     Ok(())
 }
+
+#[test]
+fn test_pair_network_type_mismatch() -> Result<()> {
+    let mut a = Agent::new(Arc::new(AgentConfig::default()))?;
+
+    let local_v4 = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.1.1".to_owned(),
+            port: 7777,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_local_candidate(local_v4)?;
+
+    let remote_v6 = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "2001:db8::1".to_owned(),
+            port: 8888,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(remote_v6)?;
+
+    assert!(
+        a.candidate_pairs.is_empty(),
+        "IPv4 local and IPv6 remote candidates should not be paired"
+    );
+
+    let remote_v4 = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.1.2".to_owned(),
+            port: 8888,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(remote_v4)?;
+
+    assert_eq!(
+        a.candidate_pairs.len(),
+        1,
+        "IPv4 local and IPv4 remote candidates should form exactly one pair"
+    );
+
+    a.close()?;
+    Ok(())
+}

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -413,21 +413,26 @@ impl Agent {
         let local_index = self.local_candidates.len() - 1;
         let local_tcp_type = self.local_candidates[local_index].tcp_type();
 
+        let local_network_type = self.local_candidates[local_index].network_type();
+
         for remote_index in 0..self.remote_candidates.len() {
             let remote_tcp_type = self.remote_candidates[remote_index].tcp_type();
+            let remote_network_type = self.remote_candidates[remote_index].network_type();
 
+            // Candidates must share the same address family (IPv4 with IPv4, IPv6 with IPv6).
             // TCP type pairing rules (RFC 6544):
             // - Active can only pair with Passive
             // - Passive can only pair with Active
             // - SimultaneousOpen can pair with SimultaneousOpen
             // - Unspecified (UDP) can pair with Unspecified
-            let should_pair = match (local_tcp_type, remote_tcp_type) {
-                (TcpType::Active, TcpType::Passive) => true,
-                (TcpType::Passive, TcpType::Active) => true,
-                (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
-                (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
-                _ => false,
-            };
+            let should_pair = local_network_type == remote_network_type
+                && match (local_tcp_type, remote_tcp_type) {
+                    (TcpType::Active, TcpType::Passive) => true,
+                    (TcpType::Passive, TcpType::Active) => true,
+                    (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
+                    (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
+                    _ => false,
+                };
 
             if should_pair {
                 self.add_pair(local_index, remote_index);
@@ -494,25 +499,29 @@ impl Agent {
         for c in remote_candidates {
             if !self.remote_candidates.iter().any(|cand| cand.equal(&c)) {
                 let remote_tcp_type = c.tcp_type();
+                let remote_network_type = c.network_type();
                 self.remote_candidates.push(c);
                 let remote_index = self.remote_candidates.len() - 1;
 
                 // Apply TCP type pairing rules (RFC 6544)
                 for local_index in 0..self.local_candidates.len() {
                     let local_tcp_type = self.local_candidates[local_index].tcp_type();
+                    let local_network_type = self.local_candidates[local_index].network_type();
 
+                    // Candidates must share the same address family (IPv4 with IPv4, IPv6 with IPv6).
                     // TCP type pairing rules:
                     // - Active can only pair with Passive
                     // - Passive can only pair with Active
                     // - SimultaneousOpen can pair with SimultaneousOpen
                     // - Unspecified (UDP) can pair with Unspecified
-                    let should_pair = match (local_tcp_type, remote_tcp_type) {
-                        (TcpType::Active, TcpType::Passive) => true,
-                        (TcpType::Passive, TcpType::Active) => true,
-                        (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
-                        (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
-                        _ => false,
-                    };
+                    let should_pair = local_network_type == remote_network_type
+                        && match (local_tcp_type, remote_tcp_type) {
+                            (TcpType::Active, TcpType::Passive) => true,
+                            (TcpType::Passive, TcpType::Active) => true,
+                            (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
+                            (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
+                            _ => false,
+                        };
 
                     if should_pair {
                         self.add_pair(local_index, remote_index);

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -411,30 +411,11 @@ impl Agent {
 
         self.local_candidates.push(c);
         let local_index = self.local_candidates.len() - 1;
-        let local_tcp_type = self.local_candidates[local_index].tcp_type();
-
-        let local_network_type = self.local_candidates[local_index].network_type();
 
         for remote_index in 0..self.remote_candidates.len() {
-            let remote_tcp_type = self.remote_candidates[remote_index].tcp_type();
-            let remote_network_type = self.remote_candidates[remote_index].network_type();
-
-            // Candidates must share the same address family (IPv4 with IPv4, IPv6 with IPv6).
-            // TCP type pairing rules (RFC 6544):
-            // - Active can only pair with Passive
-            // - Passive can only pair with Active
-            // - SimultaneousOpen can pair with SimultaneousOpen
-            // - Unspecified (UDP) can pair with Unspecified
-            let should_pair = local_network_type == remote_network_type
-                && match (local_tcp_type, remote_tcp_type) {
-                    (TcpType::Active, TcpType::Passive) => true,
-                    (TcpType::Passive, TcpType::Active) => true,
-                    (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
-                    (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
-                    _ => false,
-                };
-
-            if should_pair {
+            if self.local_candidates[local_index]
+                .can_pair_with(&self.remote_candidates[remote_index])
+            {
                 self.add_pair(local_index, remote_index);
             }
         }
@@ -498,32 +479,13 @@ impl Agent {
     fn trigger_request_connectivity_check(&mut self, remote_candidates: Vec<Candidate>) {
         for c in remote_candidates {
             if !self.remote_candidates.iter().any(|cand| cand.equal(&c)) {
-                let remote_tcp_type = c.tcp_type();
-                let remote_network_type = c.network_type();
                 self.remote_candidates.push(c);
                 let remote_index = self.remote_candidates.len() - 1;
 
-                // Apply TCP type pairing rules (RFC 6544)
                 for local_index in 0..self.local_candidates.len() {
-                    let local_tcp_type = self.local_candidates[local_index].tcp_type();
-                    let local_network_type = self.local_candidates[local_index].network_type();
-
-                    // Candidates must share the same address family (IPv4 with IPv4, IPv6 with IPv6).
-                    // TCP type pairing rules:
-                    // - Active can only pair with Passive
-                    // - Passive can only pair with Active
-                    // - SimultaneousOpen can pair with SimultaneousOpen
-                    // - Unspecified (UDP) can pair with Unspecified
-                    let should_pair = local_network_type == remote_network_type
-                        && match (local_tcp_type, remote_tcp_type) {
-                            (TcpType::Active, TcpType::Passive) => true,
-                            (TcpType::Passive, TcpType::Active) => true,
-                            (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
-                            (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
-                            _ => false,
-                        };
-
-                    if should_pair {
+                    if self.local_candidates[local_index]
+                        .can_pair_with(&self.remote_candidates[remote_index])
+                    {
                         self.add_pair(local_index, remote_index);
                     }
                 }

--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -347,6 +347,26 @@ impl Candidate {
             && self.related_address() == other.related_address()
     }
 
+    /// Returns true if this candidate can be paired with `other` according to
+    /// ICE candidate pairing rules.
+    ///
+    /// Candidates must share the same network type (protocol and address family)
+    /// and have compatible TCP types (RFC 6544). UDP candidates use
+    /// `TcpType::Unspecified`.
+    pub(crate) fn can_pair_with(&self, other: &Candidate) -> bool {
+        if self.network_type() != other.network_type() {
+            return false;
+        }
+
+        match (self.tcp_type(), other.tcp_type()) {
+            (TcpType::Active, TcpType::Passive) => true,
+            (TcpType::Passive, TcpType::Active) => true,
+            (TcpType::SimultaneousOpen, TcpType::SimultaneousOpen) => true,
+            (TcpType::Unspecified, TcpType::Unspecified) => true, // UDP candidates
+            _ => false,
+        }
+    }
+
     pub fn set_ip(&mut self, ip: &IpAddr) -> Result<()> {
         self.network_type = determine_network_type(&self.network, ip)?;
         self.resolved_addr = SocketAddr::new(*ip, self.port); //TODO:  create_addr(network_type, *ip, self.port);


### PR DESCRIPTION
Fix this error

```
2026-06-24T17:43:23.063810Z ERROR ThreadId(04) webrtc::peer_connection::driver: /home/binbat/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/webrtc-0.20.0-alpha.2/src/peer_connection/driver.rs:343: Failed to send to [fd07:b51a:cc66:0:a617:db5e:ab7:e9f1]:62509 from 192.168.127.128:39320: Address family not supported by protocol (os error 97)
2026-06-24T17:43:23.064484Z  INFO ThreadId(04) liveion::forward::internal: liveion/src/forward/internal.rs:283: subscribe ICE gathering complete
2026-06-24T17:43:23.066410Z ERROR ThreadId(04) webrtc::peer_connection::driver: /home/binbat/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/webrtc-0.20.0-alpha.2/src/peer_connection/driver.rs:343: Failed to send to [fd07:b51a:cc66:0:a617:db5e:ab7:e9f1]:62509 from 192.168.127.128:39320: Address family not supported by protocol (os error 97)
2026-06-24T17:43:23.066606Z ERROR ThreadId(04) webrtc::peer_connection::driver: /home/binbat/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/webrtc-0.20.0-alpha.2/src/peer_connection/driver.rs:343: Failed to send to [fd07:b51a:cc66:0:a617:db5e:ab7:e9f1]:62509 from 192.168.127.128:39320: Address family not supported by protocol (os error 97)
```