### PR TITLE
Only start SCTP transport if application media has been negotiated

### DIFF
--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -263,9 +263,10 @@ use crate::peer_connection::handler::ice::IceHandlerContext;
 use crate::peer_connection::handler::sctp::SctpHandlerContext;
 use crate::peer_connection::sdp::session_description::RTCSessionDescription;
 use crate::peer_connection::sdp::{
-    extract_fingerprint, extract_ice_details, get_application_media_section_max_message_size,
-    get_application_media_section_sctp_port, get_mid_value, get_peer_direction,
-    has_ice_trickle_option, is_lite_set, sdp_type::RTCSdpType, update_sdp_origin,
+    extract_fingerprint, extract_ice_details, get_application_media,
+    get_application_media_section_max_message_size, get_application_media_section_sctp_port,
+    get_mid_value, get_peer_direction, has_ice_trickle_option, is_lite_set, sdp_type::RTCSdpType,
+    update_sdp_origin,
 };
 use crate::peer_connection::state::RTCIceGatheringState;
 use crate::peer_connection::state::ice_connection_state::RTCIceConnectionState;
@@ -1135,30 +1136,36 @@ where
             if let Some(remote_description) = self.remote_description().cloned()
                 && let Some(parsed_remote_description) = remote_description.parsed.as_ref()
             {
-                let (dtls_role, remote_caps, local_sctp_port, remote_sctp_port) = (
-                    self.dtls_transport().role(),
-                    SCTPTransportCapabilities {
-                        max_message_size: get_application_media_section_max_message_size(
-                            parsed_remote_description,
-                        )
-                        .unwrap_or(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE),
-                    },
-                    get_application_media_section_sctp_port(parsed_local_description)
-                        .unwrap_or(5000),
-                    get_application_media_section_sctp_port(parsed_remote_description)
-                        .unwrap_or(5000),
-                );
+                // only start sctp transport if application media has been negotiated
+                if let (Some(local_application_media), Some(remote_application_media)) = (
+                    get_application_media(parsed_local_description),
+                    get_application_media(parsed_remote_description),
+                ) {
+                    let (dtls_role, remote_caps, local_sctp_port, remote_sctp_port) = (
+                        self.dtls_transport().role(),
+                        SCTPTransportCapabilities {
+                            max_message_size: get_application_media_section_max_message_size(
+                                remote_application_media,
+                            )
+                            .unwrap_or(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE),
+                        },
+                        get_application_media_section_sctp_port(local_application_media)
+                            .unwrap_or(5000),
+                        get_application_media_section_sctp_port(remote_application_media)
+                            .unwrap_or(5000),
+                    );
 
-                // we_answer: we first call set_remote_description,
-                // then, we create_answer() and set_local_description() here
-                // Now we should have done SDP negotiation.
-                // Therefore, it is ready to start sctp and rtp.
-                self.sctp_transport_mut().start(
-                    dtls_role,
-                    remote_caps,
-                    local_sctp_port,
-                    remote_sctp_port,
-                )?;
+                    // we_answer: we first call set_remote_description,
+                    // then, we create_answer() and set_local_description() here
+                    // Now we should have done SDP negotiation.
+                    // Therefore, it is ready to start sctp and rtp.
+                    self.sctp_transport_mut().start(
+                        dtls_role,
+                        remote_caps,
+                        local_sctp_port,
+                        remote_sctp_port,
+                    )?;
+                }
                 self.start_rtp(remote_description)?;
             }
         }
@@ -1521,30 +1528,36 @@ where
                     .as_ref()
                     .and_then(|desc| desc.parsed.as_ref())
             {
-                let (dtls_role, remote_caps, local_sctp_port, remote_sctp_port) = (
-                    self.dtls_transport().role(),
-                    SCTPTransportCapabilities {
-                        max_message_size: get_application_media_section_max_message_size(
-                            parsed_remote_description,
-                        )
-                        .unwrap_or(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE),
-                    },
-                    get_application_media_section_sctp_port(parsed_local_description)
-                        .unwrap_or(5000),
-                    get_application_media_section_sctp_port(parsed_remote_description)
-                        .unwrap_or(5000),
-                );
+                // only start sctp transport if application media has been negotiated
+                if let (Some(local_application_media), Some(remote_application_media)) = (
+                    get_application_media(parsed_local_description),
+                    get_application_media(parsed_remote_description),
+                ) {
+                    let (dtls_role, remote_caps, local_sctp_port, remote_sctp_port) = (
+                        self.dtls_transport().role(),
+                        SCTPTransportCapabilities {
+                            max_message_size: get_application_media_section_max_message_size(
+                                remote_application_media,
+                            )
+                            .unwrap_or(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE),
+                        },
+                        get_application_media_section_sctp_port(local_application_media)
+                            .unwrap_or(5000),
+                        get_application_media_section_sctp_port(remote_application_media)
+                            .unwrap_or(5000),
+                    );
 
-                // we_offer: we create_offer() and set_local_description() first
-                // then, after call set_remote_description here,
-                // Now we should have done SDP negotiation.
-                // Therefore, it is ready to start sctp and rtp.
-                self.sctp_transport_mut().start(
-                    dtls_role,
-                    remote_caps,
-                    local_sctp_port,
-                    remote_sctp_port,
-                )?;
+                    // we_offer: we create_offer() and set_local_description() first
+                    // then, after call set_remote_description here,
+                    // Now we should have done SDP negotiation.
+                    // Therefore, it is ready to start sctp and rtp.
+                    self.sctp_transport_mut().start(
+                        dtls_role,
+                        remote_caps,
+                        local_sctp_port,
+                        remote_sctp_port,
+                    )?;
+                }
                 self.start_rtp(remote_description)?;
             }
         }

--- a/rtc/src/peer_connection/sdp/mod.rs
+++ b/rtc/src/peer_connection/sdp/mod.rs
@@ -1267,42 +1267,50 @@ pub(crate) fn is_lite_set(desc: &SessionDescription) -> bool {
     false
 }
 
-pub(crate) fn get_application_media_section_sctp_port(desc: &SessionDescription) -> Option<u16> {
-    for m in &desc.media_descriptions {
-        if m.media_name.media == MEDIA_SECTION_APPLICATION {
-            return if let Some(sctp_port_attr) =
-                m.attributes.iter().find(|attr| attr.key == "sctp-port")
-            {
-                let sctp_port_value = sctp_port_attr.value.as_ref();
+pub(crate) fn get_application_media_section_sctp_port(
+    media_desc: &MediaDescription,
+) -> Option<u16> {
+    if media_desc.media_name.media == MEDIA_SECTION_APPLICATION {
+        return if let Some(sctp_port_attr) = media_desc
+            .attributes
+            .iter()
+            .find(|attr| attr.key == "sctp-port")
+        {
+            let sctp_port_value = sctp_port_attr.value.as_ref();
 
-                sctp_port_value.and_then(|attr| attr.parse::<u16>().ok())
-            } else if let Some(sctp_port_attr) =
-                m.attributes.iter().find(|attr| attr.key == "sctpmap")
-            {
-                if let Some(sctp_port_attr_value) = sctp_port_attr.value.as_ref() {
-                    sctp_port_attr_value
-                        .split(" ")
-                        .next()
-                        .and_then(|port| u16::from_str(port).ok())
-                } else {
-                    None
-                }
+            sctp_port_value.and_then(|attr| attr.parse::<u16>().ok())
+        } else if let Some(sctp_port_attr) = media_desc
+            .attributes
+            .iter()
+            .find(|attr| attr.key == "sctpmap")
+        {
+            if let Some(sctp_port_attr_value) = sctp_port_attr.value.as_ref() {
+                sctp_port_attr_value
+                    .split(" ")
+                    .next()
+                    .and_then(|port| u16::from_str(port).ok())
             } else {
                 None
-            };
-        }
+            }
+        } else {
+            None
+        };
     }
 
     None
 }
 
 pub(crate) fn get_application_media_section_max_message_size(
-    desc: &SessionDescription,
+    media_desc: &MediaDescription,
 ) -> Option<u32> {
-    get_application_media(desc)?
-        .attribute(ATTR_KEY_MAX_MESSAGE_SIZE)??
-        .parse()
-        .ok()
+    if media_desc.media_name.media == MEDIA_SECTION_APPLICATION {
+        media_desc
+            .attribute(ATTR_KEY_MAX_MESSAGE_SIZE)??
+            .parse()
+            .ok()
+    } else {
+        None
+    }
 }
 
 pub(crate) fn get_by_mid<'a>(


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8831#section-6.2 Specifies that SCTP association will be set up when the two sides of the PeerConnection agrees to set it up.

My understanding is that they agree when the SDP offer/answer contains an application media section.

This change thus only starts SCTP transport if an application media section can be found in the SDP offer/answer.