### PR TITLE
Fix AV1 LEB128 encoding for values greater than 127

### DIFF
--- a/rtc-rtp/src/codec/av1/av1_test.rs
+++ b/rtc-rtp/src/codec/av1/av1_test.rs
@@ -1,4 +1,6 @@
-use crate::codec::av1::leb128::read_leb128;
+use bytes::BytesMut;
+
+use crate::codec::av1::leb128::{BytesMutExt, leb128_size, read_leb128};
 use crate::codec::av1::obu::{
     OBU_HAS_EXTENSION_BIT, OBU_TYPE_FRAME, OBU_TYPE_FRAME_HEADER, OBU_TYPE_METADATA,
     OBU_TYPE_SEQUENCE_HEADER, OBU_TYPE_TEMPORAL_DELIMITER, OBU_TYPE_TILE_GROUP, OBU_TYPE_TILE_LIST,
@@ -474,4 +476,49 @@ fn read_leb128_5_byte() {
     let (payload_size, leb128_size) = read_leb128(&(bytes.into()));
     assert_eq!(leb128_size, 5);
     assert_eq!(payload_size, 16451);
+}
+
+#[test]
+fn put_leb128_single_byte_values() {
+    // Values that fit in 7 bits encode to a single unchanged byte.
+    for &v in &[0u32, 1, 42, 127] {
+        let mut buf = BytesMut::new();
+        buf.put_leb128(v);
+        assert_eq!(buf.as_ref(), &[v as u8][..]);
+    }
+}
+
+#[test]
+fn put_leb128_128_is_two_bytes() {
+    // Regression test for https://github.com/webrtc-rs/rtc/issues/92: 128 must
+    // encode as [0x80, 0x01], not the previously produced [129, 128, 2].
+    let mut buf = BytesMut::new();
+    buf.put_leb128(128);
+    assert_eq!(buf.as_ref(), &[0x80u8, 0x01][..]);
+}
+
+#[test]
+fn put_leb128_matches_size_and_roundtrips() {
+    // Covers single-byte, multi-byte, and the full-width 5-byte cases. Values
+    // >= 2^28 need five LEB128 bytes, which the previous u32-packing encoder
+    // could not represent (it overflowed / panicked in debug builds).
+    for &v in &[
+        0u32,
+        1,
+        127,
+        128,
+        300,
+        16451,
+        0x0FFF_FFFF,
+        0x1000_0000,
+        u32::MAX,
+    ] {
+        let mut buf = BytesMut::new();
+        buf.put_leb128(v);
+        assert_eq!(buf.len(), leb128_size(v), "encoded length mismatch for {v}");
+
+        let (decoded, size) = read_leb128(&buf.freeze());
+        assert_eq!(decoded, v, "round-trip failed for {v}");
+        assert_eq!(size, leb128_size(v), "read size mismatch for {v}");
+    }
 }

--- a/rtc-rtp/src/codec/av1/leb128.rs
+++ b/rtc-rtp/src/codec/av1/leb128.rs
@@ -1,19 +1,5 @@
 use bytes::{BufMut, Bytes, BytesMut};
 
-pub fn encode_leb128(mut val: u32) -> u32 {
-    let mut b = 0;
-    loop {
-        b |= val & 0b_0111_1111;
-        val >>= 7;
-        if val != 0 {
-            b |= 0b_1000_0000;
-            b <<= 8;
-        } else {
-            return b;
-        }
-    }
-}
-
 pub fn decode_leb128(mut val: u64) -> u32 {
     let mut b = 0;
     loop {
@@ -53,12 +39,19 @@ pub trait BytesMutExt {
 }
 
 impl BytesMutExt for BytesMut {
-    fn put_leb128(&mut self, n: u32) {
-        let mut encoded = encode_leb128(n);
-        while encoded >= 0b_1000_0000 {
-            self.put_u8(0b_1000_0000 | (encoded & 0b_0111_1111) as u8);
-            encoded >>= 7;
+    /// Appends `n` to the buffer using unsigned LEB128 variable-length encoding,
+    /// as required by the AV1 bitstream/RTP OBU size fields. Each output byte
+    /// carries 7 bits of the value in its low bits; bit 7 is a continuation flag
+    /// that is set on every byte except the last.
+    fn put_leb128(&mut self, mut n: u32) {
+        loop {
+            let byte = (n & 0b_0111_1111) as u8;
+            n >>= 7;
+            if n == 0 {
+                self.put_u8(byte);
+                return;
+            }
+            self.put_u8(byte | 0b_1000_0000);
         }
-        self.put_u8(encoded as u8);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #92.

`put_leb128` (in `rtc-rtp/src/codec/av1/leb128.rs`) fed the result of `encode_leb128` — which *already* packs finished LEB128 bytes (continuation bits included) at 8-bit boundaries into a `u32` — back through a **second** 7-bit-shift LEB128 pass. This double-encoding corrupted every value above 127.

For example, `128` was encoded as `[129, 128, 2]` instead of the correct `[128, 1]`, producing malformed AV1 OBU size fields that browsers cannot parse (frame drops / stuttering).

`encode_leb128` had a second latent bug: it packs bytes into a `u32`, so any value that needs five LEB128 bytes (`>= 2^28`) overflowed and panicked in debug builds.

## Fix

- Replace `put_leb128` with a correct, self-contained byte-by-byte LEB128 encoder. Its behavior is identical to the depacketizer's existing (correct) `write_leb128`.
- Remove the now-unused, broken `encode_leb128`. It was `pub` only within the private `av1::leb128` module, so it is not part of the crate's public API.

## Why it went unnoticed

Every existing packetization test uses MTU 100, which yields OBU fragments of ~98–99 bytes — all within the single-byte LEB128 range. Real-world MTUs (~1200) routinely produce fragments larger than 127 bytes, which is where the bug triggers.

## Tests

Added to `rtc-rtp/src/codec/av1/av1_test.rs`:

- `put_leb128_128_is_two_bytes` — the exact `128 → [0x80, 0x01]` case from the issue.
- `put_leb128_single_byte_values` — values `<= 127` stay single-byte.
- `put_leb128_matches_size_and_roundtrips` — encoded length matches `leb128_size`, and `put_leb128` → `read_leb128` round-trips across the full `u32` range, including the 5-byte cases (`>= 2^28`, up to `u32::MAX`) that the old encoder could not represent.

Verified the new tests **fail** against the previous implementation:

```
assertion `left == right` failed
  left: [129, 128, 2]
 right: [128, 1]
```

and **pass** after the fix. Full `rtc-rtp` suite: 102/102 passing; `cargo clippy` clean for the changed files; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
