### PR TITLE
Fix ICE agent crashes from stale candidate indices (#88)

### DIFF
--- a/rtc-ice/src/agent/agent_proto.rs
+++ b/rtc-ice/src/agent/agent_proto.rs
@@ -122,7 +122,8 @@ impl sansio::Protocol<TaggedBytesMut, (), ()> for Agent {
         self.trigger_request_connectivity_check(remote_candidates);
 
         if self.ufrag_pwd.remote_credentials.is_some()
-            && self.last_checking_time + self.get_timeout_interval() <= now
+            && (self.force_candidate_contact
+                || self.last_checking_time + self.get_timeout_interval() <= now)
         {
             self.contact(now);
         }
@@ -137,7 +138,14 @@ impl sansio::Protocol<TaggedBytesMut, (), ()> for Agent {
         };
 
         let ice_timeout = if self.ufrag_pwd.remote_credentials.is_some() {
-            Some(self.last_checking_time + self.get_timeout_interval())
+            if self.force_candidate_contact {
+                // A connectivity check was requested; ask the driver to call
+                // `handle_timeout` as soon as possible. `last_checking_time` is in the
+                // past, so the resulting deadline is immediate.
+                Some(self.last_checking_time)
+            } else {
+                Some(self.last_checking_time + self.get_timeout_interval())
+            }
         } else {
             None
         };

--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2672,3 +2672,166 @@ fn test_pair_network_type_mismatch() -> Result<()> {
     a.close()?;
     Ok(())
 }
+
+// Regression test for https://github.com/webrtc-rs/rtc/issues/88 (Issue 1).
+//
+// When the agent transitions to `Failed` it calls `delete_all_candidates`, which
+// empties `local_candidates`/`remote_candidates`. Previously the candidate pairs -
+// and the `selected_pair`/`nominated_pair` indices into them - were left behind, so
+// they referenced candidates that no longer existed. Any later access through a pair,
+// e.g. `get_best_available_candidate_pair`, then indexed out of bounds and panicked:
+//
+//     thread '...' panicked at 'index out of bounds: the len is 0 but the index is 0'
+#[test]
+fn test_transition_to_failed_clears_stale_candidate_pairs() -> Result<()> {
+    let mut a = Agent::new(Arc::new(AgentConfig::default()))?;
+
+    let local = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.0.2".to_owned(),
+            port: 777,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_local_candidate(local)?;
+
+    let remote = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "172.17.0.3".to_owned(),
+            port: 999,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(remote)?;
+
+    // A single local/remote pair now exists; mark it selected and nominated so that
+    // both index-into-pairs fields are populated.
+    assert_eq!(a.candidate_pairs.len(), 1);
+    a.set_selected_pair(Some(0));
+    a.nominated_pair = Some(0);
+
+    // Transition to Failed: this deletes all candidates.
+    a.update_connection_state(ConnectionState::Failed);
+
+    // The pairs and the indices into them must be gone, otherwise they dangle.
+    assert!(
+        a.candidate_pairs.is_empty(),
+        "candidate pairs must be cleared when candidates are deleted"
+    );
+    assert!(a.selected_pair.is_none(), "selected_pair must be reset");
+    assert!(a.nominated_pair.is_none(), "nominated_pair must be reset");
+    assert!(a.local_candidates.is_empty());
+    assert!(a.remote_candidates.is_empty());
+
+    // Before the fix these accessors dereferenced stale pair indices into the emptied
+    // candidate vectors and panicked; now they must simply return `None`.
+    assert!(a.get_selected_candidate_pair().is_none());
+    assert!(a.get_best_available_candidate_pair().is_none());
+
+    a.close()?;
+    Ok(())
+}
+
+// Regression test for https://github.com/webrtc-rs/rtc/issues/88 (Issue 2).
+//
+// Handling an inbound binding request from an unknown address adds a peer-reflexive
+// remote candidate. Previously `add_remote_candidate` ran the connectivity check
+// inline, which could advance the state to `Failed` and clear `remote_candidates`
+// mid-call. The caller then computed `remote_candidates.len() - 1` on an empty vector
+// and panicked ('attempt to subtract with overflow' in debug builds). Deferring the
+// check to `handle_timeout` keeps candidate mutation free of surprising re-entrant
+// state changes.
+#[test]
+fn test_handle_inbound_request_defers_failing_connectivity_check() -> Result<()> {
+    use sansio::Protocol as _;
+
+    let cfg = AgentConfig {
+        disconnected_timeout: Some(Duration::from_secs(0)),
+        failed_timeout: Some(Duration::from_secs(0)),
+        ..Default::default()
+    };
+    let mut a = Agent::new(Arc::new(cfg))?;
+
+    let local_candidate = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.0.2".to_owned(),
+            port: 777,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    let local_index = 0;
+    let local_priority = local_candidate.priority();
+    a.add_local_candidate(local_candidate)?;
+
+    a.ufrag_pwd.remote_credentials = Some(Credentials {
+        ufrag: "".to_string(),
+        pwd: "".to_string(),
+    });
+    let username = a.ufrag_pwd.local_credentials.ufrag.clone() + ":";
+    let local_pwd = a.ufrag_pwd.local_credentials.pwd.clone();
+    let tie_breaker = a.tie_breaker;
+
+    // Put the agent in a state where running a connectivity check now would time out
+    // and transition to `Failed` (which deletes all candidates).
+    a.connection_state = ConnectionState::Checking;
+    a.last_connection_state = ConnectionState::Checking;
+    a.checking_duration = Instant::now()
+        .checked_sub(Duration::from_secs(3600))
+        .unwrap_or(a.start_time);
+
+    let remote_addr = SocketAddr::from_str("172.17.0.3:999")?;
+    let mut msg = Message::new();
+    msg.build(&[
+        Box::new(BINDING_REQUEST),
+        Box::new(TransactionId::new()),
+        Box::new(Username::new(ATTR_USERNAME, username)),
+        Box::new(UseCandidateAttr::new()),
+        Box::new(AttrControlling(tie_breaker)),
+        Box::new(PriorityAttr(local_priority)),
+        Box::new(MessageIntegrity::new_short_term_integrity(local_pwd)),
+        Box::new(FINGERPRINT),
+    ])?;
+
+    // Before the fix this call panicked while adding the peer-reflexive candidate.
+    a.handle_inbound(Instant::now(), &mut msg, local_index, remote_addr)?;
+
+    // The candidate was added and no re-entrant state change happened during the call.
+    assert_eq!(
+        a.remote_candidates.len(),
+        1,
+        "peer-reflexive remote candidate should have been added"
+    );
+    assert_eq!(
+        a.connection_state,
+        ConnectionState::Checking,
+        "connection state must not change while handling the inbound request"
+    );
+    assert!(
+        a.force_candidate_contact,
+        "a connectivity check should have been deferred to the timeout handler"
+    );
+
+    // The deferred check now runs via the timeout handler, fails, and cleans up fully.
+    a.handle_timeout(Instant::now())?;
+    assert_eq!(a.connection_state, ConnectionState::Failed);
+    assert!(a.candidate_pairs.is_empty());
+    assert!(a.local_candidates.is_empty());
+    assert!(a.remote_candidates.is_empty());
+    assert!(a.selected_pair.is_none());
+    assert!(a.nominated_pair.is_none());
+
+    a.close()?;
+    Ok(())
+}

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -140,6 +140,12 @@ pub struct Agent {
     pub(crate) check_interval: Duration,
     pub(crate) checking_duration: Instant,
     pub(crate) last_checking_time: Instant,
+    // When set, a connectivity check has been requested and must be run on the next
+    // `handle_timeout`. Checks are deferred (rather than run inline) so that adding a
+    // candidate can never re-enter `contact()` and mutate agent state - e.g. transition
+    // to `Failed` and drop candidates - while a caller still holds indices into the
+    // candidate vectors. See issue #88.
+    pub(crate) force_candidate_contact: bool,
 
     pub(crate) mdns: Option<Mdns>,
     pub(crate) mdns_queries: HashMap<QueryId, Candidate>,
@@ -185,6 +191,7 @@ impl Default for Agent {
             check_interval: Default::default(),
             checking_duration: Instant::now(),
             last_checking_time: Instant::now(),
+            force_candidate_contact: false,
             mdns_mode: MulticastDnsMode::Disabled,
             mdns_local_name: "".to_owned(),
             mdns_local_ip: None,
@@ -328,6 +335,7 @@ impl Agent {
             last_consent_sent: Instant::now(),
             checking_duration: Instant::now(),
             last_checking_time: Instant::now(),
+            force_candidate_contact: false,
             last_connection_state: ConnectionState::Unspecified,
 
             mdns,
@@ -670,6 +678,11 @@ impl Agent {
     }
 
     fn contact(&mut self, now: Instant) {
+        // Consume any pending deferred-check request now that we are running one.
+        // Reset before the early returns below so a failed/settled agent does not
+        // keep asking `poll_timeout` for an immediate wake-up.
+        self.force_candidate_contact = false;
+
         if self.connection_state == ConnectionState::Failed {
             // The connection is currently failed so don't send any checks
             // In the future it may be restarted though
@@ -874,9 +887,12 @@ impl Agent {
     }
 
     fn request_connectivity_check(&mut self) {
-        if self.ufrag_pwd.remote_credentials.is_some() {
-            self.contact(Instant::now());
-        }
+        // Defer the connectivity check to `handle_timeout` instead of running it
+        // inline. Running `contact()` here is re-entrant: it can advance the state
+        // to `Failed`, which calls `delete_all_candidates()` and wipes the candidate
+        // and pair vectors while a caller still holds indices into them (for example
+        // `handle_inbound` while adding a peer-reflexive candidate). See issue #88.
+        self.force_candidate_contact = true;
     }
 
     /// Remove all candidates.
@@ -888,6 +904,15 @@ impl Agent {
             self.local_candidates.clear();
         }
         self.remote_candidates.clear();
+
+        // Candidate pairs reference candidates by index, so once the candidates are
+        // removed every pair - and the `selected_pair`/`nominated_pair` indices into
+        // the pair list - is dangling and must be dropped to avoid out-of-bounds
+        // access. `remote_candidates` is always cleared here, so no pair can remain
+        // valid even when the local candidates are kept. See issue #88.
+        self.candidate_pairs.clear();
+        self.selected_pair = None;
+        self.nominated_pair = None;
     }
 
     pub(crate) fn find_remote_candidate(&self, addr: SocketAddr) -> Option<usize> {
@@ -1301,7 +1326,11 @@ impl Agent {
                         if let Ok(added) = self.add_remote_candidate(prflx_candidate)
                             && added
                         {
-                            remote_candidate_index = Some(self.remote_candidates.len() - 1);
+                            // Look the candidate up by address rather than assuming it
+                            // is the last element: `add_remote_candidate` may not have
+                            // appended it (e.g. a duplicate), and this stays correct if
+                            // the vector is ever mutated underneath us. See issue #88.
+                            remote_candidate_index = self.find_remote_candidate(remote_addr);
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
## Summary

Fixes #88. The ICE agent stores candidate pairs and the selected/nominated pair as **indices** into the `local_candidates` / `remote_candidates` vectors. Two code paths left those indices dangling after the candidates were removed, causing panics.

### Issue 1 — stale candidate pairs after `Failed`

`delete_all_candidates` (invoked when the connection transitions to `Failed`, and on `close` / `restart`) emptied the candidate vectors but left `candidate_pairs`, `selected_pair` and `nominated_pair` untouched. Any later access through a pair then indexed out of bounds, e.g. via `get_best_available_candidate_pair`:

```
panicked at 'index out of bounds: the len is 0 but the index is 0'
```

**Fix:** `delete_all_candidates` now also clears `candidate_pairs` and resets `selected_pair` / `nominated_pair`. `remote_candidates` is always cleared there, so every pair is invalidated even when local candidates are kept.

### Issue 2 — re-entrant connectivity check during `handle_inbound`

`add_remote_candidate` ran the connectivity check inline. While `handle_inbound` was adding a peer-reflexive candidate, that check could advance the state to `Failed`, which clears the candidate vectors mid-call. The caller then computed `remote_candidates.len() - 1` on an empty vector:

```
panicked at 'attempt to subtract with overflow', rtc-ice/src/agent/mod.rs
```

(This also left `handle_inbound` holding a now-stale `local_index`, so the crash was not limited to the `len() - 1` line.)

**Fix:** connectivity checks are deferred to `handle_timeout` via a `force_candidate_contact` flag. `poll_timeout` returns an immediate deadline while the flag is set, so the driver calls `handle_timeout` right away, but candidate mutation never re-enters `contact()` and can no longer change agent state underneath a caller. The peer-reflexive candidate index is also looked up by address (`find_remote_candidate`) instead of assuming it is the last element.

This follows the direction suggested in the issue (the `ice_state_fail` branch on `nabto/webrtc-rs-rtc`): defer the contact calls to the timeout handler and clean up candidate pairs properly. To answer the question in the issue — yes, deferring the checks is the more robust fix, because it removes the re-entrancy for *all* of `handle_inbound`'s indices, not just the `len() - 1` computation.

## Test plan

Two regression tests were added in `rtc-ice/src/agent/agent_test.rs`; both **panic without the fix** and pass with it:

- `test_transition_to_failed_clears_stale_candidate_pairs` — reproduces Issue 1 (asserts pairs/indices are cleared and that the pair accessors no longer index out of bounds).
- `test_handle_inbound_request_defers_failing_connectivity_check` — reproduces Issue 2 (the `attempt to subtract with overflow` panic), then drives `handle_timeout` to confirm the deferred check still runs and cleans up.

Verified locally:

- `cargo test -p rtc-ice` — all pass.
- rtc-to-rtc / interop integration tests exercising the full ICE handshake and the changed paths pass: `offer_answer_rtc2rtc`, `one_media_section_rtc_to_rtc_unicast`, `media_only_negotiation_no_sctp`, `ice_tcp_active_passive`, `trickle_ice_interop`, `ice_restart_by_webrtc_interop`.
- `cargo clippy -p rtc-ice` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
