### PR TITLE
Open the SCTP stream for negotiated data channels (#61)

### DIFF
--- a/rtc-datachannel/src/data_channel/data_channel_test.rs
+++ b/rtc-datachannel/src/data_channel/data_channel_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::message::message_type::MessageType;
 use sansio::Protocol;
 use shared::error::Result;
 
@@ -204,6 +205,74 @@ fn test_data_channel_channel_type_reliable_ordered() -> Result<()> {
     dc1.close()?;
 
     close_association_pair(a0, a1);
+
+    Ok(())
+}
+
+/// Regression test for <https://github.com/webrtc-rs/rtc/issues/61>.
+///
+/// An out-of-band *negotiated* channel used to emit no message from `dial`, so
+/// the underlying SCTP stream was never opened and any later write failed with
+/// "Stream not existed". `dial` must now emit a `DATA_CHANNEL_OPEN` (to open and
+/// configure the local stream) that is flagged so the transport keeps it local
+/// and does not perform the DCEP handshake with the peer.
+#[test]
+fn test_data_channel_negotiated_opens_stream_without_dcep_handshake() -> Result<()> {
+    let (a0, _a1) = create_new_association_pair()?;
+
+    let cfg = DataChannelConfig {
+        channel_type: ChannelType::Reliable,
+        label: "negotiated".to_string(),
+        negotiated: true,
+        ..Default::default()
+    };
+
+    let mut dc = DataChannel::dial(cfg, a0, 100)?;
+
+    // A single DATA_CHANNEL_OPEN must be queued so the stream gets opened.
+    let msg = dc.poll_write().ok_or(Error::ErrStreamNotExisted)?;
+    assert_eq!(
+        msg.ppi,
+        PayloadProtocolIdentifier::Dcep,
+        "negotiated dial should emit a DATA_CHANNEL_OPEN to open the stream"
+    );
+    assert!(
+        msg.negotiated,
+        "a negotiated channel's DATA_CHANNEL_OPEN must be flagged internal-only"
+    );
+    assert_eq!(
+        Message::unmarshal(&mut &msg.payload[..])?.message_type(),
+        MessageType::DataChannelOpen,
+        "the queued message should be a DATA_CHANNEL_OPEN"
+    );
+    assert!(
+        dc.poll_write().is_none(),
+        "no further DCEP messages expected for a negotiated channel"
+    );
+
+    Ok(())
+}
+
+/// A non-negotiated (in-band) channel emits a `DATA_CHANNEL_OPEN` that IS sent
+/// over the wire, so it must not be flagged as negotiated.
+#[test]
+fn test_data_channel_in_band_open_is_transmitted() -> Result<()> {
+    let (a0, _a1) = create_new_association_pair()?;
+
+    let cfg = DataChannelConfig {
+        channel_type: ChannelType::Reliable,
+        label: "in-band".to_string(),
+        negotiated: false,
+        ..Default::default()
+    };
+
+    let mut dc = DataChannel::dial(cfg, a0, 100)?;
+    let msg = dc.poll_write().ok_or(Error::ErrStreamNotExisted)?;
+    assert_eq!(msg.ppi, PayloadProtocolIdentifier::Dcep);
+    assert!(
+        !msg.negotiated,
+        "an in-band DATA_CHANNEL_OPEN must be transmitted to the peer"
+    );
 
     Ok(())
 }

--- a/rtc-datachannel/src/data_channel/mod.rs
+++ b/rtc-datachannel/src/data_channel/mod.rs
@@ -32,6 +32,13 @@ pub struct DataChannelMessage {
     pub stream_id: u16,
     pub ppi: PayloadProtocolIdentifier,
     pub payload: BytesMut,
+
+    /// Marks a `DATA_CHANNEL_OPEN` that belongs to an out-of-band *negotiated*
+    /// channel (W3C WebRTC `RTCDataChannelInit.negotiated`). Such a message is
+    /// only used to open and configure the local SCTP stream and must not be
+    /// transmitted to the peer, which already created its own channel with the
+    /// pre-agreed stream id. Ignored for every other message.
+    pub negotiated: bool,
 }
 
 /// DataChannel represents a data channel
@@ -71,23 +78,29 @@ impl DataChannel {
     ) -> Result<Self> {
         let mut data_channel = DataChannel::new(config.clone(), association_handle, stream_id);
 
-        if !config.negotiated {
-            let msg = Message::DataChannelOpen(DataChannelOpen {
-                channel_type: config.channel_type,
-                priority: config.priority,
-                reliability_parameter: config.reliability_parameter,
-                label: config.label.bytes().collect(),
-                protocol: config.protocol.bytes().collect(),
-            })
-            .marshal()?;
+        // Both in-band and out-of-band (negotiated) channels emit a
+        // DATA_CHANNEL_OPEN so the underlying SCTP stream gets opened and its
+        // reliability parameters configured (the Channel Type / Reliability
+        // Parameter mapping in RFC 8832 section 5.1). For a negotiated channel
+        // the message is flagged so the transport opens the stream locally
+        // without sending the DCEP handshake to the peer; that suppression is
+        // required by the W3C WebRTC `negotiated` semantics, not by DCEP.
+        let msg = Message::DataChannelOpen(DataChannelOpen {
+            channel_type: config.channel_type,
+            priority: config.priority,
+            reliability_parameter: config.reliability_parameter,
+            label: config.label.bytes().collect(),
+            protocol: config.protocol.bytes().collect(),
+        })
+        .marshal()?;
 
-            data_channel.write_outs.push_back(DataChannelMessage {
-                association_handle,
-                stream_id,
-                ppi: PayloadProtocolIdentifier::Dcep,
-                payload: msg,
-            });
-        }
+        data_channel.write_outs.push_back(DataChannelMessage {
+            association_handle,
+            stream_id,
+            ppi: PayloadProtocolIdentifier::Dcep,
+            payload: msg,
+            negotiated: config.negotiated,
+        });
 
         Ok(data_channel)
     }
@@ -189,6 +202,7 @@ impl DataChannel {
             stream_id: self.stream_id,
             ppi: PayloadProtocolIdentifier::Dcep,
             payload: ack,
+            negotiated: false,
         });
         Ok(())
     }
@@ -200,6 +214,7 @@ impl DataChannel {
             stream_id: self.stream_id,
             ppi: PayloadProtocolIdentifier::Dcep,
             payload: close,
+            negotiated: false,
         });
         Ok(())
     }
@@ -212,6 +227,7 @@ impl DataChannel {
             stream_id: self.stream_id,
             ppi: PayloadProtocolIdentifier::Dcep,
             payload: low_threshold,
+            negotiated: false,
         });
         Ok(())
     }
@@ -224,6 +240,7 @@ impl DataChannel {
             stream_id: self.stream_id,
             ppi: PayloadProtocolIdentifier::Dcep,
             payload: low_threshold,
+            negotiated: false,
         });
         Ok(())
     }

--- a/rtc/src/peer_connection/handler/sctp.rs
+++ b/rtc/src/peer_connection/handler/sctp.rs
@@ -159,6 +159,7 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                                         payload: BytesMut::from(
                                             &self.ctx.sctp_transport.internal_buffer[0..n],
                                         ),
+                                        negotiated: false,
                                     }));
                                 }
                             }
@@ -287,6 +288,15 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                                 reliability_type,
                                 data_channel_open.reliability_parameter,
                             )?;
+
+                            // Out-of-band negotiated channels (W3C WebRTC
+                            // `RTCDataChannelInit.negotiated`) only open the SCTP
+                            // stream locally; the DCEP handshake must not be sent
+                            // to the peer, which already created its own channel
+                            // with the pre-agreed stream id.
+                            if message.negotiated {
+                                is_dcep_internal_control_message = true;
+                            }
                         }
                         Message::DataChannelClose(_) => {
                             is_dcep_internal_control_message = true;

--- a/rtc/tests/data_channels_negotiated_rtc2rtc.rs
+++ b/rtc/tests/data_channels_negotiated_rtc2rtc.rs
@@ -1,0 +1,340 @@
+//! Regression test for <https://github.com/webrtc-rs/rtc/issues/61>.
+//!
+//! An out-of-band *negotiated* data channel could be opened but never exchange
+//! data: `DataChannel::dial` emitted no `DATA_CHANNEL_OPEN`, so the underlying
+//! SCTP stream was never created and every write failed with "Stream not
+//! existed". This test drives two rtc peers that each create a negotiated
+//! channel with the same pre-agreed stream id and verifies that application
+//! messages flow in *both* directions.
+
+use anyhow::Result;
+use bytes::BytesMut;
+use rtc::data_channel::RTCDataChannelInit;
+use rtc::peer_connection::configuration::RTCConfigurationBuilder;
+use rtc::peer_connection::configuration::setting_engine::SettingEngine;
+use rtc::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent};
+use rtc::peer_connection::message::RTCMessage;
+use rtc::peer_connection::state::RTCPeerConnectionState;
+use rtc::peer_connection::transport::{
+    CandidateConfig, CandidateHostConfig, RTCDtlsRole, RTCIceCandidate, RTCIceServer,
+};
+use rtc::peer_connection::{RTCPeerConnection, RTCPeerConnectionBuilder};
+use rtc::sansio::Protocol;
+use rtc::shared::{TaggedBytesMut, TransportContext, TransportProtocol};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
+
+const DEFAULT_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+
+/// The stream id both peers agree on out-of-band for the negotiated channel.
+const NEGOTIATED_ID: u16 = 1;
+/// Messages sent offerer -> answerer.
+const OFFER_TO_ANSWER: usize = 3;
+/// Messages sent answerer -> offerer.
+const ANSWER_TO_OFFER: usize = 2;
+
+/// Helper struct to run two peers in an event loop.
+struct PeerRunner {
+    offer_pc: RTCPeerConnection,
+    answer_pc: RTCPeerConnection,
+    offer_socket: Arc<UdpSocket>,
+    answer_socket: Arc<UdpSocket>,
+    offer_local_addr: std::net::SocketAddr,
+    answer_local_addr: std::net::SocketAddr,
+}
+
+impl PeerRunner {
+    async fn new() -> Result<Self> {
+        // Create offer peer
+        let offer_socket = UdpSocket::bind("127.0.0.1:0").await?;
+        let offer_local_addr = offer_socket.local_addr()?;
+
+        let mut offer_setting_engine = SettingEngine::default();
+        offer_setting_engine.set_answering_dtls_role(RTCDtlsRole::Server)?;
+
+        let offer_config = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+                ..Default::default()
+            }])
+            .build();
+
+        let mut offer_pc = RTCPeerConnectionBuilder::new()
+            .with_configuration(offer_config)
+            .with_setting_engine(offer_setting_engine)
+            .build()?;
+
+        let offer_candidate = CandidateHostConfig {
+            base_config: CandidateConfig {
+                network: "udp".to_owned(),
+                address: offer_local_addr.ip().to_string(),
+                port: offer_local_addr.port(),
+                component: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .new_candidate_host()?;
+        offer_pc.add_local_candidate(RTCIceCandidate::from(&offer_candidate).to_json()?)?;
+
+        // Create answer peer
+        let answer_socket = UdpSocket::bind("127.0.0.1:0").await?;
+        let answer_local_addr = answer_socket.local_addr()?;
+
+        let mut answer_setting_engine = SettingEngine::default();
+        answer_setting_engine.set_answering_dtls_role(RTCDtlsRole::Client)?;
+
+        let answer_config = RTCConfigurationBuilder::new()
+            .with_ice_servers(vec![RTCIceServer {
+                urls: vec!["stun:stun.l.google.com:19302".to_owned()],
+                ..Default::default()
+            }])
+            .build();
+
+        let mut answer_pc = RTCPeerConnectionBuilder::new()
+            .with_configuration(answer_config)
+            .with_setting_engine(answer_setting_engine)
+            .build()?;
+
+        let answer_candidate = CandidateHostConfig {
+            base_config: CandidateConfig {
+                network: "udp".to_owned(),
+                address: answer_local_addr.ip().to_string(),
+                port: answer_local_addr.port(),
+                component: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .new_candidate_host()?;
+        answer_pc.add_local_candidate(RTCIceCandidate::from(&answer_candidate).to_json()?)?;
+
+        Ok(Self {
+            offer_pc,
+            answer_pc,
+            offer_socket: Arc::new(offer_socket),
+            answer_socket: Arc::new(answer_socket),
+            offer_local_addr,
+            answer_local_addr,
+        })
+    }
+}
+
+/// Both peers create a negotiated channel sharing `NEGOTIATED_ID` and exchange
+/// messages in both directions. Before the fix, the negotiated channel's SCTP
+/// stream was never opened, so no message could be sent.
+#[tokio::test]
+async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let mut runner = PeerRunner::new().await?;
+
+    // Both sides create the SAME out-of-band negotiated channel.
+    let init = RTCDataChannelInit {
+        ordered: true,
+        negotiated: Some(NEGOTIATED_ID),
+        ..Default::default()
+    };
+    runner
+        .offer_pc
+        .create_data_channel("negotiated", Some(init.clone()))?;
+    runner
+        .answer_pc
+        .create_data_channel("negotiated", Some(init))?;
+
+    // Exchange offer/answer
+    let offer = runner.offer_pc.create_offer(None)?;
+    runner.offer_pc.set_local_description(offer.clone())?;
+    runner.answer_pc.set_remote_description(offer)?;
+
+    let answer = runner.answer_pc.create_answer(None)?;
+    runner.answer_pc.set_local_description(answer.clone())?;
+    runner.offer_pc.set_remote_description(answer)?;
+
+    let mut offer_connected = false;
+    let mut answer_connected = false;
+    let mut offer_dc_open = false;
+    let mut answer_dc_open = false;
+    let mut offer_sent = 0;
+    let mut answer_sent = 0;
+    let mut offer_received: Vec<String> = Vec::new();
+    let mut answer_received: Vec<String> = Vec::new();
+
+    let mut offer_buf = vec![0u8; 2000];
+    let mut answer_buf = vec![0u8; 2000];
+
+    let start_time = Instant::now();
+    let test_timeout = Duration::from_secs(30);
+
+    while start_time.elapsed() < test_timeout {
+        // Process offer peer writes
+        while let Some(msg) = runner.offer_pc.poll_write() {
+            runner
+                .offer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+
+        // Process offer peer events
+        while let Some(event) = runner.offer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => offer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
+                    assert_eq!(id, NEGOTIATED_ID, "offer opened unexpected channel id");
+                    offer_dc_open = true;
+                }
+                _ => {}
+            }
+        }
+
+        // Read messages arriving at the offer peer (answer -> offer). This
+        // connection carries no media, so every read is a data-channel message.
+        while let Some(RTCMessage::DataChannelMessage(id, msg)) = runner.offer_pc.poll_read() {
+            assert_eq!(id, NEGOTIATED_ID);
+            offer_received.push(String::from_utf8_lossy(&msg.data).into_owned());
+        }
+
+        // Process answer peer writes
+        while let Some(msg) = runner.answer_pc.poll_write() {
+            runner
+                .answer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+
+        // Process answer peer events
+        while let Some(event) = runner.answer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => answer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
+                    assert_eq!(id, NEGOTIATED_ID, "answer opened unexpected channel id");
+                    answer_dc_open = true;
+                }
+                _ => {}
+            }
+        }
+
+        // Read messages arriving at the answer peer (offer -> answer). This
+        // connection carries no media, so every read is a data-channel message.
+        while let Some(RTCMessage::DataChannelMessage(id, msg)) = runner.answer_pc.poll_read() {
+            assert_eq!(id, NEGOTIATED_ID);
+            answer_received.push(String::from_utf8_lossy(&msg.data).into_owned());
+        }
+
+        // Once both ends are up, send in both directions. The channel is
+        // guaranteed to be in the map once its OnOpen event has fired.
+        if offer_connected && offer_dc_open && offer_sent < OFFER_TO_ANSWER {
+            let mut dc = runner
+                .offer_pc
+                .data_channel(NEGOTIATED_ID)
+                .expect("negotiated channel must exist once open");
+            dc.send_text(format!("o2a-{offer_sent}"))?;
+            offer_sent += 1;
+        }
+        if answer_connected && answer_dc_open && answer_sent < ANSWER_TO_OFFER {
+            let mut dc = runner
+                .answer_pc
+                .data_channel(NEGOTIATED_ID)
+                .expect("negotiated channel must exist once open");
+            dc.send_text(format!("a2o-{answer_sent}"))?;
+            answer_sent += 1;
+        }
+
+        // Done once every message crossed the wire.
+        if answer_received.len() >= OFFER_TO_ANSWER && offer_received.len() >= ANSWER_TO_OFFER {
+            break;
+        }
+
+        // Handle timeouts / socket reads
+        let offer_timeout = runner
+            .offer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + DEFAULT_TIMEOUT_DURATION);
+        let answer_timeout = runner
+            .answer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + DEFAULT_TIMEOUT_DURATION);
+        let next_timeout = offer_timeout.min(answer_timeout);
+        let delay = next_timeout
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+
+        if delay.is_zero() {
+            runner.offer_pc.handle_timeout(Instant::now()).ok();
+            runner.answer_pc.handle_timeout(Instant::now()).ok();
+            continue;
+        }
+
+        let sleep = tokio::time::sleep(delay);
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            _ = sleep => {
+                runner.offer_pc.handle_timeout(Instant::now()).ok();
+                runner.answer_pc.handle_timeout(Instant::now()).ok();
+            }
+            Ok((n, peer_addr)) = runner.offer_socket.recv_from(&mut offer_buf) => {
+                runner.offer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: runner.offer_local_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&offer_buf[..n]),
+                }).ok();
+            }
+            Ok((n, peer_addr)) = runner.answer_socket.recv_from(&mut answer_buf) => {
+                runner.answer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: runner.answer_local_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&answer_buf[..n]),
+                }).ok();
+            }
+        }
+    }
+
+    assert!(offer_connected && answer_connected, "peers should connect");
+    assert!(
+        offer_dc_open && answer_dc_open,
+        "both negotiated channels should open (offer={offer_dc_open}, answer={answer_dc_open})"
+    );
+
+    // The core of the regression: messages must actually be delivered both ways.
+    answer_received.sort();
+    offer_received.sort();
+    assert_eq!(
+        answer_received,
+        (0..OFFER_TO_ANSWER)
+            .map(|i| format!("o2a-{i}"))
+            .collect::<Vec<_>>(),
+        "answer should receive all offer->answer messages"
+    );
+    assert_eq!(
+        offer_received,
+        (0..ANSWER_TO_OFFER)
+            .map(|i| format!("a2o-{i}"))
+            .collect::<Vec<_>>(),
+        "offer should receive all answer->offer messages"
+    );
+
+    runner.offer_pc.close()?;
+    runner.answer_pc.close()?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #61: a message could not be sent on an out-of-band **negotiated** data channel. The connection and channel would open, but every send failed with:

```
sctp data channel set threshold Low(0) for stream id 5
SctpHandler.handle_write got error: Stream not existed
```

**Root cause.** The SCTP stream is only created when a DCEP `DATA_CHANNEL_OPEN` message flows through `SctpHandler::handle_write` (via `conn.open_stream`). `DataChannel::dial` is the sole emitter of that message, and it was guarded by `if !config.negotiated`. So negotiated channels emitted nothing → the stream was never opened → the first write (a buffered-amount threshold, then any data) hit `conn.stream(id)` and returned `ErrStreamNotExisted`.

Simply negating the guard (as floated in the issue) would open the stream but is wrong: the DCEP handshake must **not** be sent for negotiated channels.

**Fix (mirrors pion).** In pion, `Dial` always `OpenStream`s the id; only the DCEP handshake is gated on `!Negotiated`. This PR does the same:

- `DataChannel::dial` now always emits `DATA_CHANNEL_OPEN`, so the stream is opened and its reliability parameters configured (the Channel Type / Reliability Parameter mapping of [RFC 8832 §5.1](https://www.rfc-editor.org/rfc/rfc8832.html#section-5.1)). The message carries a new `DataChannelMessage.negotiated` flag.
- `SctpHandler::handle_write` opens/configures the stream locally for such a message but sets `is_dcep_internal_control_message = true`, so the DCEP handshake is **not** transmitted to the peer, which already created its own channel with the pre-agreed stream id.

The in-band (non-negotiated) path is unchanged on the wire.

**On the specs.** RFC 8832 (DCEP) only describes *in-band* setup — its §5.1 defines the `DATA_CHANNEL_OPEN` message format (including the reliability mapping this fix applies to the stream) and §6 the `DATA_CHANNEL_OPEN`/`DATA_CHANNEL_ACK` handshake. The rule that a *negotiated* channel does **not** perform that handshake comes from the [W3C WebRTC `RTCDataChannelInit.negotiated`](https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-negotiated) semantics (the application negotiates out-of-band and creates a matching channel with the same `id` at the other peer), not from DCEP itself.

## Test plan

Two regression tests, both verified to **fail against the current code** and **pass with the fix**:

- **Unit** (`rtc-datachannel/.../data_channel_test.rs`): a negotiated `dial` emits exactly one internal-flagged `DATA_CHANNEL_OPEN`; an in-band `dial` emits a non-flagged one.
- **End-to-end** (`rtc/tests/data_channels_negotiated_rtc2rtc.rs`): two rtc peers each create a negotiated channel with the same id and exchange messages in **both directions**. Against the current code it fails with `answer received: []` (the reported bug).

Also verified no regressions: `rtc-datachannel` (27), `rtc` lib (164), `statistics_rtc_to_rtc` (9), and the non-negotiated `data_channels_interop` / `data_channels_create_interop` / `data_channels_close_by_{rtc,webrtc}_interop` tests all pass. `cargo fmt` and `clippy` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)