### PR TITLE
Update the negotiation-needed flag when a transceiver's direction changes (#51)

### DIFF
--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -851,6 +851,17 @@ where
         Err(Error::ErrMaxDataChannelID)
     }
 
+    /// Called by the public `RTCRtpTransceiver::set_direction` when a transceiver's preferred
+    /// direction actually changes, to update the connection's negotiation-needed flag.
+    ///
+    /// This is a narrow, purpose-specific entry point so the general-purpose
+    /// [`Self::trigger_negotiation_needed`] can stay `pub(super)`.
+    ///
+    /// See <https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction>.
+    pub(crate) fn on_transceiver_direction_changed(&mut self) {
+        self.trigger_negotiation_needed();
+    }
+
     /// Helper to trigger a negotiation needed.
     pub(super) fn trigger_negotiation_needed(&mut self) {
         if !self.do_negotiation_needed() {

--- a/rtc/src/rtp_transceiver/internal.rs
+++ b/rtc/src/rtp_transceiver/internal.rs
@@ -149,16 +149,12 @@ where
     ///
     /// See [RTCRtpTransceiver.direction](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction).
     pub(crate) fn set_direction(&mut self, direction: RTCRtpTransceiverDirection) {
-        let previous_direction: RTCRtpTransceiverDirection = self.direction;
-
+        // The negotiation-needed flag is intentionally not updated here: this internal setter is
+        // also invoked while applying a remote/local session description, where triggering
+        // renegotiation would be incorrect. The public `RTCRtpTransceiver::set_direction` (which
+        // maps to the spec's `direction` setter) performs that step.
+        // See https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction
         self.direction = direction;
-
-        if direction != previous_direction {
-            trace!("Changing direction of transceiver from {previous_direction} to {direction}");
-
-            //TODO: https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction
-            // Update the negotiation-needed flag for connection.
-        }
     }
 
     /// Returns the negotiated direction of the transceiver.

--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -96,15 +96,13 @@
 //!
 //! See [RTCRtpTransceiver](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver) in the W3C WebRTC specification.
 
-//TODO: #[cfg(test)]
-//mod rtp_transceiver_test;
-
 use crate::media_stream::MediaStreamId;
 use crate::peer_connection::RTCPeerConnection;
 use crate::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
 use crate::rtp_transceiver::rtp_sender::rtp_encoding_parameters::RTCRtpEncodingParameters;
 pub use direction::RTCRtpTransceiverDirection;
 use interceptor::{Interceptor, NoopInterceptor};
+use log::trace;
 use shared::error::Result;
 
 pub(crate) mod direction;
@@ -292,7 +290,22 @@ where
     pub fn set_direction(&mut self, direction: RTCRtpTransceiverDirection) {
         // peer_connection is mutable borrow, its rtp_transceivers won't be resized,
         // so, [self.id] here is safe.
+        let previous_direction = self.peer_connection.rtp_transceivers[self.id].direction();
         self.peer_connection.rtp_transceivers[self.id].set_direction(direction);
+        // Compare the effective direction after the setter (rather than the requested value) so
+        // any future normalization inside `set_direction` cannot bypass this check.
+        let current_direction = self.peer_connection.rtp_transceivers[self.id].direction();
+
+        // https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction
+        // The direction setter is a no-op when the new direction equals the current one;
+        // otherwise its final step updates the negotiation-needed flag for the connection,
+        // which may fire a `negotiationneeded` event.
+        if current_direction != previous_direction {
+            trace!(
+                "Changing direction of transceiver from {previous_direction} to {current_direction}"
+            );
+            self.peer_connection.on_transceiver_direction_changed();
+        }
     }
 
     /// Returns the negotiated direction of the transceiver.
@@ -344,5 +357,121 @@ where
         // so, [self.id] here is safe.
         self.peer_connection.rtp_transceivers[self.id]
             .set_codec_preferences(codecs, &self.peer_connection.media_engine)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sansio::Protocol;
+
+    use crate::peer_connection::configuration::media_engine::MediaEngine;
+    use crate::peer_connection::event::RTCPeerConnectionEvent;
+    use crate::peer_connection::{RTCPeerConnection, RTCPeerConnectionBuilder};
+    use crate::rtp_transceiver::RTCRtpTransceiverDirection;
+    use crate::rtp_transceiver::rtp_sender::RtpCodecKind;
+
+    fn build_pc() -> RTCPeerConnection {
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("register default codecs");
+        RTCPeerConnectionBuilder::new()
+            .with_media_engine(media_engine)
+            .build()
+            .expect("build peer connection")
+    }
+
+    /// Drain every queued event and count the `OnNegotiationNeededEvent`s, driving only the
+    /// public sans-I/O `Protocol` API (no private negotiation state is touched).
+    fn count_negotiation_needed(pc: &mut RTCPeerConnection) -> usize {
+        let mut count = 0;
+        while let Some(event) = pc.poll_event() {
+            if matches!(event, RTCPeerConnectionEvent::OnNegotiationNeededEvent) {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Complete a full offer/answer exchange so `offerer` settles back into a stable, idle
+    /// negotiation state.
+    fn negotiate(offerer: &mut RTCPeerConnection, answerer: &mut RTCPeerConnection) {
+        let offer = offerer.create_offer(None).expect("create offer");
+        offerer
+            .set_local_description(offer.clone())
+            .expect("offerer set local");
+        answerer
+            .set_remote_description(offer)
+            .expect("answerer set remote");
+        let answer = answerer.create_answer(None).expect("create answer");
+        answerer
+            .set_local_description(answer.clone())
+            .expect("answerer set local");
+        offerer
+            .set_remote_description(answer)
+            .expect("offerer set remote");
+    }
+
+    #[test]
+    fn test_set_direction_triggers_negotiation_on_change() {
+        let mut offerer = build_pc();
+        let mut answerer = build_pc();
+
+        let tid = offerer
+            .add_transceiver_from_kind(RtpCodecKind::Video, None)
+            .expect("add offerer transceiver");
+        answerer
+            .add_transceiver_from_kind(RtpCodecKind::Video, None)
+            .expect("add answerer transceiver");
+
+        negotiate(&mut offerer, &mut answerer);
+        // Discard events produced by the initial negotiation.
+        let _ = count_negotiation_needed(&mut offerer);
+
+        let current = offerer.rtp_transceivers[tid].direction();
+        let new_direction = if current == RTCRtpTransceiverDirection::Inactive {
+            RTCRtpTransceiverDirection::Sendrecv
+        } else {
+            RTCRtpTransceiverDirection::Inactive
+        };
+        offerer
+            .rtp_transceiver(tid)
+            .expect("transceiver exists")
+            .set_direction(new_direction);
+
+        assert_eq!(
+            count_negotiation_needed(&mut offerer),
+            1,
+            "changing the transceiver direction must trigger negotiation-needed",
+        );
+    }
+
+    #[test]
+    fn test_set_direction_noop_when_unchanged() {
+        let mut offerer = build_pc();
+        let mut answerer = build_pc();
+
+        let tid = offerer
+            .add_transceiver_from_kind(RtpCodecKind::Video, None)
+            .expect("add offerer transceiver");
+        answerer
+            .add_transceiver_from_kind(RtpCodecKind::Video, None)
+            .expect("add answerer transceiver");
+
+        negotiate(&mut offerer, &mut answerer);
+        let _ = count_negotiation_needed(&mut offerer);
+
+        // Setting the current direction again must be a no-op.
+        let current = offerer.rtp_transceivers[tid].direction();
+        offerer
+            .rtp_transceiver(tid)
+            .expect("transceiver exists")
+            .set_direction(current);
+
+        assert_eq!(
+            count_negotiation_needed(&mut offerer),
+            0,
+            "setting the same direction must not trigger negotiation-needed",
+        );
     }
 }

--- a/rtc/tests/set_direction_negotiation_needed.rs
+++ b/rtc/tests/set_direction_negotiation_needed.rs
@@ -1,0 +1,112 @@
+//! Regression test for webrtc-rs/rtc#51.
+//!
+//! Calling `RTCRtpTransceiver::set_direction` must update the negotiation-needed
+//! flag for the connection, which (when negotiation is otherwise idle) fires an
+//! `OnNegotiationNeededEvent`. Per the WebRTC specification the direction setter
+//! only takes effect when the new direction differs from the current one:
+//!
+//! > 3. If newDirection is equal to transceiver.[[Direction]], abort these steps.
+//! > ...
+//! > 6. Update the negotiation-needed flag for connection.
+//!
+//! See <https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction>.
+
+use rtc::peer_connection::RTCPeerConnectionBuilder;
+use rtc::peer_connection::configuration::media_engine::MediaEngine;
+use rtc::peer_connection::event::RTCPeerConnectionEvent;
+use rtc::rtp_transceiver::RTCRtpTransceiverDirection;
+use rtc::rtp_transceiver::rtp_sender::RtpCodecKind;
+use sansio::Protocol;
+
+/// Drain every currently queued peer-connection event and return how many of
+/// them were `OnNegotiationNeededEvent`.
+fn count_negotiation_needed<I: rtc::interceptor::Interceptor>(
+    pc: &mut rtc::peer_connection::RTCPeerConnection<I>,
+) -> usize {
+    let mut count = 0;
+    while let Some(event) = pc.poll_event() {
+        if matches!(event, RTCPeerConnectionEvent::OnNegotiationNeededEvent) {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[test]
+fn test_set_direction_updates_negotiation_needed_flag() -> Result<(), Box<dyn std::error::Error>> {
+    let mut me = MediaEngine::default();
+    me.register_default_codecs()?;
+    let me2 = me.clone();
+
+    let mut offerer = RTCPeerConnectionBuilder::new()
+        .with_media_engine(me)
+        .build()?;
+    let mut answerer = RTCPeerConnectionBuilder::new()
+        .with_media_engine(me2)
+        .build()?;
+
+    // Add one video transceiver on each side (defaults to "recvonly").
+    let transceiver_id = offerer.add_transceiver_from_kind(RtpCodecKind::Video, None)?;
+    answerer.add_transceiver_from_kind(RtpCodecKind::Video, None)?;
+
+    // Complete a full offer/answer exchange so the offerer settles back into a
+    // stable, idle negotiation state.
+    let offer = offerer.create_offer(None)?;
+    offerer.set_local_description(offer.clone())?;
+    answerer.set_remote_description(offer)?;
+
+    let answer = answerer.create_answer(None)?;
+    answerer.set_local_description(answer.clone())?;
+    offerer.set_remote_description(answer)?;
+
+    // Drain everything produced by the initial negotiation so the counter starts clean.
+    let _ = count_negotiation_needed(&mut offerer);
+
+    // Sanity: with negotiation idle, poll produces no further negotiation-needed events.
+    assert_eq!(
+        count_negotiation_needed(&mut offerer),
+        0,
+        "connection should be idle after a clean negotiation",
+    );
+
+    // Pick a direction that actually differs from the current one.
+    let current_direction = offerer
+        .rtp_transceiver(transceiver_id)
+        .expect("transceiver should exist")
+        .direction();
+    let new_direction = if current_direction == RTCRtpTransceiverDirection::Inactive {
+        RTCRtpTransceiverDirection::Sendrecv
+    } else {
+        RTCRtpTransceiverDirection::Inactive
+    };
+
+    // Changing the direction must update the negotiation-needed flag (spec step 6),
+    // firing exactly one negotiation-needed event.
+    offerer
+        .rtp_transceiver(transceiver_id)
+        .expect("transceiver should exist")
+        .set_direction(new_direction);
+
+    assert_eq!(
+        count_negotiation_needed(&mut offerer),
+        1,
+        "changing the transceiver direction must trigger negotiation-needed",
+    );
+
+    // Setting the same direction again is a no-op (spec step 3) and must not
+    // trigger negotiation.
+    offerer
+        .rtp_transceiver(transceiver_id)
+        .expect("transceiver should exist")
+        .set_direction(new_direction);
+
+    assert_eq!(
+        count_negotiation_needed(&mut offerer),
+        0,
+        "setting the same direction must not trigger negotiation-needed",
+    );
+
+    offerer.close()?;
+    answerer.close()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements #51. `RTCRtpTransceiver::set_direction` had a `//TODO` to update the connection's negotiation-needed flag. Per the [W3C WebRTC `direction` setter](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiver-direction), changing the direction to a new value must update the negotiation-needed flag (which may fire a `negotiationneeded` event); setting the same direction is a no-op.

## What changed

- **`rtp_transceiver/mod.rs`** — the public `set_direction` (the spec's `direction` setter) now snapshots the transceiver's direction, applies the inner setter, re-reads the **effective** direction, and — only on a real change — updates the negotiation-needed flag. Comparing the effective direction (rather than the requested value) keeps the check correct if the inner setter ever normalizes/rejects a value.
- **`peer_connection/internal.rs`** — added a narrow, purpose-specific `on_transceiver_direction_changed()` so `trigger_negotiation_needed` can stay `pub(super)` instead of being widened to the whole crate.
- **`rtp_transceiver/internal.rs`** — the internal setter is reduced to a plain assignment and documents why it must **not** trigger renegotiation: it is also invoked while applying a remote/local session description, where triggering renegotiation would be incorrect.

## Why the trigger lives in the public setter

The internal `RTCRtpTransceiverInternal::set_direction` is called both by the public API **and** while applying SDP (e.g. in `set_remote_description`). Triggering renegotiation from there would be wrong, so the flag update lives only in the public `RTCRtpTransceiver::set_direction`, which maps to the spec's `direction` setter.

## Test plan

- [x] `cargo build -p rtc`
- [x] `cargo test -p rtc` (166 lib tests + integration tests pass)
- [x] `cargo fmt -p rtc -- --check` clean
- [x] `cargo clippy -p rtc` clean on the changed files
- [x] Unit tests (`rtp_transceiver/mod.rs`): `test_set_direction_triggers_negotiation_on_change`, `test_set_direction_noop_when_unchanged`
- [x] Integration test (`tests/set_direction_negotiation_needed.rs`): full offer/answer, then a direction change fires exactly one `OnNegotiationNeededEvent` and a same-direction call fires none

Both test layers drive only the public sans-I/O API (a full offer/answer, then draining `poll_event`), so they exercise the real negotiation-needed state machine rather than mutating private state. Both were verified to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)