### PR TITLE
test: make set_direction negotiation tests branch-free

### DIFF
--- a/rtc/src/rtp_transceiver/mod.rs
+++ b/rtc/src/rtp_transceiver/mod.rs
@@ -428,16 +428,15 @@ mod tests {
         // Discard events produced by the initial negotiation.
         let _ = count_negotiation_needed(&mut offerer);
 
-        let current = offerer.rtp_transceivers[tid].direction();
-        let new_direction = if current == RTCRtpTransceiverDirection::Inactive {
-            RTCRtpTransceiverDirection::Sendrecv
-        } else {
-            RTCRtpTransceiverDirection::Inactive
-        };
+        // A transceiver added with `add_transceiver_from_kind(.., None)` negotiates as recvonly.
+        assert_eq!(
+            offerer.rtp_transceivers[tid].direction(),
+            RTCRtpTransceiverDirection::Recvonly,
+        );
         offerer
             .rtp_transceiver(tid)
             .expect("transceiver exists")
-            .set_direction(new_direction);
+            .set_direction(RTCRtpTransceiverDirection::Inactive);
 
         assert_eq!(
             count_negotiation_needed(&mut offerer),

--- a/rtc/tests/set_direction_negotiation_needed.rs
+++ b/rtc/tests/set_direction_negotiation_needed.rs
@@ -69,23 +69,21 @@ fn test_set_direction_updates_negotiation_needed_flag() -> Result<(), Box<dyn st
         "connection should be idle after a clean negotiation",
     );
 
-    // Pick a direction that actually differs from the current one.
-    let current_direction = offerer
-        .rtp_transceiver(transceiver_id)
-        .expect("transceiver should exist")
-        .direction();
-    let new_direction = if current_direction == RTCRtpTransceiverDirection::Inactive {
-        RTCRtpTransceiverDirection::Sendrecv
-    } else {
-        RTCRtpTransceiverDirection::Inactive
-    };
+    // A transceiver added with `add_transceiver_from_kind(.., None)` negotiates as recvonly.
+    assert_eq!(
+        offerer
+            .rtp_transceiver(transceiver_id)
+            .expect("transceiver should exist")
+            .direction(),
+        RTCRtpTransceiverDirection::Recvonly,
+    );
 
-    // Changing the direction must update the negotiation-needed flag (spec step 6),
-    // firing exactly one negotiation-needed event.
+    // Changing the direction (recvonly -> inactive) must update the negotiation-needed flag
+    // (spec step 6), firing exactly one negotiation-needed event.
     offerer
         .rtp_transceiver(transceiver_id)
         .expect("transceiver should exist")
-        .set_direction(new_direction);
+        .set_direction(RTCRtpTransceiverDirection::Inactive);
 
     assert_eq!(
         count_negotiation_needed(&mut offerer),
@@ -98,7 +96,7 @@ fn test_set_direction_updates_negotiation_needed_flag() -> Result<(), Box<dyn st
     offerer
         .rtp_transceiver(transceiver_id)
         .expect("transceiver should exist")
-        .set_direction(new_direction);
+        .set_direction(RTCRtpTransceiverDirection::Inactive);
 
     assert_eq!(
         count_negotiation_needed(&mut offerer),


### PR DESCRIPTION
## Summary

Follow-up to #102. That PR's tests chose the target direction with:

```rust
let new_direction = if current == Inactive { Sendrecv } else { Inactive };
```

After a full offer/answer the transceiver added via `add_transceiver_from_kind(.., None)` is deterministically `recvonly`, so the `Sendrecv` arm never executes — Codecov flagged it as an uncovered patch line (98.41% patch coverage).

## What changed

- In both the unit tests (`rtp_transceiver/mod.rs`) and the integration test (`tests/set_direction_negotiation_needed.rs`), assert the known negotiated direction (`recvonly`) and change it to a fixed `inactive`.
- Removes the dead branch (→ 100% patch coverage) and documents the expected negotiated direction, so the test fails loudly if that assumption ever changes.

No behavior change; test-only.

## Test plan

- [x] `cargo test -p rtc` (unit + integration tests pass)
- [x] `cargo fmt -p rtc -- --check` clean
- [x] `cargo clippy -p rtc` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)