### PR TITLE
perf: bulk-copy & preallocate on RTCP / media / NACK serialization paths

### DIFF
--- a/rtc-interceptor/src/nack/send_buffer.rs
+++ b/rtc-interceptor/src/nack/send_buffer.rs
@@ -13,6 +13,10 @@ pub(crate) struct SendBuffer {
     packets: Vec<Option<rtp::Packet>>,
     /// Size of the buffer (must be power of 2).
     size: u16,
+    /// `size - 1`, used to index the circular buffer with `& mask` instead of
+    /// `% size`. Since `size` is a runtime value the compiler can't prove is a
+    /// power of two, `% size` would emit a real integer division per lookup.
+    mask: u16,
     /// Highest sequence number added.
     highest_added: u16,
     /// Whether any packet has been added yet.
@@ -34,6 +38,7 @@ impl SendBuffer {
         Some(Self {
             packets: vec![None; size as usize],
             size,
+            mask: size - 1,
             highest_added: 0,
             started: false,
         })
@@ -44,7 +49,7 @@ impl SendBuffer {
         let seq = packet.header.sequence_number;
 
         if !self.started {
-            self.packets[(seq % self.size) as usize] = Some(packet);
+            self.packets[(seq & self.mask) as usize] = Some(packet);
             self.highest_added = seq;
             self.started = true;
             return;
@@ -59,7 +64,7 @@ impl SendBuffer {
             // Clear packets between highest_added and seq
             let mut i = self.highest_added.wrapping_add(1);
             while i != seq {
-                let idx = (i % self.size) as usize;
+                let idx = (i & self.mask) as usize;
                 self.packets[idx] = None;
                 i = i.wrapping_add(1);
             }
@@ -67,7 +72,7 @@ impl SendBuffer {
         }
         // For negative diff (out of order), we still store but don't update highest_added
 
-        let idx = (seq % self.size) as usize;
+        let idx = (seq & self.mask) as usize;
         self.packets[idx] = Some(packet);
     }
 
@@ -90,7 +95,7 @@ impl SendBuffer {
             return None;
         }
 
-        let idx = (seq % self.size) as usize;
+        let idx = (seq & self.mask) as usize;
         let packet = self.packets[idx].as_ref()?;
 
         // Verify the sequence number matches (handle wraparound collisions)

--- a/rtc-media/src/io/ivf_writer/mod.rs
+++ b/rtc-media/src/io/ivf_writer/mod.rs
@@ -182,13 +182,11 @@ impl<W: Write + Seek> IVFWriter<W> {
 
     /// Append payload to current frame
     fn append_to_frame(&mut self, payload: Bytes) {
-        if let Some(current_frame) = &mut self.current_frame {
-            current_frame.extend(payload);
-        } else {
-            let mut current_frame = BytesMut::new();
-            current_frame.extend(payload);
-            self.current_frame = Some(current_frame);
-        }
+        // `extend_from_slice` bulk-copies; `BytesMut`'s `Extend` impl resolves to
+        // `Extend<u8>` for `Bytes`, which would copy one byte at a time.
+        self.current_frame
+            .get_or_insert_with(BytesMut::new)
+            .extend_from_slice(&payload);
     }
 
     /// Get current frame length

--- a/rtc-rtcp/src/packet.rs
+++ b/rtc-rtcp/src/packet.rs
@@ -42,7 +42,10 @@ impl Clone for Box<dyn Packet> {
 
 /// marshal takes an array of Packets and serializes them to a single buffer
 pub fn marshal(packets: &[Box<dyn Packet>]) -> Result<BytesMut> {
-    let mut out = BytesMut::new();
+    // Preallocate the whole compound packet up front so appending each
+    // sub-packet doesn't repeatedly grow and reallocate the buffer.
+    let total: usize = packets.iter().map(|p| p.marshal_size()).sum();
+    let mut out = BytesMut::with_capacity(total);
     for p in packets {
         let data = p.marshal()?;
         out.put(data);

--- a/rtc-rtcp/src/raw_packet.rs
+++ b/rtc-rtcp/src/raw_packet.rs
@@ -84,9 +84,11 @@ impl Unmarshal for RawPacket {
 
         let raw_hdr = h.marshal()?;
         let raw_body = raw_packet.copy_to_bytes(raw_packet.remaining());
-        let mut raw = BytesMut::new();
-        raw.extend(raw_hdr);
-        raw.extend(raw_body);
+        // Preallocate the exact size and bulk-copy: `BytesMut::extend` resolves to
+        // `Extend<u8>` here, copying a byte at a time and growing via reallocation.
+        let mut raw = BytesMut::with_capacity(raw_hdr.len() + raw_body.len());
+        raw.extend_from_slice(&raw_hdr);
+        raw.extend_from_slice(&raw_body);
 
         Ok(RawPacket(raw.freeze()))
     }


### PR DESCRIPTION
Follow-up to #104, continuing the performance work in #32.

## Analysis first

I re-profiled the per-packet paths with `perf`/`poop` before changing anything. The headline media path is already optimal and there's nothing left to win there:

- `perf record` on SRTP encrypt of a 1200-byte packet is **~65% SHA-NI** (`sha1::compress::x86::digest_blocks` — the hardware path, not the soft fallback), **~17% AES-NI**, ~5% the unavoidable plaintext→writer memcpy. That's ~82% irreducible, hardware-accelerated protocol crypto. The per-packet AES key schedule (`aes128::expand_key`) was only **0.65%**, so caching it isn't worth it.
- RTP header/packet marshal is already allocation-lean (`&mut [u8]` + `put_*`, bulk payload copy), and SCTP marshal was handled in #104.

So this PR targets the remaining **crypto-free serialization paths**, which still carried the same copy/alloc bug-class that #104 fixed on the SCTP/SRTP paths. All four changes produce **byte-identical output** (existing round-trip tests unchanged) and each carries a `poop` before/after measurement in its commit.

## Changes

| Commit | Fix | Measured (`poop`, before → after) |
|---|---|---|
| `RawPacket::unmarshal` | `BytesMut::extend(Bytes)` resolves to `Extend<u8>` (byte-at-a-time) + zero-cap buffer → preallocate + `extend_from_slice` | **−98.3% instr / −98.0% wall** (1200-byte body) |
| RTCP compound `marshal()` | zero-capacity `BytesMut` grown by realloc → preallocate to summed `marshal_size()` | **−26.0% instr / −21.0% wall** |
| `ivf_writer` frame append | same byte-by-byte `extend(Bytes)` on the VP8/VP9/AV1 recording path | **−98.5% instr / −98.1% wall** (~1200 B/frame) |
| NACK `SendBuffer` index | `seq % size` (runtime → hardware `div`) → `& mask` | `get()` **−49.2% cycles**; see note |

Notes on scope/honesty:

- The **RawPacket** 98% is worst-case (large unknown-type packet); typical unknown RTCP packets are small, so the real-world benefit scales with body size. Same class of bug as #104, fixed for consistency.
- The **SendBuffer** win is in *cycles*, not instruction count (a `div` and an `and` are both one instruction, but 16-bit `div` is ~20+ cycle latency). Only `get()` (the per-seq NACK retransmit lookup) measurably benefits; `add()` and the full `handle_write` path are dominated by the per-packet `rtp::Packet` clone, so end-to-end impact is negligible. Kept because it's strictly cheaper with zero downside.

The **RTCP compound marshal** (−21–26%) is the one on a genuinely recurring path (every compound RTCP report).

## Methodology

Each number is a `poop` comparison of two release binaries built from the same fixed-work micro-harness — one against this change, one against the parent version of just that file. The harnesses were temporary and are **not** included in the PR (kept it to the 4 source files). Full commands and per-metric tables are in the individual commit messages.

## Testing

- `cargo test --workspace` — 30 test binaries, all green, 0 failures.
- `cargo fmt --all --check` clean; `cargo clippy` clean on the changed library code.
- Output verified byte-identical by the existing marshal/unmarshal round-trip tests in each crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
