### PR TITLE
perf: receive-path copy elimination and O(N²)→O(N) SCTP DataChannel queues

### DIFF
--- a/rtc-interceptor/src/nack/receive_log.rs
+++ b/rtc-interceptor/src/nack/receive_log.rs
@@ -12,6 +12,10 @@ pub(crate) struct ReceiveLog {
     packets: Vec<u64>,
     /// Size of the tracking window (must be power of 2, minimum 64).
     size: u16,
+    /// `size - 1`. `size` is a power of two, so packets are indexed with
+    /// `& size_mask` instead of `% size`, avoiding a hardware division per
+    /// received packet.
+    size_mask: u16,
     /// Highest sequence number received.
     end: u16,
     /// Whether any packet has been received yet.
@@ -35,6 +39,7 @@ impl ReceiveLog {
         Some(Self {
             packets: vec![0u64; (size / 64) as usize],
             size,
+            size_mask: size - 1,
             end: 0,
             started: false,
             last_consecutive: 0,
@@ -123,17 +128,17 @@ impl ReceiveLog {
     }
 
     fn set_received(&mut self, seq: u16) {
-        let pos = seq % self.size;
+        let pos = seq & self.size_mask;
         self.packets[(pos / 64) as usize] |= 1 << (pos % 64);
     }
 
     fn del_received(&mut self, seq: u16) {
-        let pos = seq % self.size;
+        let pos = seq & self.size_mask;
         self.packets[(pos / 64) as usize] &= !(1u64 << (pos % 64));
     }
 
     fn get_received(&self, seq: u16) -> bool {
-        let pos = seq % self.size;
+        let pos = seq & self.size_mask;
         (self.packets[(pos / 64) as usize] & (1 << (pos % 64))) != 0
     }
 

--- a/rtc-interceptor/src/report/receiver_stream.rs
+++ b/rtc-interceptor/src/report/receiver_stream.rs
@@ -12,6 +12,10 @@ pub(crate) struct ReceiverStream {
     /// With size=128, total capacity is 128 * 64 = 8192 packets.
     packets: Vec<u64>,
     size: usize,
+    /// `size * PACKETS_PER_ENTRY - 1`. The bitmap capacity is a power of two, so
+    /// packets are indexed with `& index_mask` instead of `% (size * ...)`, which
+    /// the compiler would otherwise lower to a hardware division on every packet.
+    index_mask: usize,
     started: bool,
     seq_num_cycles: u16,
     last_seq_num: u16,
@@ -34,6 +38,7 @@ impl ReceiverStream {
 
             packets: vec![0u64; DEFAULT_SIZE],
             size: DEFAULT_SIZE,
+            index_mask: DEFAULT_SIZE * PACKETS_PER_ENTRY - 1,
             started: false,
             seq_num_cycles: 0,
             last_seq_num: 0,
@@ -48,17 +53,17 @@ impl ReceiverStream {
     }
 
     fn set_received(&mut self, seq: u16) {
-        let pos = (seq as usize) % (self.size * PACKETS_PER_ENTRY);
+        let pos = (seq as usize) & self.index_mask;
         self.packets[pos / PACKETS_PER_ENTRY] |= 1 << (pos % PACKETS_PER_ENTRY);
     }
 
     fn del_received(&mut self, seq: u16) {
-        let pos = (seq as usize) % (self.size * PACKETS_PER_ENTRY);
+        let pos = (seq as usize) & self.index_mask;
         self.packets[pos / PACKETS_PER_ENTRY] &= !(1u64 << (pos % PACKETS_PER_ENTRY));
     }
 
     fn get_received(&self, seq: u16) -> bool {
-        let pos = (seq as usize) % (self.size * PACKETS_PER_ENTRY);
+        let pos = (seq as usize) & self.index_mask;
         (self.packets[pos / PACKETS_PER_ENTRY] & (1 << (pos % PACKETS_PER_ENTRY))) != 0
     }
 

--- a/rtc-media/src/io/sample_builder/mod.rs
+++ b/rtc-media/src/io/sample_builder/mod.rs
@@ -322,27 +322,43 @@ impl<T: Depacketizer> SampleBuilder<T> {
         // the head set of packets is now fully consumed
         self.active.head = consume.tail;
 
-        // merge all the buffers into a sample
-        let mut data: Vec<u8> = Vec::new();
-        let mut i = consume.head;
-        while i != consume.tail {
-            let payload = self.buffer[i as usize]
+        // Assemble the sample payload from the consumed packets. For the common
+        // single-packet sample (all audio, and any frame that fits one RTP
+        // packet) hand back the depacketized `Bytes` directly — it is
+        // refcounted, so no copy is needed. Only multi-packet samples require
+        // concatenation, and even then `Bytes::from(data)` reuses the `Vec`'s
+        // buffer instead of copying it a second time.
+        let sample_data: Bytes = if consume.count() == 1 {
+            let payload = self.buffer[consume.head as usize]
                 .as_ref()
                 .map(|p| &p.payload)
                 .ok_or(BuildError::GapInSegment)?;
-
-            let p = self
-                .depacketizer
+            self.depacketizer
                 .depacketize(payload)
-                .map_err(|_| BuildError::DepacketizerFailed)?;
+                .map_err(|_| BuildError::DepacketizerFailed)?
+        } else {
+            let mut data: Vec<u8> = Vec::new();
+            let mut i = consume.head;
+            while i != consume.tail {
+                let payload = self.buffer[i as usize]
+                    .as_ref()
+                    .map(|p| &p.payload)
+                    .ok_or(BuildError::GapInSegment)?;
 
-            data.extend_from_slice(&p);
-            i = i.wrapping_add(1);
-        }
+                let p = self
+                    .depacketizer
+                    .depacketize(payload)
+                    .map_err(|_| BuildError::DepacketizerFailed)?;
+
+                data.extend_from_slice(&p);
+                i = i.wrapping_add(1);
+            }
+            Bytes::from(data)
+        };
         let samples = after_timestamp.wrapping_sub(sample_timestamp);
 
         let sample = Sample {
-            data: Bytes::copy_from_slice(&data),
+            data: sample_data,
             timestamp: SystemInstant::now(),
             duration: Duration::from_secs_f64((samples as f64) / (self.sample_rate as f64)),
             packet_timestamp: sample_timestamp,

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -18,14 +18,14 @@ impl PayloadQueue {
         PayloadQueue::default()
     }
 
-    pub(crate) fn update_sorted_keys(&mut self) {
-        self.sorted.sort_by(|a, b| {
-            if sna32lt(*a, *b) {
-                std::cmp::Ordering::Less
-            } else {
-                std::cmp::Ordering::Greater
-            }
-        });
+    /// Insert `tsn` into `sorted`, keeping SCTP serial-number order. Binary-search
+    /// the insertion point instead of re-sorting the whole vector on every push:
+    /// re-sorting made a burst of N chunks O(N^2 log N). In-order arrivals — the
+    /// common case, since TSNs are assigned/received sequentially — land at the
+    /// end in O(1) amortized.
+    fn insert_sorted(&mut self, tsn: u32) {
+        let idx = self.sorted.partition_point(|&x| sna32lt(x, tsn));
+        self.sorted.insert(idx, tsn);
     }
 
     pub(crate) fn can_push(&self, p: &ChunkPayloadData, cumulative_tsn: u32) -> bool {
@@ -34,10 +34,9 @@ impl PayloadQueue {
 
     pub(crate) fn push_no_check(&mut self, p: ChunkPayloadData) {
         self.n_bytes += p.user_data.len();
-        self.sorted.push(p.tsn);
+        self.insert_sorted(p.tsn);
         self.chunk_map.insert(p.tsn, p);
         //self.length += 1;
-        self.update_sorted_keys();
     }
 
     /// push pushes a payload data. If the payload data is already in our queue or
@@ -52,10 +51,9 @@ impl PayloadQueue {
         }
 
         self.n_bytes += p.user_data.len();
-        self.sorted.push(p.tsn);
+        self.insert_sorted(p.tsn);
         self.chunk_map.insert(p.tsn, p);
         //self.length += 1;
-        self.update_sorted_keys();
 
         true
     }

--- a/rtc-sctp/src/queue/reassembly_queue.rs
+++ b/rtc-sctp/src/queue/reassembly_queue.rs
@@ -4,28 +4,7 @@ use crate::util::*;
 use shared::error::{Error, Result};
 
 use bytes::{Bytes, BytesMut};
-use std::cmp::Ordering;
 use std::time::Instant;
-
-fn sort_chunks_by_tsn(c: &mut [ChunkPayloadData]) {
-    c.sort_by(|a, b| {
-        if sna32lt(a.tsn, b.tsn) {
-            Ordering::Less
-        } else {
-            Ordering::Greater
-        }
-    });
-}
-
-fn sort_chunks_by_ssn(c: &mut [Chunks]) {
-    c.sort_by(|a, b| {
-        if sna16lt(a.ssn, b.ssn) {
-            Ordering::Less
-        } else {
-            Ordering::Greater
-        }
-    });
-}
 
 /// A chunk of data from the stream
 #[derive(Debug, PartialEq)]
@@ -118,16 +97,14 @@ impl Chunks {
     }
 
     pub(crate) fn push(&mut self, chunk: ChunkPayloadData) -> bool {
-        // check if dup
-        for c in &self.chunks {
-            if c.tsn == chunk.tsn {
-                return false;
-            }
+        // Binary-search the insertion point (fragments are kept in TSN order),
+        // which also detects duplicates -- instead of an O(n) dup scan plus a
+        // full re-sort of every fragment on each push.
+        let idx = self.chunks.partition_point(|c| sna32lt(c.tsn, chunk.tsn));
+        if idx < self.chunks.len() && self.chunks[idx].tsn == chunk.tsn {
+            return false;
         }
-
-        // append and sort
-        self.chunks.push(chunk);
-        sort_chunks_by_tsn(&mut self.chunks);
+        self.chunks.insert(idx, chunk);
 
         // Check if we now have a complete set
         self.is_complete()
@@ -216,8 +193,10 @@ impl ReassemblyQueue {
             // First, insert into unordered_chunks array
             //atomic.AddUint64(&r.n_bytes, uint64(len(chunk.userData)))
             self.n_bytes += chunk.user_data.len();
-            self.unordered_chunks.push(chunk);
-            sort_chunks_by_tsn(&mut self.unordered_chunks);
+            let idx = self
+                .unordered_chunks
+                .partition_point(|c| sna32lt(c.tsn, chunk.tsn));
+            self.unordered_chunks.insert(idx, chunk);
 
             // Scan unordered_chunks that are contiguous (in TSN)
             // If found, append the complete set to the unordered array
@@ -242,14 +221,13 @@ impl ReassemblyQueue {
                 }
             }
 
-            // If not found, create a new chunkSet
-            let mut cset = Chunks::new(chunk.stream_sequence_number, chunk.payload_type, vec![]);
-            let unordered = chunk.unordered;
+            // If not found, create a new chunkSet and insert it in SSN order
+            // (this branch is only reached for ordered chunks).
+            let ssn = chunk.stream_sequence_number;
+            let mut cset = Chunks::new(ssn, chunk.payload_type, vec![]);
             let ok = cset.push(chunk);
-            self.ordered.push(cset);
-            if !unordered {
-                sort_chunks_by_ssn(&mut self.ordered);
-            }
+            let idx = self.ordered.partition_point(|s| sna16lt(s.ssn, ssn));
+            self.ordered.insert(idx, cset);
 
             ok
         }


### PR DESCRIPTION
Third round of performance work on #32 (after #104 and #105), this time targeting the **receive path** and the **SCTP DataChannel queues** — found by profiling the paths those earlier PRs didn't touch. Every change is byte-identical / order-identical (existing tests unchanged) and carries a `poop` before/after table in its commit.

## Highlights: two O(N²) → O(N) fixes on the DataChannel path

`PayloadQueue` and the reassembly queues appended to a `Vec` and then **re-sorted the whole vector on every push**. `PayloadQueue` backs *both* `inflight_queue` (send) and `payload_queue` (receive), so a saturated window — hundreds to thousands of chunks — was quadratic in both directions. Replaced the re-sort with a `partition_point` binary-search insert; in-order arrivals (the common case, since TSNs are sequential) become O(1) appends.

| Change | Measured (`poop`, before → after) |
|---|---|
| **`PayloadQueue` sorted-insert** (send inflight + receive) — N=1024 window | **−92.9% instr / −72.7% wall** |
| **Reassembly queues sorted-insert** — 256-fragment message | **−90.3% instr / −88.1% wall** |

The quadratic is unmistakable: filling the same ~10M total chunks, the old `PayloadQueue` doubled its instruction count when the window doubled (54.6G→102G) while the new one stayed flat (7.14G→7.20G).

## Receive-path copy & division

| Change | Measured |
|---|---|
| **`SampleBuilder::build_sample`** — dropped a redundant full-frame copy (`Bytes::copy_from_slice`→`Bytes::from`) + zero-copy fast path for single-packet samples | audio/1-pkt **−56.6% instr / −38% wall**; video/multi-pkt **−19.9% instr** |
| **`ReceiverStream` + `ReceiveLog`** — power-of-two bitmaps indexed with `& mask` instead of `% size` (division per received packet) | `ReceiveLog::add` **−45.3% cycles**; `process_rtp` −3.7% (jitter-float-bound) |

The SampleBuilder change is the notable one — it eliminated a second copy of every decoded media frame (all audio, and single-packet video frames now involve zero copies).

## What I profiled and deliberately left alone

- **DTLS record encrypt/decrypt** (`crypto_gcm`/`ccm`/`chacha20`) — the per-record `Vec::new()` is real but AEAD-dominated (same conclusion as SRTP in #104); not worth the churn.
- **STUN `read_from` double-alloc** — only the blocking `client.rs` wrapper calls it; the sans-IO decode path (`write(&[u8])`) already reuses `self.raw`.
- **TURN `handle_channel_data` per-packet `to_vec()`** — real, but only on the TURN-relay fallback path and needs an owned-→-borrowed API change.
- **RTP packetizer / TWCC arrival-time map** — already allocation-lean (preallocated vecs; the arrival map already masks a power-of-two capacity).

## Methodology & testing

Each number is a `poop` comparison of two release binaries from the same fixed-work micro-harness — one built against the change, one against the parent version of that single file. Harnesses were temporary and are **not** in the PR (it's 4 source files). Full commands and per-metric tables are in the commit messages.

- `cargo test --workspace` green (0 failures); rtc-sctp 108, rtc-media, rtc-interceptor suites all pass.
- `cargo fmt --all --check` clean; `cargo clippy` clean on changed library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
