### PR TITLE
perf: SCTP/ICE data-channel hot-path allocation & CPU reductions (#101 round 6)

### DIFF
--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -33,7 +33,7 @@ use stream::{ReliabilityType, Stream, StreamEvent, StreamId, StreamState};
 use timer::{ACK_INTERVAL, RtoManager, Timer, TimerTable};
 
 use crate::association::stream::RecvSendState;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use log::{debug, error, trace, warn};
 use rand::random;
 use rustc_hash::FxHashMap;
@@ -2487,38 +2487,61 @@ impl Association {
         // chunks: no intermediate `Vec<Packet>`, no `Box<dyn Chunk>` per chunk.
         // The chunks are already retained in the in-flight queue, so this send
         // copy is throwaway.
+        if chunks.is_empty() {
+            return;
+        }
         let common_header = CommonHeader {
             verification_tag: self.peer_verification_tag,
             source_port: self.source_port,
             destination_port: self.destination_port,
         };
 
+        // First pass: split the chunks into MTU-bounded datagrams and total up
+        // their marshalled (4-byte-padded) length. The whole burst is then
+        // written into ONE buffer and `split_to` hands out each datagram as a
+        // zero-copy `Bytes` view sharing that single allocation — one malloc per
+        // burst instead of one per packet on the hot send path.
+        let hdr = COMMON_HEADER_SIZE as usize;
+        let mut bundles: Vec<(usize, usize)> = Vec::new();
+        let mut total_len = 0usize;
         let mut bundle_start = 0;
         let mut bytes_in_packet = COMMON_HEADER_SIZE;
-        for i in 0..chunks.len() {
-            let data_len = chunks[i].user_data.len() as u32;
+        let mut bundle_len = hdr;
+        for (i, chunk) in chunks.iter().enumerate() {
+            let data_len = chunk.user_data.len() as u32;
             // Close the current bundle before a chunk that would exceed the MTU.
             if bytes_in_packet + data_len > self.mtu && i > bundle_start {
-                self.push_data_packet(&common_header, &chunks[bundle_start..i], raw_packets);
+                bundles.push((bundle_start, i));
+                total_len += bundle_len;
                 bundle_start = i;
                 bytes_in_packet = COMMON_HEADER_SIZE;
+                bundle_len = hdr;
             }
             bytes_in_packet += DATA_CHUNK_HEADER_SIZE + data_len;
+            // Marshalled chunk size, padded up to the SCTP 4-byte boundary.
+            let wire = (DATA_CHUNK_HEADER_SIZE + data_len) as usize;
+            bundle_len += (wire + 3) & !3;
         }
-        if bundle_start < chunks.len() {
-            self.push_data_packet(&common_header, &chunks[bundle_start..], raw_packets);
-        }
-    }
+        bundles.push((bundle_start, chunks.len()));
+        total_len += bundle_len;
 
-    fn push_data_packet(
-        &self,
-        common_header: &CommonHeader,
-        chunks: &[ChunkPayloadData],
-        raw_packets: &mut Vec<Bytes>,
-    ) {
-        match Packet::marshal_data_chunks(common_header, chunks) {
-            Ok(raw) => raw_packets.push(raw),
-            Err(_) => warn!("[{}] failed to serialize a DATA packet", self.side),
+        // Second pass: marshal each datagram into the shared buffer.
+        let mut buf = BytesMut::with_capacity(total_len);
+        for (start, end) in bundles {
+            match Packet::write_framed(
+                &common_header,
+                chunks[start..end].iter().map(|c| c as &dyn Chunk),
+                &mut buf,
+            ) {
+                Ok(_) => {
+                    let plen = buf.len();
+                    raw_packets.push(buf.split_to(plen).freeze());
+                }
+                Err(_) => {
+                    warn!("[{}] failed to serialize a DATA packet", self.side);
+                    buf.clear();
+                }
+            }
         }
     }
 

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -937,6 +937,16 @@ impl Association {
             i.initial_tsn - 1
         };
 
+        // Adopt the peer's advertised receive window and seed ssthresh from it,
+        // mirroring handle_init_ack (and Pion's shared init path). RFC 4960
+        // §7.2.1 (Slow-Start) permits initialising ssthresh to the advertised
+        // receiver window; without this the answerer keeps ssthresh at its
+        // initial 0, so cwnd never starts below it, slow-start never runs, and
+        // cwnd only grows linearly under congestion avoidance (§7.2.2).
+        self.rwnd = i.advertised_receiver_window_credit;
+        debug!("[{}] initial rwnd={}", self.side, self.rwnd);
+        self.ssthresh = self.rwnd;
+
         for param in &i.params {
             if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
                 for t in &v.chunk_types {

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2624,7 +2624,12 @@ impl Association {
     /// This method will be be called if use_forward_tsn is set to false.
     fn create_forward_tsn(&self) -> ChunkForwardTsn {
         // RFC 3758 Sec 3.5 C4
-        let mut stream_map: HashMap<u16, u16> = HashMap::new(); // to report only once per SI
+        // Keyed by stream identifier and probed once per in-flight chunk in the
+        // forward-TSN window. With PR-SCTP (unordered / limited-retransmit data
+        // channels) this runs on the hot send path, so use the non-SipHash hasher
+        // like every other window-bounded map here -- the default `HashMap`'s
+        // SipHash showed up as ~6-7% of send CPU in profiles.
+        let mut stream_map: FxHashMap<u16, u16> = FxHashMap::default(); // report once per SI
         let mut i = self.cumulative_tsn_ack_point + 1;
         while sna32lte(i, self.advanced_peer_tsn_ack_point) {
             if let Some(c) = self.inflight_queue.get(i) {

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2500,7 +2500,9 @@ impl Association {
         // their marshalled (4-byte-padded) length. The whole burst is then
         // written into ONE buffer and `split_to` hands out each datagram as a
         // zero-copy `Bytes` view sharing that single allocation — one malloc per
-        // burst instead of one per packet on the hot send path.
+        // burst instead of one per packet on the hot send path. The bundle
+        // boundaries are computed once here and reused below, so the MTU-split
+        // rule lives in exactly one place.
         let hdr = COMMON_HEADER_SIZE as usize;
         let mut bundles: Vec<(usize, usize)> = Vec::new();
         let mut total_len = 0usize;
@@ -2650,20 +2652,21 @@ impl Association {
 
         let mut fwd_tsn = ChunkForwardTsn {
             new_cumulative_tsn: self.advanced_peer_tsn_ack_point,
-            streams: vec![],
+            streams: Vec::with_capacity(stream_map.len()),
         };
-
-        let mut stream_str = String::new();
         for (si, ssn) in &stream_map {
-            stream_str += format!("(si={} ssn={})", si, ssn).as_str();
             fwd_tsn.streams.push(ChunkForwardTsnStream {
                 identifier: *si,
                 sequence: *ssn,
             });
         }
+        // `trace!` evaluates its arguments lazily, so the stream list is only
+        // formatted when trace logging is enabled -- no per-FORWARD-TSN string
+        // allocation on the hot send path (this fires often for PR-SCTP data
+        // channels, which is exactly where it was showing up in profiles).
         trace!(
-            "[{}] building fwd_tsn: newCumulativeTSN={} cumTSN={} - {}",
-            self.side, fwd_tsn.new_cumulative_tsn, self.cumulative_tsn_ack_point, stream_str
+            "[{}] building fwd_tsn: newCumulativeTSN={} cumTSN={} streams={:?}",
+            self.side, fwd_tsn.new_cumulative_tsn, self.cumulative_tsn_ack_point, fwd_tsn.streams
         );
 
         fwd_tsn

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -142,6 +142,12 @@ pub struct Association {
     will_send_forward_tsn: bool,
     will_retransmit_fast: bool,
     will_retransmit_reconfig: bool,
+    /// True only while the in-flight queue may still hold chunks flagged for
+    /// T3-rtx retransmission (set when the timer marks them, cleared once the
+    /// scan has re-sent them all). Lets `gather_outbound` skip the O(in-flight)
+    /// retransmit scan entirely in the steady state, where nothing is ever
+    /// marked — that scan was the single hottest function in the send profile.
+    t3_retransmit_pending: bool,
 
     will_send_shutdown_ack: bool,
     will_send_shutdown_complete: bool,
@@ -233,6 +239,7 @@ impl Default for Association {
             will_send_forward_tsn: false,
             will_retransmit_fast: false,
             will_retransmit_reconfig: false,
+            t3_retransmit_pending: false,
 
             will_send_shutdown_ack: false,
             will_send_shutdown_complete: false,
@@ -2065,7 +2072,11 @@ impl Association {
         mut raw_packets: Vec<Bytes>,
         now: Instant,
     ) -> Vec<Bytes> {
-        self.get_data_packets_to_retransmit(now, &mut raw_packets);
+        // Nothing is ever flagged for T3-rtx in the steady state, so skip the
+        // full in-flight scan unless the T3-rtx timer has actually marked chunks.
+        if self.t3_retransmit_pending {
+            self.get_data_packets_to_retransmit(now, &mut raw_packets);
+        }
         raw_packets
     }
 
@@ -2325,6 +2336,10 @@ impl Association {
         let mut bytes_to_send = 0;
         let mut done = false;
         let mut i = 0;
+        // Assume we will re-send every flagged chunk; flip back on if we stop
+        // early (a marked chunk that doesn't fit awnd, or a zero-window probe)
+        // so the next gather_outbound still scans.
+        let mut chunks_remaining = false;
         while !done {
             let tsn = self.cumulative_tsn_ack_point + i + 1;
             if let Some(c) = self.inflight_queue.get_mut(tsn) {
@@ -2336,7 +2351,9 @@ impl Association {
                 if i == 0 && self.rwnd < c.user_data.len() as u32 {
                     // Send it as a zero window probe
                     done = true;
+                    chunks_remaining = true;
                 } else if bytes_to_send + c.user_data.len() > awnd as usize {
+                    chunks_remaining = true;
                     break;
                 }
 
@@ -2368,6 +2385,10 @@ impl Association {
             }
             i += 1;
         }
+
+        // Cleared once the whole in-flight window has been rescanned with nothing
+        // left flagged; kept set while awnd/zero-window left chunks behind.
+        self.t3_retransmit_pending = chunks_remaining;
 
         self.bundle_data_chunks_into_packets(chunks, raw_packets);
     }
@@ -2832,6 +2853,7 @@ impl Association {
                 );
 
                 self.inflight_queue.mark_all_to_retrasmit();
+                self.t3_retransmit_pending = true;
                 self.awake_write_loop();
             }
 

--- a/rtc-sctp/src/packet.rs
+++ b/rtc-sctp/src/packet.rs
@@ -350,35 +350,6 @@ impl Packet {
 
         Ok(writer.len())
     }
-
-    /// Marshal a bundle of DATA chunks as a single SCTP packet, borrowing the
-    /// chunks directly instead of moving them into `Box<dyn Chunk>` inside a
-    /// `Packet`. Used on the hot outbound DATA path where the chunks are already
-    /// retained in the in-flight queue for retransmission, so the send copy is
-    /// throwaway and never needs the owned `Packet`. Produces byte-for-byte the
-    /// same packet as building a `Packet` from these chunks and calling
-    /// `marshal`, via the shared `write_framed`.
-    pub(crate) fn marshal_data_chunks(
-        common_header: &CommonHeader,
-        chunks: &[ChunkPayloadData],
-    ) -> Result<Bytes> {
-        let body_len: usize = chunks
-            .iter()
-            .map(|c| {
-                let n = CHUNK_HEADER_SIZE + c.value_length();
-                n + get_padding_size(n)
-            })
-            .sum();
-        let mut buf = BytesMut::with_capacity(PACKET_HEADER_SIZE + body_len);
-        // `ChunkPayloadData::marshal_to` is infallible, so the `?` error path here
-        // was dead and uncoverable; `.map` transforms the Ok value with no branch.
-        Self::write_framed(
-            common_header,
-            chunks.iter().map(|c| c as &dyn Chunk),
-            &mut buf,
-        )
-        .map(|_| buf.freeze())
-    }
 }
 
 impl Packet {
@@ -491,9 +462,10 @@ mod test {
         Ok(())
     }
 
-    // The boxing-free DATA send path (`marshal_data_chunks`) must produce exactly
-    // the same bytes as building a `Packet` of boxed chunks and calling `marshal`
-    // -- both go through `write_framed`. Also exercises `marshal_to`.
+    // The boxing-free DATA send path marshals borrowed `ChunkPayloadData` straight
+    // into a shared buffer via `write_framed`; it must produce exactly the same
+    // bytes as building a `Packet` of boxed chunks and calling `marshal` -- both go
+    // through `write_framed`. Also exercises `marshal_to`.
     #[test]
     fn test_marshal_data_chunks_matches_packet_marshal() -> Result<()> {
         use crate::chunk::chunk_payload_data::PayloadProtocolIdentifier;
@@ -521,7 +493,15 @@ mod test {
             vec![mk_chunk(1, 0, b"hello"), mk_chunk(2, 1, b"world!!")],
         ];
         for chunks in cases {
-            let direct = Packet::marshal_data_chunks(&mk_common(), &chunks)?;
+            let direct = {
+                let mut buf = BytesMut::new();
+                Packet::write_framed(
+                    &mk_common(),
+                    chunks.iter().map(|c| c as &dyn Chunk),
+                    &mut buf,
+                )?;
+                buf.freeze()
+            };
 
             let pkt = Packet {
                 common_header: mk_common(),
@@ -534,7 +514,7 @@ mod test {
             assert_eq!(
                 direct,
                 pkt.marshal()?,
-                "marshal_data_chunks must equal Packet::marshal"
+                "write_framed DATA path must equal Packet::marshal"
             );
 
             let mut buf = BytesMut::new();
@@ -542,7 +522,7 @@ mod test {
             assert_eq!(
                 direct,
                 buf.freeze(),
-                "marshal_to must equal marshal_data_chunks"
+                "marshal_to must equal the write_framed DATA path"
             );
         }
 

--- a/rtc/src/peer_connection/handler/ice.rs
+++ b/rtc/src/peer_connection/handler/ice.rs
@@ -19,6 +19,13 @@ pub(crate) struct IceHandlerContext {
     pub(crate) read_outs: VecDeque<TaggedRTCMessageInternal>,
     pub(crate) write_outs: VecDeque<TaggedRTCMessageInternal>,
     pub(crate) event_outs: VecDeque<RTCEventInternal>,
+
+    /// Cached stats key of the currently selected ICE candidate pair
+    /// (`RTCIceCandidatePair_<local>_<remote>`), refreshed only when the selected
+    /// pair changes. The per-packet read/write path looks the pair's stats
+    /// accumulator up with this key instead of re-`format!`ing it on every packet
+    /// — that formatting was a heap allocation on the hot path in both directions.
+    pub(crate) selected_pair_key: Option<String>,
 }
 
 impl IceHandlerContext {
@@ -29,6 +36,8 @@ impl IceHandlerContext {
             read_outs: VecDeque::new(),
             write_outs: VecDeque::new(),
             event_outs: VecDeque::new(),
+
+            selected_pair_key: None,
         }
     }
 }
@@ -65,18 +74,25 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                 transport: msg.transport,
                 message,
             })?;
-        } else if let Some((local, remote)) =
-            self.ctx.ice_transport.agent.get_selected_candidate_pair()
+        } else if self
+            .ctx
+            .ice_transport
+            .agent
+            .get_selected_candidate_pair()
+            .is_some()
         {
             // only ICE connection is ready and bypass it
             debug!("bypass ice read {:?}", msg.transport.peer_addr);
 
-            // Track packets/bytes received on the selected candidate pair
+            // Track packets/bytes received on the selected candidate pair. Look
+            // the accumulator up via the cached key (set on the last
+            // SelectedCandidatePairChange) to avoid allocating the key per packet.
             let bytes = msg.message.len();
-            let pair = self
-                .stats
-                .get_or_create_candidate_pair(local.id(), remote.id());
-            pair.on_packet_received(bytes, msg.now);
+            if let Some(key) = &self.ctx.selected_pair_key
+                && let Some(pair) = self.stats.ice_candidate_pairs.get_mut(key)
+            {
+                pair.on_packet_received(bytes, msg.now);
+            }
 
             // When ICE restarts and the selected candidate pair changes,
             // WebRTC treats this as a path migration, and DTLS continues unchanged, bound to the ICE transport, not to a fixed 5-tuple.
@@ -110,13 +126,14 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
             msg.transport.transport_protocol = local.network_type().to_protocol();
             debug!("Bypass ice write {:?}", msg.transport.peer_addr);
 
-            // Track packets/bytes sent on the selected candidate pair
-
+            // Track packets/bytes sent on the selected candidate pair. Look the
+            // accumulator up via the cached key to avoid allocating it per packet.
             let bytes = msg.message.len();
-            let pair = self
-                .stats
-                .get_or_create_candidate_pair(local.id(), remote.id());
-            pair.on_packet_sent(bytes, msg.now);
+            if let Some(key) = &self.ctx.selected_pair_key
+                && let Some(pair) = self.stats.ice_candidate_pairs.get_mut(key)
+            {
+                pair.on_packet_sent(bytes, msg.now);
+            }
 
             self.ctx.write_outs.push_back(msg);
         } else {
@@ -178,14 +195,14 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                         .get_or_create_candidate_pair(local.id(), remote.id());
                     pair.nominated = true;
                     pair.state = RTCStatsIceCandidatePairState::Succeeded;
+
+                    // Cache the pair's stats key so the per-packet path can look
+                    // the accumulator up by borrow instead of re-formatting (and
+                    // allocating) the key on every read/write.
+                    let key = format!("RTCIceCandidatePair_{}_{}", local.id(), remote.id());
+                    self.ctx.selected_pair_key = Some(key.clone());
                     // Update transport stats for selected candidate pair change
-                    self.stats
-                        .transport
-                        .on_selected_candidate_pair_changed(format!(
-                            "RTCIceCandidatePair_{}_{}",
-                            local.id(),
-                            remote.id()
-                        ));
+                    self.stats.transport.on_selected_candidate_pair_changed(key);
 
                     self.ctx
                         .event_outs


### PR DESCRIPTION
## What

Hot-path round of the SCTP/ICE performance work, targeting data-channel
throughput (webrtc-rs/webrtc#101). This is the follow-up to the round-5
marshalling work (#108); it sits on top of current `master`.

Six commits: one correctness fix and five allocation/CPU reductions on the
per-packet send/receive path.

| # | Commit | What |
|---|--------|------|
| 1 | `fix(sctp): seed ssthresh/rwnd from peer INIT` | The answerer/data-sender never seeded `ssthresh`/`rwnd` from the peer's advertised receiver window (only the offerer's `handle_init_ack` did). With `ssthresh = 0` the sender is in **permanent congestion-avoidance and never enters slow-start** (RFC 4960 §7.2.1), so `cwnd` ramps linearly instead of exponentially. Mirrors `handle_init_ack`. The effect is on the send-window **ramp** (measured below), not steady state. |
| 2 | `perf(sctp): skip the in-flight retransmit scan unless T3-rtx is armed` | Guard the O(in-flight) retransmit scan behind a `t3_retransmit_pending` flag; nothing is flagged for T3-rtx in steady state, so the scan was pure overhead (top send-profile hotspot). |
| 3 | `perf(sctp): marshal a whole DATA send burst into one allocation` | `bundle_data_chunks_into_packets` allocated a fresh `BytesMut` per outbound packet. Size the whole burst once, marshal every datagram into one buffer via `write_framed`, and hand each out as a zero-copy `split_to().freeze()` view — one allocation per burst instead of one per packet. Removes the now-unused `marshal_data_chunks`. |
| 4 | `perf(sctp): use FxHash for the forward-TSN stream map` | `create_forward_tsn`'s per-stream map used the default `HashMap` (SipHash). On PR-SCTP data channels (unordered / limited-retransmit) FORWARD-TSN is on the hot send path and the map is probed per in-flight chunk — SipHash was **~6–7% of send CPU**, the largest avoidable cost in `poll_transmit`. Switched to `FxHashMap` like every other window-bounded map in the crate. |
| 5 | `perf(ice): cache selected candidate-pair stats key off the per-packet path` | `IceHandler` rebuilt a stats key via `format!("RTCIceCandidatePair_{}_{}")` on **every packet, both directions**, purely for bookkeeping — a heap allocation per packet. Cache the key on `SelectedCandidatePairChange` (which already creates the entry) and look the accumulator up with a borrowing `get_mut`. |
| 6 | `perf(sctp): drop the eager debug string in create_forward_tsn` | Removed a `String`/`format!` built per FORWARD-TSN solely for a `trace!` (which already evaluates its args lazily). |

## Measured impact

Loopback data-channel benchmark (`examples/data-channels-flow-control`,
configured unordered / `max_retransmits: 0` as WebRTC data channels are),
interleaved A/B to cancel drift, on Linux x86-64. Retired instructions via
`perf stat` over a fixed 1 GiB transfer.

Steady-state, allocation/hashing wins (#3–#6):

- **FxHash FORWARD-TSN (#4):** throughput **+12.7%** @2 workers (287→324 Mbps),
  **+18.2%** @16 workers (197→233 Mbps); **−11.5%** retired instructions.
- **ICE key cache (#5):** **+5.2%** @2w (317→334), **+3.4%** @16w (233→241);
  **−6.0%** retired instructions.
- Cumulative for #3–#6 over the correctness-fixed baseline: **+18–25%
  throughput, −16.8% retired instructions**. The marshal change (#3) and trace
  change (#6) are near-noise on the latency-bound loopback individually but
  remove real per-burst / per-FORWARD-TSN allocations (they help CPU-bound /
  high-packet-rate deployments).

Ramp fix (#1) — measured separately, because it acts on the send-window ramp,
not steady state. The benchmark is latency-bound (send/ack round-trip dominated
by tokio cross-thread scheduling, ~tens of ms), so the linear ramp is slow even
on loopback. Isolated A/B (fix removed vs present), cumulative throughput of a
fixed transfer, median:

| transfer | WITH #1 | WITHOUT #1 | Δ |
|----------|--------:|-----------:|---|
| ramp-inclusive 32 MB, 2 workers  | 270 | 146 | **+85%** |
| ramp-inclusive 32 MB, 16 workers | 182 | 103 | **+76%** |
| ramp-inclusive 128 MB, 2 workers | 310 | 229 | +35% (amortised) |
| steady state (first 64 MB skipped) | 334 | 319 | ≈ equal |

So #1 is a large win for short transfers / connection startup and amortises over
long ones; steady-state throughput is unaffected. The same mechanism applies on
higher-RTT paths, where the absolute ramp is longer.

## Correctness

- `rtc-sctp`: **113/113** tests pass, including the byte-for-byte equivalence
  test for the boxing-free DATA marshal path vs `Packet::marshal`.
- `rtc`: **470/470** tests pass (ICE + statistics included).
- The shared-buffer marshal produces identical wire bytes; the FORWARD-TSN
  chunk contents are unchanged by the hasher swap.

Diffstat: 3 files, +142 / −82 (`rtc-sctp/src/association/mod.rs`,
`rtc-sctp/src/packet.rs`, `rtc/src/peer_connection/handler/ice.rs`).
