### PR TITLE
perf(sctp): make FORWARD-TSN generation O(streams) instead of O(rwnd)

### DIFF
--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -15,23 +15,20 @@ fn create_association(config: TransportConfig) -> Association {
     )
 }
 
+// `create_forward_tsn` no longer rescans the in-flight window; it emits the
+// `fwd_tsn_stream_map` that the RFC 3758 C2 loops fill via
+// `note_abandoned_for_forward_tsn` as each chunk is abandoned. These unit tests
+// drive that same entry point directly (ascending TSN, as C2 would); the full
+// window/SACK-driven path is exercised end-to-end by the `endpoint_test`
+// `test_assoc_unreliable_rexmit_*` suite.
 #[test]
 fn test_create_forward_tsn_forward_one_abandoned() -> Result<()> {
     let mut a = Association::default();
 
     a.cumulative_tsn_ack_point = 9;
     a.advanced_peer_tsn_ack_point = 10;
-    a.inflight_queue.push_no_check(ChunkPayloadData {
-        beginning_fragment: true,
-        ending_fragment: true,
-        tsn: 10,
-        stream_identifier: 1,
-        stream_sequence_number: 2,
-        user_data: Bytes::from_static(b"ABC"),
-        nsent: 1,
-        abandoned: true,
-        ..Default::default()
-    });
+    // tsn=10, ordered, si=1, ssn=2
+    a.note_abandoned_for_forward_tsn(false, 1, 2);
 
     let fwdtsn = a.create_forward_tsn();
 
@@ -49,39 +46,9 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
 
     a.cumulative_tsn_ack_point = 9;
     a.advanced_peer_tsn_ack_point = 12;
-    a.inflight_queue.push_no_check(ChunkPayloadData {
-        beginning_fragment: true,
-        ending_fragment: true,
-        tsn: 10,
-        stream_identifier: 1,
-        stream_sequence_number: 2,
-        user_data: Bytes::from_static(b"ABC"),
-        nsent: 1,
-        abandoned: true,
-        ..Default::default()
-    });
-    a.inflight_queue.push_no_check(ChunkPayloadData {
-        beginning_fragment: true,
-        ending_fragment: true,
-        tsn: 11,
-        stream_identifier: 1,
-        stream_sequence_number: 3,
-        user_data: Bytes::from_static(b"DEF"),
-        nsent: 1,
-        abandoned: true,
-        ..Default::default()
-    });
-    a.inflight_queue.push_no_check(ChunkPayloadData {
-        beginning_fragment: true,
-        ending_fragment: true,
-        tsn: 12,
-        stream_identifier: 2,
-        stream_sequence_number: 1,
-        user_data: Bytes::from_static(b"123"),
-        nsent: 1,
-        abandoned: true,
-        ..Default::default()
-    });
+    a.note_abandoned_for_forward_tsn(false, 1, 2); // tsn=10
+    a.note_abandoned_for_forward_tsn(false, 1, 3); // tsn=11 -> greatest SSN for si=1
+    a.note_abandoned_for_forward_tsn(false, 2, 1); // tsn=12
 
     let fwdtsn = a.create_forward_tsn();
 
@@ -105,6 +72,33 @@ fn test_create_forward_tsn_forward_two_abandoned_with_the_same_si() -> Result<()
     }
     assert!(si1ok, "si=1 should be present");
     assert!(si2ok, "si=2 should be present");
+
+    Ok(())
+}
+
+#[test]
+fn test_create_forward_tsn_omits_unordered_streams() -> Result<()> {
+    // Unordered chunks carry no meaningful stream-sequence-number: the receiver
+    // advances unordered streams purely by `new_cumulative_tsn` and ignores the
+    // per-stream list (see handle_forward_tsn), so create_forward_tsn must not
+    // report them — only ordered streams contribute.
+    let mut a = Association::default();
+
+    a.cumulative_tsn_ack_point = 9;
+    a.advanced_peer_tsn_ack_point = 11;
+    a.note_abandoned_for_forward_tsn(true, 1, 5); // unordered -> omitted
+    a.note_abandoned_for_forward_tsn(false, 2, 7); // ordered   -> reported
+
+    let fwdtsn = a.create_forward_tsn();
+
+    assert_eq!(11, fwdtsn.new_cumulative_tsn);
+    assert_eq!(
+        1,
+        fwdtsn.streams.len(),
+        "only the ordered stream is reported"
+    );
+    assert_eq!(2, fwdtsn.streams[0].identifier, "si should be 2");
+    assert_eq!(7, fwdtsn.streams[0].sequence, "ssn should be 7");
 
     Ok(())
 }

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -180,6 +180,16 @@ pub struct Association {
     cumulative_tsn_ack_point: u32,
     advanced_peer_tsn_ack_point: u32,
     use_forward_tsn: bool,
+    /// Max stream-sequence-number per *ordered* stream among abandoned chunks
+    /// currently in the forward-TSN window `(cumulative_tsn_ack_point,
+    /// advanced_peer_tsn_ack_point]`. Maintained incrementally as chunks are
+    /// abandoned (the two RFC 3758 C2 loops) so that `create_forward_tsn` is
+    /// O(streams) instead of rescanning the whole in-flight window — which, for
+    /// PR-SCTP data channels, ran ~1000 hashmap probes per FORWARD-TSN and was
+    /// ~9% of send CPU in profiles. Unordered chunks are omitted: the receiver
+    /// ignores the per-stream list for them (it advances by `new_cumulative_tsn`
+    /// alone), so reporting them was pure waste.
+    fwd_tsn_stream_map: FxHashMap<u16, u16>,
 
     pub(crate) rto_mgr: RtoManager,
     timers: TimerTable,
@@ -272,6 +282,7 @@ impl Default for Association {
             cumulative_tsn_ack_point: 0,
             advanced_peer_tsn_ack_point: 0,
             use_forward_tsn: false,
+            fwd_tsn_stream_map: FxHashMap::default(),
 
             rto_mgr: RtoManager::default(),
             timers: TimerTable::default(),
@@ -1331,16 +1342,29 @@ impl Association {
                 self.advanced_peer_tsn_ack_point,
                 self.cumulative_tsn_ack_point,
             ) {
-                self.advanced_peer_tsn_ack_point = self.cumulative_tsn_ack_point
+                self.advanced_peer_tsn_ack_point = self.cumulative_tsn_ack_point;
+                // Window reset: everything previously tracked is now at/below
+                // the cumulative ack point, so start the stream map fresh.
+                self.fwd_tsn_stream_map.clear();
             }
 
-            // RFC 3758 Sec 3.5 C2
+            // RFC 3758 Sec 3.5 C2 — advance over newly-abandoned chunks,
+            // folding each ordered one into the forward-TSN stream map so
+            // create_forward_tsn needn't rescan the window.
             let mut i = self.advanced_peer_tsn_ack_point + 1;
-            while let Some(c) = self.inflight_queue.get(i) {
-                if !c.abandoned() {
+            while let Some((abandoned, unordered, si, ssn)) = self.inflight_queue.get(i).map(|c| {
+                (
+                    c.abandoned(),
+                    c.unordered,
+                    c.stream_identifier,
+                    c.stream_sequence_number,
+                )
+            }) {
+                if !abandoned {
                     break;
                 }
                 self.advanced_peer_tsn_ack_point = i;
+                self.note_abandoned_for_forward_tsn(unordered, si, ssn);
                 i += 1;
             }
 
@@ -1357,6 +1381,10 @@ impl Association {
                     self.advanced_peer_tsn_ack_point,
                     self.cumulative_tsn_ack_point
                 );
+            } else {
+                // No forward-TSN window open (receiver has caught up): drop any
+                // stale per-stream SSNs so they aren't reported later.
+                self.fwd_tsn_stream_map.clear();
             }
             self.awake_write_loop();
         }
@@ -2622,39 +2650,56 @@ impl Association {
         }
     }
 
+    /// Record an abandoned chunk into the forward-TSN stream map (RFC 3758 C4),
+    /// called from the two C2 loops as `advanced_peer_tsn_ack_point` advances
+    /// over each newly-abandoned in-flight chunk. Only *ordered* streams are
+    /// tracked: the receiver ignores the per-stream SSN list for unordered
+    /// chunks (it advances purely by `new_cumulative_tsn`). Keeps the greatest
+    /// SSN seen per stream, which is the value RFC 3758 C4 requires to report.
+    ///
+    /// A stream's entry may briefly outlive the chunk that set it (until the
+    /// window closes and the map is cleared), so a stale SSN can be re-reported;
+    /// that is safe because the receiver only advances a stream forward and the
+    /// SSN always corresponds to a really-abandoned chunk. The `u16` SSN compare
+    /// (`sna16lt`) is sound because the window span is bounded by rwnd — a
+    /// stream cannot lap the full 65536-sequence space before the window closes.
+    fn note_abandoned_for_forward_tsn(&mut self, unordered: bool, si: u16, ssn: u16) {
+        if unordered {
+            return;
+        }
+        self.fwd_tsn_stream_map
+            .entry(si)
+            .and_modify(|cur| {
+                if sna16lt(*cur, ssn) {
+                    *cur = ssn;
+                }
+            })
+            .or_insert(ssn);
+    }
+
+    /// Test-only observer for the incremental forward-TSN stream map, so the
+    /// endpoint tests can assert it is cleared once the forward-TSN window
+    /// closes (the C1/C3 clear paths, which the unit tests can't reach).
+    #[cfg(test)]
+    pub(crate) fn fwd_tsn_stream_map_is_empty(&self) -> bool {
+        self.fwd_tsn_stream_map.is_empty()
+    }
+
     /// create_forward_tsn generates ForwardTSN chunk.
     /// This method will be be called if use_forward_tsn is set to false.
     fn create_forward_tsn(&self) -> ChunkForwardTsn {
-        // RFC 3758 Sec 3.5 C4
-        // Keyed by stream identifier and probed once per in-flight chunk in the
-        // forward-TSN window. With PR-SCTP (unordered / limited-retransmit data
-        // channels) this runs on the hot send path, so use the non-SipHash hasher
-        // like every other window-bounded map here -- the default `HashMap`'s
-        // SipHash showed up as ~6-7% of send CPU in profiles.
-        let mut stream_map: FxHashMap<u16, u16> = FxHashMap::default(); // report once per SI
-        let mut i = self.cumulative_tsn_ack_point + 1;
-        while sna32lte(i, self.advanced_peer_tsn_ack_point) {
-            if let Some(c) = self.inflight_queue.get(i) {
-                if let Some(ssn) = stream_map.get(&c.stream_identifier) {
-                    if sna16lt(*ssn, c.stream_sequence_number) {
-                        // to report only once with greatest SSN
-                        stream_map.insert(c.stream_identifier, c.stream_sequence_number);
-                    }
-                } else {
-                    stream_map.insert(c.stream_identifier, c.stream_sequence_number);
-                }
-            } else {
-                break;
-            }
-
-            i += 1;
-        }
-
+        // RFC 3758 Sec 3.5 C4: report, once per ordered stream, the greatest
+        // stream-sequence-number among abandoned chunks in the forward-TSN
+        // window. This is maintained incrementally in `fwd_tsn_stream_map` (see
+        // its declaration and the two C2 loops that feed it), so we no longer
+        // rescan `(cumulative_tsn_ack_point, advanced_peer_tsn_ack_point]` with
+        // a per-TSN hashmap probe on every FORWARD-TSN — that scan was O(rwnd)
+        // (~1000 probes/call for a 1 MB window) and dominated the send profile.
         let mut fwd_tsn = ChunkForwardTsn {
             new_cumulative_tsn: self.advanced_peer_tsn_ack_point,
-            streams: Vec::with_capacity(stream_map.len()),
+            streams: Vec::with_capacity(self.fwd_tsn_stream_map.len()),
         };
-        for (si, ssn) in &stream_map {
+        for (si, ssn) in &self.fwd_tsn_stream_map {
             fwd_tsn.streams.push(ChunkForwardTsnStream {
                 identifier: *si,
                 sequence: *ssn,
@@ -2854,11 +2899,21 @@ impl Association {
                 if self.use_forward_tsn {
                     // RFC 3758 Sec 3.5 C2
                     let mut i = self.advanced_peer_tsn_ack_point + 1;
-                    while let Some(c) = self.inflight_queue.get(i) {
-                        if !c.abandoned() {
+                    while let Some((abandoned, unordered, si, ssn)) =
+                        self.inflight_queue.get(i).map(|c| {
+                            (
+                                c.abandoned(),
+                                c.unordered,
+                                c.stream_identifier,
+                                c.stream_sequence_number,
+                            )
+                        })
+                    {
+                        if !abandoned {
                             break;
                         }
                         self.advanced_peer_tsn_ack_point = i;
+                        self.note_abandoned_for_forward_tsn(unordered, si, ssn);
                         i += 1;
                     }
 

--- a/rtc-sctp/src/endpoint/endpoint_test.rs
+++ b/rtc-sctp/src/endpoint/endpoint_test.rs
@@ -1050,6 +1050,75 @@ fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
 }
 
 #[test]
+fn test_forward_tsn_stream_map_populated_then_cleared() -> Result<()> {
+    // Regression guard for the incremental forward-TSN stream map. Exercises
+    // both halves of the new logic that the association-level unit tests can't
+    // reach on their own:
+    //   1. Population: an *ordered* message following a skipped (abandoned) one
+    //      is only delivered if the FORWARD-TSN carried the skipped stream
+    //      sequence number, i.e. the map was populated by the C2 loop.
+    //   2. Clear: once the FORWARD-TSN is acknowledged and the window closes,
+    //      the map must be emptied (the C1 / C3-else clear paths), otherwise a
+    //      stale stream sequence would be re-reported on later FORWARD-TSNs.
+    let si: u16 = 1;
+    let sbuf = vec![0u8; 1000];
+
+    let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+    establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+
+    // Ordered stream; reliability 0 abandons a chunk after its first (here,
+    // lost) transmission.
+    pair.client_stream(client_ch, si)?
+        .set_reliability_params(false, ReliabilityType::Rexmit, 0)?;
+    pair.server_stream(server_ch, si)?
+        .set_reliability_params(false, ReliabilityType::Rexmit, 0)?;
+
+    // Send ordered ssn=0 and lose it in flight -> it becomes abandoned.
+    let mut m0 = sbuf.clone();
+    m0[0..4].copy_from_slice(&0u32.to_be_bytes());
+    pair.client_stream(client_ch, si)?
+        .write_sctp(&Bytes::from(m0), PayloadProtocolIdentifier::Binary)?;
+    pair.drive_client();
+    pair.server.inbound.clear(); // drop ssn=0
+
+    // Send ordered ssn=1. The FORWARD-TSN generated for the abandoned ssn=0
+    // must report the stream sequence so the receiver releases ssn=1.
+    let mut m1 = sbuf.clone();
+    m1[0..4].copy_from_slice(&1u32.to_be_bytes());
+    pair.client_stream(client_ch, si)?
+        .write_sctp(&Bytes::from(m1), PayloadProtocolIdentifier::Binary)?;
+    pair.drive();
+
+    // (1) Population check: the receiver skipped ssn=0 and delivered ssn=1.
+    // For an ordered stream this delivery is impossible unless the FORWARD-TSN
+    // carried the stream/SSN pair, so this proves the map was populated.
+    let mut buf = vec![0u8; 2000];
+    let chunks = pair.server_stream(server_ch, si)?.read_sctp()?.unwrap();
+    let (n, ppi) = (chunks.len(), chunks.ppi);
+    chunks.read(&mut buf)?;
+    assert_eq!(n, sbuf.len(), "unexpected length of received data");
+    assert_eq!(ppi, PayloadProtocolIdentifier::Binary, "unexpected ppi");
+    assert_eq!(
+        u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]),
+        1,
+        "receiver must skip abandoned ssn=0 and deliver ordered ssn=1"
+    );
+
+    // (2) Clear check: the FORWARD-TSN has been acknowledged and the window has
+    // closed, so the sender's stream map must be empty.
+    pair.drive();
+    assert!(
+        pair.client_conn_mut(client_ch)
+            .fwd_tsn_stream_map_is_empty(),
+        "forward-TSN stream map must be cleared once the window closes"
+    );
+
+    close_association_pair(&mut pair, client_ch, server_ch, si);
+
+    Ok(())
+}
+
+#[test]
 fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     //let _guard = subscribe();
 


### PR DESCRIPTION
## Problem

`Association::create_forward_tsn` (RFC 3758 §3.5 C4) rebuilds its per-stream "greatest stream-sequence-number" map by linearly rescanning the whole forward-TSN window `(cumulative_tsn_ack_point, advanced_peer_tsn_ack_point]`, doing a per-TSN `inflight_queue.get()` hashmap probe on **every** FORWARD-TSN.

For PR-SCTP data channels (`max_retransmits: 0`, so every chunk is abandon-eligible) that window spans the entire in-flight set — i.e. the full receive window. Profiling a 1 MB-rwnd / 1 KB-message data-channel transfer (`examples/data-channels-flow-control`) showed this at **~9% of send-side self-time**: `create_forward_tsn` was called ~100k times per 512 MB, scanning ~1000 TSNs each — **~99 million hashmap probes to produce a map with a single entry**.

## Fix

Maintain the map incrementally. `fwd_tsn_stream_map` is folded forward at the **two RFC 3758 C2 loops** (`handle_sack` and the T3-rtx timeout), which already visit each newly-abandoned chunk as `advanced_peer_tsn_ack_point` advances — so the update costs **no extra probes** — and it is cleared when the window closes. `create_forward_tsn` then just emits the map: **O(streams)** instead of O(rwnd).

## RFC 3758 conformance

Only **ordered** streams are tracked, which the spec requires (verified against the primary text):

- §3.2: the Stream-Sequence field *"MUST NOT report TSN's corresponding to DATA chunks that are marked as unordered. For ordered DATA chunks this field MUST be filled in."*
- §3.5 C4: the sender includes a stream/SSN pair only *"if ... it was ordered"*, and *"only the highest abandoned stream sequence number is reported"* — exactly the per-stream max this map keeps.

The previous scan inserted every chunk's SSN regardless of the U bit, so this also removes an over-report of unordered streams (harmless before only because the receiver's `handle_forward_tsn_for_ordered` early-returns for unordered). Every map entry is a genuinely-abandoned ordered SSN, so re-reporting a stale entry is idempotent on the receiver (`forward_tsn_for_ordered` only advances forward); the max-insert never fabricates an SSN.

## Measurements

Interleaved A/B (`poop`, 6 runs, fixed 512 MB, dedicated reactor, Ryzen 1700):

| metric | delta |
| --- | --- |
| retired instructions | **−12.3% ± 0.7%** |
| cache misses | **−12.1% ± 3.3%** |
| cpu cycles | −4.2% ± 1.8% |

`poll_transmit` self-time drops **8.9% → 0.7%** in the re-profile. The gain scales with the window (the old scan is O(window)): in a CPU-bound N=8-connection benchmark at a 16 MB receive window, base collapses while this holds flat — **+66% aggregate throughput**.

## Tests

- The two `test_create_forward_tsn_*` unit tests drove the old scan by poking `inflight_queue` directly; they now drive the same entry point (`note_abandoned_for_forward_tsn`) the C2 loops use.
- Added `test_create_forward_tsn_omits_unordered_streams` (RFC §3.2 omission).
- Added endpoint test `test_forward_tsn_stream_map_populated_then_cleared` covering the populate → window-close → clear lifecycle. Verified it fails if either clear is removed, while all other tests still pass (confirming the clear is hygiene, not correctness).
- All **115** `rtc-sctp` tests pass, including the end-to-end `test_assoc_unreliable_rexmit_*` suite (ordered / unordered / timed × fragment). No public API change.

Part of the issue #101 data-channel throughput work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)