### PR TITLE
sdp: allow extmap IDs up to 255 per RFC 8285

### DIFF
--- a/rtc-sdp/src/extmap/extmap_test.rs
+++ b/rtc-sdp/src/extmap/extmap_test.rs
@@ -49,6 +49,35 @@ fn test_extmap() -> Result<()> {
     Ok(())
 }
 
+// RFC 8285 section 4.3: two-byte-header extension IDs are valid in the range
+// 1-255 inclusive. The parser previously capped IDs at 246 (and its error
+// message said 1-256), wrongly rejecting valid IDs 247-255.
+#[test]
+fn test_extmap_id_range_rfc8285() -> Result<()> {
+    // 1..=255 are valid; 247 and 255 were wrongly rejected before the fix.
+    for value in [1u16, 14, 15, 246, 247, 255] {
+        let line =
+            format!("{ATTRIBUTE_KEY}extmap:{value} urn:ietf:params:rtp-hdrext:sdes:mid{END_LINE}");
+        let mut reader = BufReader::new(line.as_bytes());
+        let actual = ExtMap::unmarshal(&mut reader)
+            .unwrap_or_else(|e| panic!("extmap id {value} should parse: {e:?}"));
+        assert_eq!(actual.value, value);
+    }
+
+    // 0 (padding) and anything above 255 must be rejected.
+    for value in [0u16, 256, 257, 4096] {
+        let line =
+            format!("{ATTRIBUTE_KEY}extmap:{value} urn:ietf:params:rtp-hdrext:sdes:mid{END_LINE}");
+        let mut reader = BufReader::new(line.as_bytes());
+        assert!(
+            ExtMap::unmarshal(&mut reader).is_err(),
+            "extmap id {value} must be rejected"
+        );
+    }
+
+    Ok(())
+}
+
 #[test]
 fn test_transport_cc_extmap() -> Result<()> {
     // a=extmap:<value>["/"<direction>] <URI> <extensionattributes>

--- a/rtc-sdp/src/extmap/mod.rs
+++ b/rtc-sdp/src/extmap/mod.rs
@@ -80,9 +80,12 @@ impl ExtMap {
 
         let valdir: Vec<&str> = fields[0].split('/').collect();
         let value = valdir[0].parse::<u16>()?;
-        if !(1..=246).contains(&value) {
+        // RFC 8285 section 4.3: the two-byte-header extension ID is "in the
+        // range 1-255 inclusive" (0 is reserved for padding). One-byte-header
+        // IDs (1-14) are a subset of the same range.
+        if !(1..=255).contains(&value) {
             return Err(Error::ParseExtMap(format!(
-                "{} -- extmap key must be in the range 1-256",
+                "{} -- extmap key must be in the range 1-255",
                 valdir[0]
             )));
         }


### PR DESCRIPTION
## Summary

`ExtMap::unmarshal` capped the RTP header-extension ID at 246, and its error
message said "1-256" — the constant, the message, and the spec all disagreed.

[RFC 8285 §4.3](https://www.rfc-editor.org/rfc/rfc8285.html#section-4.3) defines
the two-byte-header ID as *"the local identifier of this element in the range
1-255 inclusive"* (0 is reserved for padding; one-byte-header IDs 1-14 are a
subset). IDs 247-255 are therefore valid and were wrongly rejected with
`ParseExtMap`.

This widens the range check to `1..=255` and corrects the error message to
"1-255". Not reachable by browsers (Safari's largest extmap ID is 14), but a
genuine RFC 8285 conformance defect found while auditing Safari TWCC/extmap
handling for #31.

## Test plan

- `cargo test -p rtc-sdp` — new `test_extmap_id_range_rfc8285` asserts IDs
  1..=255 parse (247/255 were rejected before) and 0/256/257/4096 are rejected.
  The existing `test_extmap` (which uses `extmap:257` as a must-fail case) still
  passes.

Part of the browser-interoperability work for #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
