### PR TITLE
Default mDNS mode to QueryOnly so Safari ICE candidates resolve

### DIFF
--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2835,3 +2835,47 @@ fn test_handle_inbound_request_defers_failing_connectivity_check() -> Result<()>
     a.close()?;
     Ok(())
 }
+
+// Safari (and Chrome) expose ICE host candidates behind an mDNS "<uuid>.local"
+// hostname by default. A QueryOnly agent (the default) must RESOLVE such a
+// candidate -- i.e. issue an mDNS query, which surfaces as an outbound packet to
+// MDNS_PORT -- whereas a Disabled agent silently drops it. This guards the
+// behavioral consequence of defaulting the SettingEngine mDNS mode to QueryOnly.
+#[test]
+fn test_query_only_agent_queries_mdns_remote_candidate() -> Result<()> {
+    // A .local host candidate in Safari's exact format.
+    let cand_line =
+        "1114572465 1 udp 2113939711 61b445d2-6503-41ac-96ce-ee3edac00e9f.local 61163 typ host";
+
+    // QueryOnly: adding the candidate issues an mDNS query (not a drop).
+    let mut agent = Agent::new(Arc::new(AgentConfig {
+        multicast_dns_mode: crate::mdns::MulticastDnsMode::QueryOnly,
+        ..Default::default()
+    }))?;
+    let added = agent.add_remote_candidate(unmarshal_candidate(cand_line)?)?;
+    assert!(
+        !added,
+        "an mDNS candidate is not immediately usable; resolution is async"
+    );
+    let pkt = agent
+        .poll_write()
+        .expect("QueryOnly must emit an mDNS query for a .local remote candidate");
+    assert_eq!(
+        pkt.transport.peer_addr.port(),
+        mdns::MDNS_PORT,
+        "the emitted packet must be an mDNS query"
+    );
+
+    // Disabled: the same candidate is silently dropped -- no mDNS query.
+    let mut agent = Agent::new(Arc::new(AgentConfig {
+        multicast_dns_mode: crate::mdns::MulticastDnsMode::Disabled,
+        ..Default::default()
+    }))?;
+    agent.add_remote_candidate(unmarshal_candidate(cand_line)?)?;
+    assert!(
+        agent.poll_write().is_none(),
+        "Disabled must not emit an mDNS query for a .local remote candidate"
+    );
+
+    Ok(())
+}

--- a/rtc-mdns/tests/integration_test.rs
+++ b/rtc-mdns/tests/integration_test.rs
@@ -601,3 +601,36 @@ fn test_poll_timeout_scheduling() {
     // but since query is cancelled, it shouldn't affect anything
     assert_eq!(conn.pending_query_count(), 0);
 }
+
+#[test]
+fn test_resolves_safari_style_mdns_candidate() {
+    // Safari and Chrome publish ICE host candidates behind an mDNS name of the
+    // form "<uuid-v4>.local" (draft-ietf-mmusic-mdns-ice-candidates) to avoid
+    // leaking private IPs. A receiving agent must resolve that name to an IP.
+    // This uses a real name captured from Safari 26.5.2, in its exact format.
+    let server_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 42));
+    let server_addr = SocketAddr::new(server_ip, 5353);
+    let safari_name = "61b445d2-6503-41ac-96ce-ee3edac00e9f.local";
+    let config_server = MdnsConfig::default()
+        .with_local_names(vec![safari_name.to_string()])
+        .with_local_ip(server_ip);
+    let mut server = Mdns::new(config_server);
+
+    let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 99)), 5353);
+    let mut client = Mdns::new(MdnsConfig::default());
+
+    let now = Instant::now();
+    let query_id = client.query(safari_name);
+
+    exchange_packets(&mut client, &mut server, client_addr, server_addr, now);
+    exchange_packets(&mut server, &mut client, server_addr, client_addr, now);
+
+    let event = client
+        .poll_event()
+        .expect("Safari-style <uuid>.local candidate must resolve");
+    assert!(
+        matches!(&event, MdnsEvent::QueryAnswered(id, addr) if *id == query_id && *addr == server_ip),
+        "expected QueryAnswered({query_id}, {server_ip}), got {event:?}"
+    );
+    assert!(!client.is_query_pending(query_id));
+}

--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -184,7 +184,13 @@ impl Default for MulticastDNS {
     fn default() -> Self {
         Self {
             timeout: Some(Duration::from_secs(10)),
-            mode: MulticastDnsMode::Disabled, //TODO: Re-enable it to QueryOnly
+            // Safari and Chrome emit only mDNS ("<uuid>.local") host candidates
+            // by default (to avoid leaking private IPs). With Disabled those are
+            // silently dropped, leaving no usable remote candidates from such an
+            // offer; QueryOnly resolves them via mDNS without publishing our own
+            // host IPs as mDNS names. This matches the MulticastDnsMode enum's
+            // own #[default].
+            mode: MulticastDnsMode::QueryOnly,
             local_name: "".to_string(),
             local_ip: None,
         }
@@ -1134,5 +1140,23 @@ impl SettingEngine {
         write_ssrc_attributes_for_simulcast: bool,
     ) {
         self.write_ssrc_attributes_for_simulcast = write_ssrc_attributes_for_simulcast;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression guard for the Safari mDNS interop fix. Safari (and Chrome)
+    // emit only mDNS "<uuid>.local" host candidates by default; a default
+    // SettingEngine must accept and resolve them (QueryOnly), not silently
+    // discard them (Disabled).
+    #[test]
+    fn test_default_multicast_dns_mode_is_query_only() {
+        assert_eq!(MulticastDNS::default().mode, MulticastDnsMode::QueryOnly);
+        assert_eq!(
+            SettingEngine::default().multicast_dns.mode,
+            MulticastDnsMode::QueryOnly
+        );
     }
 }


### PR DESCRIPTION
## Summary

Safari and Chrome, by default, expose ICE host candidates behind an mDNS
`<uuid>.local` hostname instead of a private IP. The candidate parser already
accepts these, but `SettingEngine` defaulted the multicast-DNS mode to
`Disabled` with a `//TODO: Re-enable it to QueryOnly` note.

With `Disabled`, `Agent::add_remote_candidate` logs a warning and returns
`Ok(false)` for every `.local` candidate — they are silently dropped. Against a
default Safari offer, which carries **only** mDNS host candidates, that leaves
the agent with zero usable remote candidates and ICE cannot connect.

This defaults the mode to `QueryOnly` — the value the `MulticastDnsMode` enum's
`#[default]`, `AgentConfig::default`, and the existing `TODO` already prescribe
(and which matches upstream `webrtc`'s default). `QueryOnly` only resolves remote
names via the existing rtc-ice mDNS path; it does not publish our own host IPs as
mDNS names, and it binds no additional socket at agent creation (the sans-io
`Mdns` is pure).

## Test plan

- `cargo test -p rtc` — a guard that the default `SettingEngine`/`MulticastDNS`
  mode is `QueryOnly`.
- `cargo test -p rtc-ice` — a `QueryOnly` agent issues an mDNS query for a
  Safari-style `<uuid>.local` remote candidate (surfaced as an outbound
  `MDNS_PORT` packet), while a `Disabled` agent drops it.
- `cargo test -p rtc-mdns` — an integration test resolves a real Safari 26.5.2
  `<uuid>.local` name to its IP via the sans-io query/answer path.

Verified end-to-end against a real Safari 26.5.2 offer: `rtc-mdns` resolved
Safari's actual `.local` candidate to its LAN IP over the network.

Part of the browser-interoperability work for #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
