### PR TITLE
Fix late DataChannel creation and reliability metadata

### DIFF
--- a/rtc-shared/src/error.rs
+++ b/rtc-shared/src/error.rs
@@ -1252,6 +1252,12 @@ pub enum Error {
     #[error("data channel not existed")]
     ErrDataChannelNotExisted,
 
+    /// The DCEP reliability parameter is a 32-bit wire value, while the
+    /// WebRTC API exposes a 16-bit maximum. Values outside that range cannot
+    /// be represented faithfully.
+    #[error("data channel reliability parameter {0} exceeds 65535")]
+    ErrDataChannelReliabilityParameterTooLarge(u32),
+
     /// ErrCertificateExpired indicates that an x509 certificate has expired.
     #[error("x509Cert expired")]
     ErrCertificateExpired,

--- a/rtc/src/data_channel/internal.rs
+++ b/rtc/src/data_channel/internal.rs
@@ -3,7 +3,7 @@ use crate::data_channel::parameters::DataChannelParameters;
 use crate::data_channel::state::RTCDataChannelState;
 use datachannel::data_channel::DataChannelConfig;
 use sansio::Protocol;
-use sctp::PayloadProtocolIdentifier;
+use sctp::{PayloadProtocolIdentifier, ReliabilityType};
 use shared::error::Result;
 
 #[derive(Clone)]
@@ -102,10 +102,23 @@ impl RTCDataChannelInternal {
 
         let data_channel_config = data_channel.config();
 
-        let (unordered, _reliability_type) =
+        let (unordered, reliability_type) =
             ::datachannel::data_channel::DataChannel::get_reliability_params(
                 data_channel_config.channel_type,
             );
+
+        let reliability_parameter = || {
+            u16::try_from(data_channel_config.reliability_parameter).map_err(|_| {
+                shared::error::Error::ErrDataChannelReliabilityParameterTooLarge(
+                    data_channel_config.reliability_parameter,
+                )
+            })
+        };
+        let (max_packet_life_time, max_retransmits) = match reliability_type {
+            ReliabilityType::Reliable => (None, None),
+            ReliabilityType::Rexmit => (None, Some(reliability_parameter()?)),
+            ReliabilityType::Timed => (Some(reliability_parameter()?), None),
+        };
 
         let mut data_channel_internal = RTCDataChannelInternal::new(
             stream_id,
@@ -113,8 +126,8 @@ impl RTCDataChannelInternal {
                 label: data_channel_config.label.clone(),
                 protocol: data_channel_config.protocol.clone(),
                 ordered: !unordered,
-                max_packet_life_time: None,
-                max_retransmits: None,
+                max_packet_life_time,
+                max_retransmits,
                 negotiated: None,
             },
         );
@@ -129,6 +142,103 @@ impl RTCDataChannelInternal {
             data_channel.close()?;
         }
         self.ready_state = RTCDataChannelState::Closed;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_message(
+        parameters: DataChannelParameters,
+    ) -> Result<datachannel::data_channel::DataChannelMessage> {
+        let mut channel = RTCDataChannelInternal::new(7, parameters);
+        channel.dial(13)?;
+        channel
+            .data_channel
+            .as_mut()
+            .expect("dial must create the data channel")
+            .poll_write()
+            .ok_or(shared::error::Error::ErrDataChannelNotExisted)
+    }
+
+    #[test]
+    fn accept_preserves_max_retransmits_and_ordering() -> Result<()> {
+        let message = open_message(DataChannelParameters {
+            label: "lossy".to_owned(),
+            protocol: "test".to_owned(),
+            ordered: false,
+            max_retransmits: Some(0),
+            ..Default::default()
+        })?;
+
+        let accepted = RTCDataChannelInternal::accept(
+            message.association_handle,
+            message.stream_id,
+            message.ppi,
+            &message.payload,
+        )?;
+
+        assert!(!accepted.ordered);
+        assert_eq!(accepted.max_retransmits, Some(0));
+        assert_eq!(accepted.max_packet_life_time, None);
+        Ok(())
+    }
+
+    #[test]
+    fn accept_preserves_max_packet_life_time() -> Result<()> {
+        let message = open_message(DataChannelParameters {
+            label: "timed".to_owned(),
+            ordered: true,
+            max_packet_life_time: Some(250),
+            ..Default::default()
+        })?;
+
+        let accepted = RTCDataChannelInternal::accept(
+            message.association_handle,
+            message.stream_id,
+            message.ppi,
+            &message.payload,
+        )?;
+
+        assert!(accepted.ordered);
+        assert_eq!(accepted.max_packet_life_time, Some(250));
+        assert_eq!(accepted.max_retransmits, None);
+        Ok(())
+    }
+
+    #[test]
+    fn accept_rejects_unrepresentable_partial_reliability_parameter() -> Result<()> {
+        let mut channel = datachannel::data_channel::DataChannel::dial(
+            DataChannelConfig {
+                channel_type:
+                    datachannel::message::message_channel_open::ChannelType::PartialReliableRexmit,
+                reliability_parameter: u16::MAX as u32 + 1,
+                label: "too-large".to_owned(),
+                ..Default::default()
+            },
+            13,
+            7,
+        )?;
+        let message = channel
+            .poll_write()
+            .ok_or(shared::error::Error::ErrDataChannelNotExisted)?;
+
+        let error = match RTCDataChannelInternal::accept(
+            message.association_handle,
+            message.stream_id,
+            message.ppi,
+            &message.payload,
+        ) {
+            Ok(_) => panic!("a 32-bit DCEP reliability parameter cannot fit the WebRTC API"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            shared::error::Error::ErrDataChannelReliabilityParameterTooLarge(65_536)
+        );
         Ok(())
     }
 }

--- a/rtc/src/peer_connection/handler/datachannel.rs
+++ b/rtc/src/peer_connection/handler/datachannel.rs
@@ -9,6 +9,7 @@ use crate::peer_connection::message::internal::{
 };
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use log::{debug, warn};
+use sansio::Protocol;
 use sctp::PayloadProtocolIdentifier;
 use shared::TransportContext;
 use shared::error::{Error, Result};
@@ -17,6 +18,13 @@ use std::time::Instant;
 
 #[derive(Default)]
 pub(crate) struct DataChannelHandlerContext {
+    /// The SCTP association currently available for opening DataChannels.
+    ///
+    /// A DataChannel may be created after the SCTP handshake has completed. In
+    /// that case no second `SCTPHandshakeComplete` event will arrive, so the
+    /// handler must retain the association handle and dial the new channel
+    /// immediately.
+    pub(crate) association_handle: Option<usize>,
     pub(crate) read_outs: VecDeque<TaggedRTCMessageInternal>,
     pub(crate) write_outs: VecDeque<TaggedRTCMessageInternal>,
     pub(crate) event_outs: VecDeque<RTCEventInternal>,
@@ -45,9 +53,60 @@ impl<'a> DataChannelHandler<'a> {
     pub(crate) fn name(&self) -> &'static str {
         "DataChannelHandler"
     }
+
+    pub(crate) fn open_data_channel(
+        &mut self,
+        data_channel_id: RTCDataChannelId,
+        association_handle: usize,
+    ) -> Result<()> {
+        let data_channel_internal = self
+            .data_channels
+            .get_mut(&data_channel_id)
+            .ok_or(Error::ErrDataChannelNotExisted)?;
+
+        if data_channel_internal.ready_state != RTCDataChannelState::Connecting {
+            return Ok(());
+        }
+
+        data_channel_internal.dial(association_handle)?;
+
+        let data_channel = data_channel_internal
+            .data_channel
+            .as_mut()
+            .ok_or(Error::ErrDataChannelNotExisted)?;
+
+        self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
+            now: Instant::now(),
+            transport: TransportContext::default(),
+            message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(ApplicationMessage {
+                data_channel_id: data_channel_internal.id,
+                data_channel_event: DataChannelEvent::Open,
+            })),
+        });
+
+        self.stats.peer_connection.on_data_channel_opened();
+        self.stats
+            .get_or_create_data_channel(
+                data_channel_internal.id,
+                &data_channel_internal.label,
+                &data_channel_internal.protocol,
+            )
+            .on_state_changed(RTCDataChannelState::Open);
+
+        while let Some(data_channel_message) = data_channel.poll_write() {
+            debug!("send data channel message from open_data_channel");
+            self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
+                now: Instant::now(),
+                transport: TransportContext::default(),
+                message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_channel_message)),
+            });
+        }
+
+        Ok(())
+    }
 }
 
-impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RTCEventInternal>
+impl<'a> Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RTCEventInternal>
     for DataChannelHandler<'a>
 {
     type Rout = TaggedRTCMessageInternal;
@@ -248,47 +307,17 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
     fn handle_event(&mut self, evt: RTCEventInternal) -> Result<()> {
         match evt {
             RTCEventInternal::SCTPHandshakeComplete(association_handle) => {
-                for data_channel_internal in self.data_channels.values_mut() {
-                    if data_channel_internal.ready_state == RTCDataChannelState::Connecting {
-                        data_channel_internal.dial(association_handle)?;
+                self.ctx.association_handle = Some(association_handle);
+                let connecting_ids: Vec<_> = self
+                    .data_channels
+                    .iter()
+                    .filter_map(|(id, data_channel)| {
+                        (data_channel.ready_state == RTCDataChannelState::Connecting).then_some(*id)
+                    })
+                    .collect();
 
-                        let data_channel = data_channel_internal
-                            .data_channel
-                            .as_mut()
-                            .ok_or(Error::ErrDataChannelNotExisted)?;
-
-                        self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                            now: Instant::now(),
-                            transport: TransportContext::default(),
-                            message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
-                                ApplicationMessage {
-                                    data_channel_id: data_channel_internal.id,
-                                    data_channel_event: DataChannelEvent::Open,
-                                },
-                            )),
-                        });
-
-                        // Track data channel opened (initiator side)
-                        self.stats.peer_connection.on_data_channel_opened();
-                        self.stats
-                            .get_or_create_data_channel(
-                                data_channel_internal.id,
-                                &data_channel_internal.label,
-                                &data_channel_internal.protocol,
-                            )
-                            .on_state_changed(RTCDataChannelState::Open);
-
-                        while let Some(data_channel_message) = data_channel.poll_write() {
-                            debug!("send data channel message from handle_event");
-                            self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
-                                now: Instant::now(),
-                                transport: TransportContext::default(),
-                                message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(
-                                    data_channel_message,
-                                )),
-                            });
-                        }
-                    }
+                for data_channel_id in connecting_ids {
+                    self.open_data_channel(data_channel_id, association_handle)?;
                 }
             }
 

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -1832,6 +1832,20 @@ where
 
         self.data_channels.insert(id, data_channel);
 
+        if let Some(association_handle) = self
+            .pipeline_context
+            .datachannel_handler_context
+            .association_handle
+        {
+            let open_result = self
+                .get_datachannel_handler()
+                .open_data_channel(id, association_handle);
+            if let Err(error) = open_result {
+                self.data_channels.remove(&id);
+                return Err(error);
+            }
+        }
+
         self.trigger_negotiation_needed();
 
         Ok(RTCDataChannel {
@@ -2246,5 +2260,51 @@ where
         self.pipeline_context
             .stats
             .snapshot_with_selector(now, selector)
+    }
+}
+
+#[cfg(test)]
+mod data_channel_regression_tests {
+    use super::*;
+    use crate::data_channel::RTCDataChannelState;
+    use crate::peer_connection::event::RTCEventInternal;
+    use sansio::Protocol;
+
+    #[test]
+    fn data_channel_created_after_sctp_handshake_is_opened_immediately() -> Result<()> {
+        let mut peer_connection = RTCPeerConnectionBuilder::new().build()?;
+
+        peer_connection
+            .get_datachannel_handler()
+            .handle_event(RTCEventInternal::SCTPHandshakeComplete(42))?;
+
+        let data_channel_id = {
+            let data_channel = peer_connection.create_data_channel("late-channel", None)?;
+            assert_eq!(data_channel.ready_state(), RTCDataChannelState::Open);
+            data_channel.id()
+        };
+
+        let data_channel = peer_connection
+            .data_channels
+            .get(&data_channel_id)
+            .expect("late-created DataChannel must remain registered");
+        assert!(data_channel.data_channel.is_some());
+        assert_eq!(
+            peer_connection
+                .pipeline_context
+                .datachannel_handler_context
+                .association_handle,
+            Some(42)
+        );
+        assert!(
+            !peer_connection
+                .pipeline_context
+                .datachannel_handler_context
+                .write_outs
+                .is_empty(),
+            "opening the channel must enqueue its DCEP message"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- retain the connected SCTP association in the DataChannel handler
- immediately dial DataChannels created after the SCTP handshake
- preserve received DCEP ordering and partial-reliability parameters
- reject partial-reliability values that cannot be represented by the WebRTC API

Without the retained association, a channel created after connection remains in Connecting forever because no second SCTPHandshakeComplete event is emitted. The accept path also previously discarded the DCEP reliability type and parameter.

## Validation

- cargo fmt --all -- --check
- cargo test -p rtc --lib (171 passed)
- downstream two-peer tests cover post-connect arbitrary labels, text and binary frames, and MaxRetransmits(0)

This is a draft while upstream maintainers review the API/error-shape choices.