### PR TITLE
Negotiate RTX (RFC 4588) by default and de-encapsulate received RTX packets

### DIFF
--- a/rtc/src/peer_connection/configuration/media_engine.rs
+++ b/rtc/src/peer_connection/configuration/media_engine.rs
@@ -398,6 +398,25 @@ impl MediaEngine {
                 parameter: "pli".to_owned(),
             },
         ];
+
+        // RFC 4588 retransmission (RTX) codec. The `apt` (associated payload
+        // type) fmtp parameter points at the primary codec this RTX stream
+        // repairs. Browsers offer an RTX codec for every video codec by default
+        // and drop RTX negotiation for any primary we do not pair one with, so
+        // register one RTX codec per primary video codec (mirroring pion's
+        // RegisterDefaultCodecs). ulpfec is a FEC codec, not a media codec, and
+        // does not get an RTX pairing.
+        let rtx_codec = |payload_type: PayloadType, apt: PayloadType| RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: MIME_TYPE_RTX.to_owned(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: format!("apt={apt}"),
+                rtcp_feedback: vec![],
+            },
+            payload_type,
+        };
+
         for codec in vec![
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
@@ -409,6 +428,7 @@ impl MediaEngine {
                 },
                 payload_type: 96,
             },
+            rtx_codec(97, 96),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_VP9.to_owned(),
@@ -419,6 +439,7 @@ impl MediaEngine {
                 },
                 payload_type: 98,
             },
+            rtx_codec(99, 98),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_VP9.to_owned(),
@@ -429,6 +450,7 @@ impl MediaEngine {
                 },
                 payload_type: 100,
             },
+            rtx_codec(101, 100),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_H264.to_owned(),
@@ -441,6 +463,7 @@ impl MediaEngine {
                 },
                 payload_type: 102,
             },
+            rtx_codec(103, 102),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_H264.to_owned(),
@@ -453,6 +476,7 @@ impl MediaEngine {
                 },
                 payload_type: 127,
             },
+            rtx_codec(104, 127),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_H264.to_owned(),
@@ -465,6 +489,7 @@ impl MediaEngine {
                 },
                 payload_type: 125,
             },
+            rtx_codec(105, 125),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_H264.to_owned(),
@@ -477,6 +502,7 @@ impl MediaEngine {
                 },
                 payload_type: 108,
             },
+            rtx_codec(109, 108),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_H264.to_owned(),
@@ -501,6 +527,7 @@ impl MediaEngine {
                 },
                 payload_type: 123,
             },
+            rtx_codec(124, 123),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_AV1.to_owned(),
@@ -511,6 +538,7 @@ impl MediaEngine {
                 },
                 payload_type: 41,
             },
+            rtx_codec(106, 41),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: MIME_TYPE_HEVC.to_owned(),
@@ -521,6 +549,7 @@ impl MediaEngine {
                 },
                 payload_type: 126,
             },
+            rtx_codec(107, 126),
             RTCRtpCodecParameters {
                 rtp_codec: RTCRtpCodec {
                     mime_type: "video/ulpfec".to_owned(),
@@ -1134,5 +1163,65 @@ impl MediaEngine {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod default_rtx_codec_tests {
+    use super::*;
+    use crate::rtp_transceiver::rtp_sender::rtp_codec::{find_rtx_payload_type, parse_rtx_apt};
+
+    // RFC 4588 / issue #119: register_default_codecs must register a video/rtx
+    // codec (apt=<primary>) for every primary video codec, otherwise browser
+    // RTX offers get dropped during negotiation.
+    #[test]
+    fn default_codecs_register_rtx_for_every_primary() {
+        let mut me = MediaEngine::default();
+        me.register_default_codecs().unwrap();
+
+        let mut primary_payload_types = vec![];
+        let mut rtx_apts = vec![];
+        for codec in &me.video_codecs {
+            if UniCase::new(codec.rtp_codec.mime_type.as_str()) == UniCase::new(MIME_TYPE_RTX) {
+                let apt = parse_rtx_apt(&codec.rtp_codec.sdp_fmtp_line)
+                    .expect("rtx codec must carry an apt= parameter");
+                rtx_apts.push(apt);
+            } else if UniCase::new(codec.rtp_codec.mime_type.as_str())
+                != UniCase::new("video/ulpfec")
+            {
+                // ulpfec is a FEC codec and has no RTX pairing.
+                primary_payload_types.push(codec.payload_type);
+            }
+        }
+
+        assert!(!rtx_apts.is_empty(), "no RTX codecs were registered");
+
+        for pt in &primary_payload_types {
+            assert!(
+                rtx_apts.contains(pt),
+                "primary payload type {pt} has no associated RTX codec (apt={pt})"
+            );
+            // find_rtx_payload_type must locate our RTX pt by its apt.
+            assert!(
+                find_rtx_payload_type(*pt, &me.video_codecs).is_some(),
+                "find_rtx_payload_type failed for primary payload type {pt}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_video_codec_payload_types_are_unique() {
+        let mut me = MediaEngine::default();
+        me.register_default_codecs().unwrap();
+
+        let mut seen = std::collections::HashSet::new();
+        for codec in &me.video_codecs {
+            assert!(
+                seen.insert(codec.payload_type),
+                "duplicate video payload type {} ({})",
+                codec.payload_type,
+                codec.rtp_codec.mime_type
+            );
+        }
     }
 }

--- a/rtc/src/peer_connection/handler/endpoint.rs
+++ b/rtc/src/peer_connection/handler/endpoint.rs
@@ -8,11 +8,16 @@ use crate::peer_connection::message::internal::{
 };
 
 use crate::media_stream::track::MediaStreamTrackId;
-use crate::peer_connection::configuration::media_engine::MediaEngine;
+use crate::peer_connection::configuration::media_engine::{MIME_TYPE_RTX, MediaEngine};
 use crate::peer_connection::event::track_event::{RTCTrackEvent, RTCTrackEventInit};
 use crate::rtp_transceiver::rtp_receiver::internal::RTCRtpReceiverInternal;
-use crate::rtp_transceiver::rtp_sender::{RTCRtpCodingParameters, RTCRtpHeaderExtensionCapability};
-use crate::rtp_transceiver::{RTCRtpReceiverId, SSRC, internal::RTCRtpTransceiverInternal};
+use crate::rtp_transceiver::rtp_sender::rtp_codec::parse_rtx_apt;
+use crate::rtp_transceiver::rtp_sender::{
+    RTCRtpCodecParameters, RTCRtpCodingParameters, RTCRtpHeaderExtensionCapability,
+};
+use crate::rtp_transceiver::{
+    PayloadType, RTCRtpReceiverId, SSRC, internal::RTCRtpTransceiverInternal,
+};
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use interceptor::{Interceptor, Packet};
 use log::{debug, trace, warn};
@@ -162,9 +167,32 @@ where
         &mut self,
         now: Instant,
         transport_context: TransportContext,
-        rtp_packet: rtp::Packet,
+        mut rtp_packet: rtp::Packet,
     ) -> Result<()> {
         debug!("handle_rtp_message {}", transport_context.peer_addr);
+
+        // RFC 4588: if this packet belongs to a retransmission (RTX) stream,
+        // de-encapsulate it back into its primary stream before dispatching.
+        // The RTX payload is `[OSN (2 bytes)][original RTP payload]`; the
+        // recovered packet carries the primary SSRC, the original payload type
+        // (resolved via the RTX codec's `apt=`) and the original sequence number
+        // (OSN), while keeping the timestamp/marker/extensions "as is". RTX
+        // receive statistics are tracked upstream in the interceptor handler
+        // (using the RTX SSRC), so they are not touched here.
+        if let Some((primary_ssrc, primary_payload_type)) =
+            self.rtx_primary_for(rtp_packet.header.ssrc, rtp_packet.header.payload_type)
+        {
+            let recovered = deencapsulate_rtx(&mut rtp_packet, primary_ssrc, primary_payload_type);
+            if !recovered {
+                // RTX packet with no OSN header (e.g. a padding-only bandwidth-probe
+                // packet, RFC 4588 §4): nothing to recover.
+                trace!(
+                    "drop rtx packet ssrc = {} without OSN payload",
+                    rtp_packet.header.ssrc
+                );
+                return Ok(());
+            }
+        }
 
         let ssrc = rtp_packet.header.ssrc;
 
@@ -280,6 +308,31 @@ where
         Ok(())
     }
 
+    /// RFC 4588: resolves a retransmission (RTX) SSRC to the primary stream it repairs.
+    ///
+    /// Returns `(primary_ssrc, primary_payload_type)` when `rtx_ssrc` matches the
+    /// RTX SSRC of one of this endpoint's receive codings (declared via
+    /// `a=ssrc-group:FID <primary> <rtx>` in the remote SDP, RFC 5576). The
+    /// original payload type is resolved from the negotiated RTX codec's `apt=`
+    /// parameter, looked up by the packet's RTX `payload_type`. Returns `None`
+    /// (leaving the packet to be handled as a regular RTP packet) when the SSRC
+    /// is not a known RTX SSRC or the `apt` mapping cannot be resolved.
+    fn rtx_primary_for(
+        &self,
+        rtx_ssrc: SSRC,
+        rtx_payload_type: PayloadType,
+    ) -> Option<(SSRC, PayloadType)> {
+        self.rtp_transceivers.iter().find_map(|transceiver| {
+            let receiver = transceiver.receiver().as_ref()?;
+            resolve_rtx_primary(
+                receiver.get_coding_parameters(),
+                receiver.get_codec_preferences(),
+                rtx_ssrc,
+                rtx_payload_type,
+            )
+        })
+    }
+
     // crosscheck with RTCPeerConnection::start_rtp, since remote tracks(RTCRtpCodingParameters) are added in it
     fn find_track_id(
         &mut self,
@@ -340,7 +393,9 @@ where
                         .get_codec_preferences()
                         .iter()
                         .find(|codec| codec.payload_type == rtp_header.payload_type)
-                //TODO: what about RTX/FEC stream?
+                // RTX packets are de-encapsulated into their primary stream in
+                // handle_rtp_message before reaching here, so payload_type is the
+                // primary codec's. FEC de-encapsulation is still TODO (see #12).
                 {
                     Some(codec.rtp_codec.clone())
                 } else {
@@ -444,7 +499,8 @@ where
                 && let Some(codec) = receiver
                     .get_codec_preferences()
                     .iter()
-                    .find(|codec| codec.payload_type == rtp_header.payload_type) //TODO: what about RTX/FEC stream?
+                    // RTX is de-encapsulated in handle_rtp_message, so payload_type is the primary codec's; FEC is still TODO (#12).
+                    .find(|codec| codec.payload_type == rtp_header.payload_type)
                     .cloned()
             {
                 if !rrid.is_empty() {
@@ -534,7 +590,8 @@ where
                 && let Some(codec) = receiver
                     .get_codec_preferences()
                     .iter()
-                    .find(|codec| codec.payload_type == rtp_header.payload_type) //TODO: what about RTX/FEC stream?
+                    // RTX is de-encapsulated in handle_rtp_message, so payload_type is the primary codec's; FEC is still TODO (#12).
+                    .find(|codec| codec.payload_type == rtp_header.payload_type)
                     .cloned()
             {
                 let receive_codings = vec![RTCRtpCodingParameters {
@@ -647,5 +704,230 @@ where
         };
 
         Some((mid, rid, rrid))
+    }
+}
+
+/// RFC 4588: resolve a single receiver's coding/codec state to the primary
+/// stream that an RTX packet (`rtx_ssrc`, `rtx_payload_type`) repairs.
+///
+/// Returns `(primary_ssrc, primary_payload_type)` when `rtx_ssrc` is the RTX
+/// SSRC of one of `coding_parameters` (declared via `a=ssrc-group:FID <primary>
+/// <rtx>`, RFC 5576) and the original payload type can be resolved from the
+/// matching RTX codec's `apt=` parameter (looked up by `rtx_payload_type`).
+/// Returns `None` when the SSRC is not a known RTX SSRC or the `apt` mapping
+/// cannot be resolved.
+fn resolve_rtx_primary(
+    coding_parameters: &[RTCRtpCodingParameters],
+    codec_preferences: &[RTCRtpCodecParameters],
+    rtx_ssrc: SSRC,
+    rtx_payload_type: PayloadType,
+) -> Option<(SSRC, PayloadType)> {
+    // Associate the RTX SSRC with its primary stream via the FID group recorded
+    // in the coding parameters.
+    let primary_ssrc =
+        coding_parameters
+            .iter()
+            .find_map(|coding| match (&coding.rtx, coding.ssrc) {
+                (Some(rtx), Some(primary_ssrc)) if rtx.ssrc == rtx_ssrc => Some(primary_ssrc),
+                _ => None,
+            })?;
+
+    // Resolve the original payload type from the negotiated RTX codec's `apt=`
+    // parameter.
+    let primary_payload_type = codec_preferences.iter().find_map(|codec| {
+        if codec.payload_type == rtx_payload_type
+            && codec
+                .rtp_codec
+                .mime_type
+                .eq_ignore_ascii_case(MIME_TYPE_RTX)
+        {
+            parse_rtx_apt(&codec.rtp_codec.sdp_fmtp_line)
+        } else {
+            None
+        }
+    })?;
+
+    Some((primary_ssrc, primary_payload_type))
+}
+
+/// RFC 4588 §4: recover the original RTP packet carried inside an RTX packet.
+///
+/// The retransmission payload is `[OSN: u16 big-endian][original RTP payload]`,
+/// where OSN "MUST be set to the sequence number of the associated original RTP
+/// packet" (RFC 4588 §4). On success the packet is rewritten in place to look
+/// like the original: the SSRC becomes `primary_ssrc`, the payload type becomes
+/// `primary_payload_type` (the `apt`), the sequence number becomes the OSN, and
+/// the 2-byte OSN header is stripped from the payload. The timestamp, marker and
+/// CSRC list are already carried "as is" by the RTX packet per RFC 4588 §4 and
+/// are left untouched; any original RTP padding was removed by the sender before
+/// retransmission, so the padding flag is cleared.
+///
+/// Returns `false` without modifying the packet when the payload is shorter than
+/// the 2-byte OSN header (e.g. a padding-only bandwidth-probe packet).
+fn deencapsulate_rtx(
+    packet: &mut rtp::Packet,
+    primary_ssrc: SSRC,
+    primary_payload_type: PayloadType,
+) -> bool {
+    if packet.payload.len() < 2 {
+        return false;
+    }
+
+    let original_sequence_number = u16::from_be_bytes([packet.payload[0], packet.payload[1]]);
+    packet.header.ssrc = primary_ssrc;
+    packet.header.payload_type = primary_payload_type;
+    packet.header.sequence_number = original_sequence_number;
+    packet.header.padding = false;
+    packet.payload = packet.payload.slice(2..);
+
+    true
+}
+
+#[cfg(test)]
+mod rtx_tests {
+    use super::{
+        RTCRtpCodecParameters, RTCRtpCodingParameters, deencapsulate_rtx, resolve_rtx_primary,
+    };
+    use crate::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpRtxParameters};
+    use bytes::Bytes;
+
+    fn coding(primary_ssrc: u32, rtx_ssrc: Option<u32>) -> RTCRtpCodingParameters {
+        RTCRtpCodingParameters {
+            rid: String::new(),
+            ssrc: Some(primary_ssrc),
+            rtx: rtx_ssrc.map(|ssrc| RTCRtpRtxParameters { ssrc }),
+            fec: None,
+        }
+    }
+
+    fn codec(payload_type: u8, mime_type: &str, fmtp: &str) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: mime_type.to_owned(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: fmtp.to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type,
+        }
+    }
+
+    #[test]
+    fn resolves_rtx_ssrc_to_primary_and_apt() {
+        let codings = [coding(1000, Some(2000))];
+        let prefs = [codec(96, "video/VP8", ""), codec(97, "video/rtx", "apt=96")];
+        assert_eq!(
+            resolve_rtx_primary(&codings, &prefs, 2000, 97),
+            Some((1000, 96))
+        );
+    }
+
+    #[test]
+    fn selects_the_correct_primary_among_several_codings() {
+        let codings = [coding(1000, Some(2000)), coding(1001, Some(2001))];
+        let prefs = [
+            codec(97, "video/rtx", "apt=96"),
+            codec(99, "video/rtx", "apt=98"),
+        ];
+        assert_eq!(
+            resolve_rtx_primary(&codings, &prefs, 2001, 99),
+            Some((1001, 98))
+        );
+    }
+
+    #[test]
+    fn unknown_rtx_ssrc_is_not_resolved() {
+        let codings = [coding(1000, Some(2000))];
+        let prefs = [codec(97, "video/rtx", "apt=96")];
+        // 2000 is the only RTX SSRC: an unknown SSRC (9999) and the primary's own
+        // SSRC (1000) must not be mistaken for RTX.
+        assert_eq!(resolve_rtx_primary(&codings, &prefs, 9999, 97), None);
+        assert_eq!(resolve_rtx_primary(&codings, &prefs, 1000, 97), None);
+    }
+
+    #[test]
+    fn coding_without_rtx_pairing_is_not_resolved() {
+        // rid-based / undeclared codings carry no rtx SSRC (rtx: None).
+        let codings = [coding(1000, None)];
+        let prefs = [codec(97, "video/rtx", "apt=96")];
+        assert_eq!(resolve_rtx_primary(&codings, &prefs, 2000, 97), None);
+    }
+
+    #[test]
+    fn missing_or_mismatched_rtx_codec_pref_is_not_resolved() {
+        let codings = [coding(1000, Some(2000))];
+        // No codec preference at the RTX payload type.
+        assert_eq!(resolve_rtx_primary(&codings, &[], 2000, 97), None);
+        // Payload type present but it is not an RTX codec.
+        let non_rtx = [codec(97, "video/VP8", "")];
+        assert_eq!(resolve_rtx_primary(&codings, &non_rtx, 2000, 97), None);
+        // RTX codec present but without a parseable apt.
+        let no_apt = [codec(97, "video/rtx", "")];
+        assert_eq!(resolve_rtx_primary(&codings, &no_apt, 2000, 97), None);
+    }
+
+    // RFC 4588 §4: the RTX payload is [OSN (2 bytes, big-endian)][original payload].
+    #[test]
+    fn deencapsulates_rtx_packet_into_primary() {
+        let mut packet = rtp::Packet {
+            header: rtp::Header {
+                marker: true,
+                payload_type: 97,    // negotiated RTX payload type
+                sequence_number: 42, // RTX stream sequence number (independent)
+                timestamp: 9000,     // already the original timestamp (RFC 4588 §4)
+                ssrc: 0xDEAD_BEEF,   // RTX SSRC
+                padding: true,
+                ..Default::default()
+            },
+            // OSN = 0x1234, followed by the original media payload.
+            payload: Bytes::from(vec![0x12, 0x34, 0xAA, 0xBB, 0xCC]),
+        };
+
+        assert!(deencapsulate_rtx(&mut packet, 0x1111_2222, 96));
+
+        // Rewritten to look like the original primary packet.
+        assert_eq!(packet.header.ssrc, 0x1111_2222);
+        assert_eq!(packet.header.payload_type, 96);
+        assert_eq!(packet.header.sequence_number, 0x1234); // OSN
+        // Kept "as is".
+        assert_eq!(packet.header.timestamp, 9000);
+        assert!(packet.header.marker);
+        // Original padding was removed by the sender before retransmission.
+        assert!(!packet.header.padding);
+        // OSN header stripped, original payload preserved.
+        assert_eq!(&packet.payload[..], &[0xAA, 0xBB, 0xCC]);
+    }
+
+    #[test]
+    fn padding_only_probe_packet_is_left_unchanged() {
+        // A bandwidth-probe RTX packet may carry fewer than 2 payload bytes and
+        // therefore has no OSN to recover.
+        let mut packet = rtp::Packet {
+            header: rtp::Header {
+                payload_type: 97,
+                ssrc: 0xDEAD_BEEF,
+                ..Default::default()
+            },
+            payload: Bytes::from(vec![0x00]),
+        };
+        let before = packet.clone();
+
+        assert!(!deencapsulate_rtx(&mut packet, 0x1111_2222, 96));
+        assert_eq!(packet, before);
+    }
+
+    #[test]
+    fn empty_payload_is_left_unchanged() {
+        let mut packet = rtp::Packet {
+            header: rtp::Header {
+                payload_type: 97,
+                ssrc: 7,
+                ..Default::default()
+            },
+            payload: Bytes::new(),
+        };
+
+        assert!(!deencapsulate_rtx(&mut packet, 1, 96));
     }
 }

--- a/rtc/src/peer_connection/handler/endpoint.rs
+++ b/rtc/src/peer_connection/handler/endpoint.rs
@@ -499,8 +499,7 @@ where
                 && let Some(codec) = receiver
                     .get_codec_preferences()
                     .iter()
-                    // RTX is de-encapsulated in handle_rtp_message, so payload_type is the primary codec's; FEC is still TODO (#12).
-                    .find(|codec| codec.payload_type == rtp_header.payload_type)
+                    .find(|codec| codec.payload_type == rtp_header.payload_type) //TODO: what about RTX/FEC stream?
                     .cloned()
             {
                 if !rrid.is_empty() {
@@ -590,8 +589,7 @@ where
                 && let Some(codec) = receiver
                     .get_codec_preferences()
                     .iter()
-                    // RTX is de-encapsulated in handle_rtp_message, so payload_type is the primary codec's; FEC is still TODO (#12).
-                    .find(|codec| codec.payload_type == rtp_header.payload_type)
+                    .find(|codec| codec.payload_type == rtp_header.payload_type) //TODO: what about RTX/FEC stream?
                     .cloned()
             {
                 let receive_codings = vec![RTCRtpCodingParameters {

--- a/rtc/src/peer_connection/handler/endpoint.rs
+++ b/rtc/src/peer_connection/handler/endpoint.rs
@@ -786,10 +786,20 @@ fn deencapsulate_rtx(
 #[cfg(test)]
 mod rtx_tests {
     use super::{
-        RTCRtpCodecParameters, RTCRtpCodingParameters, deencapsulate_rtx, resolve_rtx_primary,
+        EndpointHandler, EndpointHandlerContext, Instant, Packet, RTCMessageInternal,
+        RTCRtpCodecParameters, RTCRtpCodingParameters, RTCRtpTransceiverInternal, RTPMessage,
+        TrackPacket, TransportContext, deencapsulate_rtx, resolve_rtx_primary,
     };
-    use crate::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpRtxParameters};
+    use crate::media_stream::track::MediaStreamTrack;
+    use crate::peer_connection::configuration::media_engine::MediaEngine;
+    use crate::rtp_transceiver::rtp_sender::{
+        RTCRtpCodec, RTCRtpEncodingParameters, RTCRtpRtxParameters, RtpCodecKind,
+    };
+    use crate::rtp_transceiver::{RTCRtpTransceiverDirection, RTCRtpTransceiverInit};
+    use crate::statistics::accumulator::RTCStatsAccumulator;
     use bytes::Bytes;
+    use interceptor::NoopInterceptor;
+    use shared::TransportProtocol;
 
     fn coding(primary_ssrc: u32, rtx_ssrc: Option<u32>) -> RTCRtpCodingParameters {
         RTCRtpCodingParameters {
@@ -929,5 +939,167 @@ mod rtx_tests {
         };
 
         assert!(!deencapsulate_rtx(&mut packet, 1, 96));
+    }
+
+    // Builds a video receive transceiver whose primary stream is paired with an
+    // RTX stream via the FID group, matching what start_rtp sets up for an
+    // `a=ssrc-group:FID` offer. The primary SSRC already has a (non-empty) codec
+    // so find_track_id resolves it directly.
+    fn rtx_receiver_transceiver(
+        primary_ssrc: u32,
+        rtx_ssrc: u32,
+        primary_pt: u8,
+        rtx_pt: u8,
+    ) -> RTCRtpTransceiverInternal<NoopInterceptor> {
+        let mut transceiver = RTCRtpTransceiverInternal::<NoopInterceptor>::new(
+            RtpCodecKind::Video,
+            None,
+            RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Recvonly,
+                streams: vec![],
+                send_encodings: vec![],
+            },
+        );
+
+        let receiver = transceiver.receiver_mut().as_mut().unwrap();
+        receiver.set_coding_parameters(vec![coding(primary_ssrc, Some(rtx_ssrc))]);
+        receiver.set_codec_preferences(vec![
+            codec(primary_pt, "video/VP8", ""),
+            codec(rtx_pt, "video/rtx", &format!("apt={primary_pt}")),
+        ]);
+        receiver.set_track(MediaStreamTrack::new(
+            "stream".to_string(),
+            "track".to_string(),
+            "label".to_string(),
+            RtpCodecKind::Video,
+            vec![RTCRtpEncodingParameters {
+                rtp_coding_parameters: coding(primary_ssrc, Some(rtx_ssrc)),
+                active: true,
+                codec: RTCRtpCodec {
+                    mime_type: "video/VP8".to_owned(),
+                    clock_rate: 90000,
+                    channels: 0,
+                    sdp_fmtp_line: String::new(),
+                    rtcp_feedback: vec![],
+                },
+                max_bitrate: 0,
+                max_framerate: None,
+                scale_resolution_down_by: None,
+            }],
+        ));
+        transceiver
+    }
+
+    fn test_transport() -> TransportContext {
+        TransportContext {
+            local_addr: "127.0.0.1:5000".parse().unwrap(),
+            peer_addr: "127.0.0.1:5001".parse().unwrap(),
+            transport_protocol: TransportProtocol::UDP,
+            ecn: None,
+        }
+    }
+
+    #[test]
+    fn handle_rtp_message_deencapsulates_and_dispatches_rtx() {
+        let (primary_ssrc, rtx_ssrc, primary_pt, rtx_pt) = (1000u32, 2000u32, 96u8, 97u8);
+        let mut transceivers = vec![rtx_receiver_transceiver(
+            primary_ssrc,
+            rtx_ssrc,
+            primary_pt,
+            rtx_pt,
+        )];
+        let media_engine = MediaEngine::default();
+        let mut interceptor = NoopInterceptor::new();
+        let mut stats = RTCStatsAccumulator::new();
+        let mut ctx = EndpointHandlerContext::default();
+
+        // RTX packet on the RTX SSRC: payload = [OSN=42][media 0xDE 0xAD].
+        let rtx_packet = rtp::Packet {
+            header: rtp::Header {
+                marker: true,
+                payload_type: rtx_pt,
+                sequence_number: 9, // RTX stream sequence number (independent)
+                timestamp: 12_345,
+                ssrc: rtx_ssrc,
+                ..Default::default()
+            },
+            payload: Bytes::from(vec![0x00, 0x2A, 0xDE, 0xAD]),
+        };
+
+        {
+            let mut handler = EndpointHandler::new(
+                &mut ctx,
+                &mut transceivers,
+                &media_engine,
+                &mut interceptor,
+                &mut stats,
+            );
+            handler
+                .handle_rtp_message(Instant::now(), test_transport(), rtx_packet)
+                .expect("handle_rtp_message");
+        }
+
+        // The recovered packet is dispatched on the primary stream, de-encapsulated.
+        let dispatched = ctx
+            .read_outs
+            .pop_front()
+            .expect("a track packet should be dispatched");
+        match dispatched.message {
+            RTCMessageInternal::Rtp(RTPMessage::TrackPacket(TrackPacket {
+                packet: Packet::Rtp(packet),
+                ..
+            })) => {
+                assert_eq!(packet.header.ssrc, primary_ssrc);
+                assert_eq!(packet.header.payload_type, primary_pt);
+                assert_eq!(packet.header.sequence_number, 42); // OSN
+                assert_eq!(packet.header.timestamp, 12_345); // preserved
+                assert!(packet.header.marker); // preserved
+                assert_eq!(&packet.payload[..], &[0xDE, 0xAD]); // OSN stripped
+            }
+            _ => panic!("expected a de-encapsulated RTP TrackPacket on the primary stream"),
+        }
+    }
+
+    #[test]
+    fn handle_rtp_message_drops_rtx_probe_packet() {
+        let (primary_ssrc, rtx_ssrc, primary_pt, rtx_pt) = (1000u32, 2000u32, 96u8, 97u8);
+        let mut transceivers = vec![rtx_receiver_transceiver(
+            primary_ssrc,
+            rtx_ssrc,
+            primary_pt,
+            rtx_pt,
+        )];
+        let media_engine = MediaEngine::default();
+        let mut interceptor = NoopInterceptor::new();
+        let mut stats = RTCStatsAccumulator::new();
+        let mut ctx = EndpointHandlerContext::default();
+
+        // A padding-only probe on the RTX SSRC: payload shorter than the OSN.
+        let probe = rtp::Packet {
+            header: rtp::Header {
+                payload_type: rtx_pt,
+                ssrc: rtx_ssrc,
+                ..Default::default()
+            },
+            payload: Bytes::from(vec![0x00]),
+        };
+
+        {
+            let mut handler = EndpointHandler::new(
+                &mut ctx,
+                &mut transceivers,
+                &media_engine,
+                &mut interceptor,
+                &mut stats,
+            );
+            handler
+                .handle_rtp_message(Instant::now(), test_transport(), probe)
+                .expect("handle_rtp_message");
+        }
+
+        assert!(
+            ctx.read_outs.is_empty(),
+            "an RTX probe packet with no OSN should be dropped, not dispatched"
+        );
     }
 }

--- a/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/rtc/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -211,14 +211,37 @@ pub(crate) fn find_rtx_payload_type(
     needle: PayloadType,
     haystack: &[RTCRtpCodecParameters],
 ) -> Option<PayloadType> {
-    let apt_str = format!("apt={}", needle);
     for c in haystack {
-        if apt_str == c.rtp_codec.sdp_fmtp_line {
+        // Match on the parsed `apt` value rather than the whole fmtp line, so an
+        // RTX codec carrying extra parameters (e.g. `apt=96;rtx-time=3000`, RFC
+        // 4588 §8.1) is still associated with its primary.
+        if parse_rtx_apt(&c.rtp_codec.sdp_fmtp_line) == Some(needle) {
             return Some(c.payload_type);
         }
     }
 
     None
+}
+
+/// Parses the associated payload type (`apt`) from an RTX codec's fmtp line.
+///
+/// RFC 4588 §8.1 defines the `apt` parameter, which maps a retransmission
+/// payload type to the payload type of the stream it repairs. The fmtp line may
+/// carry additional parameters (e.g. `apt=96;rtx-time=3000`), so the value is
+/// extracted from the `apt=` token rather than compared against the whole line.
+///
+/// # Parameters
+///
+/// * `sdp_fmtp_line` - The RTX codec's fmtp line, e.g. `"apt=96"`
+///
+/// # Returns
+///
+/// The associated (primary) payload type if an `apt=` token is present, else None.
+pub(crate) fn parse_rtx_apt(sdp_fmtp_line: &str) -> Option<PayloadType> {
+    sdp_fmtp_line
+        .split(';')
+        .filter_map(|param| param.trim().strip_prefix("apt="))
+        .find_map(|value| value.trim().parse::<PayloadType>().ok())
 }
 
 // For now, only FlexFEC is supported.
@@ -264,4 +287,57 @@ pub(crate) fn rtcp_feedback_intersection(
     }
 
     out
+}
+
+#[cfg(test)]
+mod rtx_apt_tests {
+    use super::{RTCRtpCodec, RTCRtpCodecParameters, find_rtx_payload_type, parse_rtx_apt};
+
+    fn rtx(payload_type: u8, fmtp: &str) -> RTCRtpCodecParameters {
+        RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: "video/rtx".to_owned(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: fmtp.to_owned(),
+                rtcp_feedback: vec![],
+            },
+            payload_type,
+        }
+    }
+
+    #[test]
+    fn find_rtx_payload_type_tolerates_extra_apt_params() {
+        // A remote may append rtx-time to the apt fmtp (RFC 4588 §8.1); the
+        // association must still succeed rather than dropping RTX from the answer.
+        let haystack = vec![rtx(97, "apt=96;rtx-time=3000"), rtx(99, "apt=98")];
+        assert_eq!(find_rtx_payload_type(96, &haystack), Some(97));
+        assert_eq!(find_rtx_payload_type(98, &haystack), Some(99));
+        assert_eq!(find_rtx_payload_type(100, &haystack), None);
+    }
+
+    #[test]
+    fn parses_plain_apt() {
+        assert_eq!(parse_rtx_apt("apt=96"), Some(96));
+        assert_eq!(parse_rtx_apt("apt=127"), Some(127));
+        assert_eq!(parse_rtx_apt("apt=0"), Some(0));
+    }
+
+    #[test]
+    fn parses_apt_with_extra_params() {
+        // RFC 4588 §8.1 allows an optional rtx-time parameter alongside apt.
+        assert_eq!(parse_rtx_apt("apt=96;rtx-time=3000"), Some(96));
+        assert_eq!(parse_rtx_apt("rtx-time=3000;apt=102"), Some(102));
+        assert_eq!(parse_rtx_apt("apt=98 ; rtx-time=1000"), Some(98));
+    }
+
+    #[test]
+    fn returns_none_without_apt() {
+        assert_eq!(parse_rtx_apt(""), None);
+        assert_eq!(parse_rtx_apt("profile-id=0"), None);
+        assert_eq!(parse_rtx_apt("apt="), None);
+        assert_eq!(parse_rtx_apt("apt=notanumber"), None);
+        // Out of the u8 payload-type range.
+        assert_eq!(parse_rtx_apt("apt=300"), None);
+    }
 }

--- a/rtc/tests/codec_negotiation.rs
+++ b/rtc/tests/codec_negotiation.rs
@@ -605,3 +605,79 @@ fn test_add_track_rejects_invalid_rid_mix() {
 
     assert!(matches!(result, Err(Error::ErrRTPSenderRidNil)));
 }
+
+fn default_media_engine() -> MediaEngine {
+    let mut media_engine = MediaEngine::default();
+    media_engine
+        .register_default_codecs()
+        .expect("register default codecs");
+    media_engine
+}
+
+/// RFC 4588 / issue #119: with the default codecs registered, an RTX codec
+/// (`video/rtx`, `apt=<primary>`) must be offered and must survive answer
+/// negotiation instead of being dropped. Before registering default RTX codecs,
+/// the answerer's media engine had no RTX codec to associate with, so RTX was
+/// silently dropped from the answer.
+#[test]
+fn test_default_codecs_negotiate_rtx() {
+    let config = RTCConfigurationBuilder::new().build();
+    let mut offerer = RTCPeerConnectionBuilder::new()
+        .with_configuration(config.clone())
+        .with_media_engine(default_media_engine())
+        .build()
+        .expect("build offerer");
+
+    // A recvonly transceiver with no codec preferences offers the full default
+    // codec set, i.e. every primary video codec and its associated RTX codec.
+    offerer
+        .add_transceiver_from_kind(
+            RtpCodecKind::Video,
+            Some(RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Recvonly,
+                streams: vec![],
+                send_encodings: vec![],
+            }),
+        )
+        .expect("add transceiver from kind");
+
+    let offer = offerer.create_offer(None).expect("create offer");
+    offerer
+        .set_local_description(offer.clone())
+        .expect("set local offer");
+
+    // The offer advertises an RTX codec associated with VP8 (apt=96).
+    assert!(
+        offer.sdp.contains("rtx/90000"),
+        "offer missing rtx rtpmap:\n{}",
+        offer.sdp
+    );
+    assert!(
+        offer.sdp.contains("apt=96"),
+        "offer missing apt=96 fmtp:\n{}",
+        offer.sdp
+    );
+
+    let mut answerer = RTCPeerConnectionBuilder::new()
+        .with_configuration(config)
+        .with_media_engine(default_media_engine())
+        .build()
+        .expect("build answerer");
+
+    answerer
+        .set_remote_description(offer)
+        .expect("set remote offer");
+    let answer = answerer.create_answer(None).expect("create answer");
+
+    // RTX is retained through negotiation rather than dropped from the answer.
+    assert!(
+        answer.sdp.contains("rtx/90000"),
+        "answer missing rtx rtpmap:\n{}",
+        answer.sdp
+    );
+    assert!(
+        answer.sdp.contains("apt=96"),
+        "answer missing apt=96 fmtp:\n{}",
+        answer.sdp
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #119. RTX (RFC 4588) was not negotiated with the default `MediaEngine`, and even when RTX was negotiated the received RTX packets were never de-encapsulated. This PR addresses both gaps.

### Gap 1 — register default RTX codecs

`register_default_codecs` registered no `video/rtx` codecs, so the RTX association step in `set_codec_preferences_from_remote_description` never found a media-engine RTX codec to pair with a remote's offered RTX payload type. As a result RTX was silently dropped from the answer and never negotiated by default, diverging from pion.

This registers a `video/rtx` (`apt=<primary>`) codec for every primary video codec (VP8, VP9, the H264 variants, AV1, HEVC), mirroring pion's `RegisterDefaultCodecs`. The RTX payload types are chosen to not collide with the existing primary payload types; `ulpfec` is a FEC codec and gets no RTX pairing.

### Gap 2 — de-encapsulate received RTX packets

Incoming RTX packets matched no track and were dropped (the three `//TODO: what about RTX/FEC stream?` markers in `endpoint.rs`). `handle_rtp_message` now recovers the original packet before dispatch:

- `resolve_rtx_primary` maps an RTX SSRC to its primary stream via the `a=ssrc-group:FID <primary> <rtx>` group (RFC 5576) recorded in the receive codings, and resolves the original payload type from the negotiated RTX codec's `apt=`.
- `deencapsulate_rtx` rewrites the packet in place per RFC 4588 §4: the 2-octet OSN (the original sequence number) becomes the sequence number, the payload type becomes the `apt`, the SSRC becomes the primary SSRC, and the OSN header is stripped from the payload. Timestamp, marker and CSRC are already carried "as is" by the RTX packet and are left untouched; the padding flag is cleared because the original packet's padding was removed by the sender before retransmission. A padding-only bandwidth-probe packet (payload shorter than the OSN) is dropped.

The recovered packet then flows through normal dispatch, resolving the former RTX TODOs. RTX receive statistics are already tracked in the interceptor handler on the RTX SSRC, so they are not double-counted.

### Supporting change

`find_rtx_payload_type` now parses the `apt` value (new `parse_rtx_apt`) instead of an exact whole-line fmtp comparison, so a remote that appends parameters to `apt` (e.g. `apt=96;rtx-time=3000`, RFC 4588 §8.1) is still associated with its primary codec instead of being dropped during negotiation.

### Not covered (follow-ups)

- rid-based simulcast RTX, whose repair SSRC is not signalled via an FID group, is not de-encapsulated (the common browser unified-plan case, where the FID group is present, is covered).
- FEC de-encapsulation remains a TODO (#12).

## Test plan

The change is split into a series of atomic, independently-building commits.

New tests:
- `parse_rtx_apt` / `find_rtx_payload_type` — parsing and tolerance of `apt=N;rtx-time=M`.
- `resolve_rtx_primary` — SSRC/`apt` association, multi-coding selection, and the not-resolved cases (unknown SSRC, no RTX pairing, missing/mismatched RTX codec preference).
- `deencapsulate_rtx` — OSN recovery of the primary SSRC/payload-type/sequence-number and the short-payload probe case.
- `handle_rtp_message` end-to-end — driving an `EndpointHandler` whose primary stream is FID-paired with an RTX stream: a valid RTX packet is de-encapsulated and dispatched as a `TrackPacket` on the primary SSRC, and a padding-only probe packet is dropped.
- default RTX registration and video payload-type uniqueness.
- integration test `test_default_codecs_negotiate_rtx` — RTX is advertised in the offer and retained in the answer.

`cargo test -p rtc` is green (lib + integration + doctests); `cargo fmt` and `cargo clippy` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
