### PR TITLE
perf(datachannel): zero-copy payload on the SCTP send + receive hot path

### DIFF
--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -143,6 +143,23 @@ impl Stream<'_> {
         self.write_source(&mut BytesChunk::new(p), self.get_default_payload_type()?)
     }
 
+    /// Send an owned [`Bytes`] on the stream with a specific payload protocol.
+    ///
+    /// Unlike [`write_with_ppi`](Self::write_with_ppi), which takes a `&[u8]` and
+    /// must copy it into a freshly allocated buffer, this enqueues the payload
+    /// zero-copy: each fragment is a refcounted slice of `data` (see
+    /// [`BytesChunk`]). Prefer this on the hot send path when the caller already
+    /// owns the payload as `Bytes`.
+    ///
+    /// Returns the number of bytes successfully written.
+    pub fn write_chunk_with_ppi(
+        &mut self,
+        data: &Bytes,
+        ppi: PayloadProtocolIdentifier,
+    ) -> Result<usize> {
+        self.write_source(&mut BytesChunk::new(data), ppi)
+    }
+
     /// Send data on the given stream
     ///
     /// Returns the number of bytes and chunks successfully written.

--- a/rtc-sctp/src/queue/queue_test.rs
+++ b/rtc-sctp/src/queue/queue_test.rs
@@ -478,6 +478,56 @@ fn test_reassembly_queue_ordered_fragments() -> Result<()> {
 }
 
 #[test]
+fn test_reassembly_queue_to_payload() -> Result<()> {
+    // A multi-fragment ordered message: "ABC" + "DEFG" == "ABCDEFG" (7 bytes).
+    let mut rq = ReassemblyQueue::new(0);
+    let org_ppi = PayloadProtocolIdentifier::Binary;
+
+    rq.push(ChunkPayloadData {
+        payload_type: org_ppi,
+        beginning_fragment: true,
+        tsn: 1,
+        stream_sequence_number: 0,
+        user_data: Bytes::from_static(b"ABC"),
+        ..Default::default()
+    });
+    let complete = rq.push(ChunkPayloadData {
+        payload_type: org_ppi,
+        ending_fragment: true,
+        tsn: 2,
+        stream_sequence_number: 0,
+        user_data: Bytes::from_static(b"DEFG"),
+        ..Default::default()
+    });
+    assert!(complete, "chunk set should be complete");
+
+    let chunks = rq.read().expect("a complete message");
+
+    // Ample buffer: all fragments concatenated in order with a single copy.
+    let payload = chunks.to_payload(16)?;
+    assert_eq!(
+        &payload[..],
+        b"ABCDEFG",
+        "to_payload must concatenate fragments in order"
+    );
+
+    // Exact boundary (max_len == total) still succeeds.
+    assert_eq!(
+        &chunks.to_payload(7)?[..],
+        b"ABCDEFG",
+        "max_len == total must succeed"
+    );
+
+    // Too small (max_len < total) is rejected with ErrShortBuffer, matching read().
+    assert!(
+        matches!(chunks.to_payload(6), Err(Error::ErrShortBuffer)),
+        "to_payload must reject oversized messages like read()"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_reassembly_queue_unordered_fragments() -> Result<()> {
     let mut rq = ReassemblyQueue::new(0);
 

--- a/rtc-sctp/src/queue/reassembly_queue.rs
+++ b/rtc-sctp/src/queue/reassembly_queue.rs
@@ -39,6 +39,27 @@ impl Chunks {
         l
     }
 
+    /// Reassemble all fragments into a single freshly-allocated, exactly-sized
+    /// buffer with one copy.
+    ///
+    /// Unlike [`read`](Self::read), this does not round-trip through a
+    /// caller-provided scratch buffer, eliminating one full-payload copy on the
+    /// receive path (the reassembled message would otherwise be copied into the
+    /// scratch buffer and then again into the delivered `BytesMut`). Returns
+    /// [`Error::ErrShortBuffer`] when the message exceeds `max_len`, mirroring
+    /// `read`'s bound so oversized inbound messages are still rejected.
+    pub fn to_payload(&self, max_len: usize) -> Result<BytesMut> {
+        let total = self.len();
+        if total > max_len {
+            return Err(Error::ErrShortBuffer);
+        }
+        let mut buf = BytesMut::with_capacity(total);
+        for c in &self.chunks {
+            buf.extend_from_slice(&c.user_data);
+        }
+        Ok(buf)
+    }
+
     // Concat all fragments into the buffer
     pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
         let mut n_written = 0;

--- a/rtc/src/peer_connection/handler/sctp.rs
+++ b/rtc/src/peer_connection/handler/sctp.rs
@@ -150,15 +150,17 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                             Event::Stream(StreamEvent::Readable { id }) => {
                                 let mut stream = conn.stream(id)?;
                                 while let Some(chunks) = stream.read_sctp()? {
-                                    let n = chunks
-                                        .read(&mut self.ctx.sctp_transport.internal_buffer)?;
+                                    // Reassemble straight into the delivered buffer:
+                                    // one copy instead of the scratch-buffer round-trip
+                                    // (`internal_buffer.len()` preserves the max-message
+                                    // -size bound `read()` enforced via `ErrShortBuffer`).
+                                    let max_len = self.ctx.sctp_transport.internal_buffer.len();
+                                    let payload = chunks.to_payload(max_len)?;
                                     messages.push(SctpMessage::Inbound(DataChannelMessage {
                                         association_handle: ch.0,
                                         stream_id: id,
                                         ppi: chunks.ppi,
-                                        payload: BytesMut::from(
-                                            &self.ctx.sctp_transport.internal_buffer[0..n],
-                                        ),
+                                        payload,
                                         negotiated: false,
                                     }));
                                 }
@@ -251,7 +253,7 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
     }
 
     fn handle_write(&mut self, msg: TaggedRTCMessageInternal) -> Result<()> {
-        if let RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)) = msg.message {
+        if let RTCMessageInternal::Dtls(DTLSMessage::Sctp(mut message)) = msg.message {
             debug!(
                 "send sctp data channel message to {:?}",
                 msg.transport.peer_addr
@@ -337,7 +339,12 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
 
                 let mut stream = conn.stream(message.stream_id)?;
                 if !is_dcep_internal_control_message && stream.is_writable() {
-                    stream.write_with_ppi(&message.payload, message.ppi)?;
+                    // The payload is owned end-to-end (the DataChannel `send` API
+                    // takes the buffer by value), so hand it to SCTP zero-copy:
+                    // `freeze()` is O(1) and the enqueued chunks are refcounted
+                    // slices, eliminating a per-message alloc + full-payload memcpy.
+                    let payload = std::mem::take(&mut message.payload).freeze();
+                    stream.write_chunk_with_ppi(&payload, message.ppi)?;
                 }
 
                 while let Some(x) = conn.poll_transmit(msg.now) {


### PR DESCRIPTION
## Problem

Profiling the data-channel hot path (`examples/data-channels-flow-control`, 1 KB messages) showed the payload being copied more than necessary on both directions:

- **Send:** `dc.send(buf)` → the SCTP handler called `Stream::write_with_ppi(&payload, ppi)`, which wraps the bytes in a `ByteSlice`. `ByteSlice::pop_chunk` does `Bytes::from(slice.to_owned())` — a fresh allocation + full-payload `memcpy` per message. The zero-copy `BytesChunk` source (which yields refcounted `split_to` slices) already existed for exactly this purpose, but the data-channel path didn't use it.
- **Receive:** the SCTP handler reassembled each inbound message with `Chunks::read(&mut internal_buffer)` (copy #1, into a scratch buffer) and then `BytesMut::from(&internal_buffer[..n])` (copy #2, into the delivered buffer) — two copies where one suffices.

## Fix

- **Send** — new `Stream::write_chunk_with_ppi(&Bytes, ppi)` (sibling of the existing `write_chunk`, but takes an explicit PPI). The handler now freezes the owned payload (`std::mem::take(&mut message.payload).freeze()` — `BytesMut::freeze` is O(1)) and enqueues it zero-copy. The payload is owned end-to-end (the `DataChannel::send` API takes the buffer by value), so this is safe: the enqueued chunks are refcounted slices of the same buffer, retained until acked exactly as before.
- **Receive** — new `Chunks::to_payload(max_len) -> Result<BytesMut>` reassembles all fragments into a single exactly-sized `BytesMut` with **one** copy, skipping the scratch-buffer round-trip. `max_len` (= `internal_buffer.len()`, i.e. `max_message_size`) preserves the `ErrShortBuffer` bound `read()` enforced, so oversized inbound messages are still rejected at the same threshold.

Net: send goes from 1 alloc + 1 full-payload `memcpy` to 0 (zero-copy enqueue); receive goes from 2 copies to 1. No public API change (`RTCDataChannelMessage.data` stays `BytesMut`).

## Correctness

- `BytesChunk::pop_chunk` fragments identically to `ByteSlice::pop_chunk` (same `limit` = `max_payload_size` logic in `write_source`), so wire output / fragmentation / PPI / ordering are unchanged.
- `to_payload` concatenates `self.chunks` in the same order as `read()`, `with_capacity(self.len())` is exact (no realloc), and the `total > max_len` guard runs before allocation.
- The `internal_buffer` is still used for the outbound size check, so it isn't removed.

## Testing / measurement

- Tests pass: `rtc-sctp` **116** (adds a `to_payload` unit test covering multi-fragment concatenation, the exact-size boundary, and oversized→`ErrShortBuffer` rejection), `rtc-datachannel` 27, `rtc` lib 167. `cargo fmt` + `clippy` clean. The `test_assoc_reliable_ordered_fragmented*` / `unordered_fragmented*` / `unreliable_rexmit_*fragment*` endpoint tests exercise the multi-fragment send path (`write_chunk_with_ppi` has a body identical to the already-tested `write_sctp`).
- perf (frame-pointer build): the send-side `write_with_ppi`/`to_owned` `memcpy` **disappears** from the profile (was ~0.4% of self-time); receive reassembly drops from two copies to one.
- Throughput: this is a per-message CPU/allocation win. On the 1 KB single-connection loopback (latency-bound) it's below the noise floor; on a CPU-bound N=8 parallel run it's ~+1% aggregate. The benefit scales with message size (large messages fragment into many chunks, each previously copied twice on receive).
