### PR TITLE
Allow targetting wasm32-wasip2

### DIFF
--- a/rtc-mdns/Cargo.toml
+++ b/rtc-mdns/Cargo.toml
@@ -17,7 +17,7 @@ sansio.workspace = true
 
 bytes.workspace = true
 log.workspace = true
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/rtc-shared/src/ifaces/ffi/mod.rs
+++ b/rtc-shared/src/ifaces/ffi/mod.rs
@@ -7,3 +7,11 @@ pub use self::windows::ifaces;
 mod unix;
 #[cfg(target_family = "unix")]
 pub use self::unix::ifaces;
+
+#[cfg(not(any(target_family = "windows", target_family = "unix")))]
+pub fn ifaces() -> Result<Vec<super::Interface>, std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "ifaces is not supported on this platform",
+    ))
+}


### PR DESCRIPTION
This required two changes:

- Add a fallback `rtc_shared::ifaces::ifaces` for non-Unix, non-Windows platforms (which always returns an Error)
- Upgrade socket2 to 0.6 for https://github.com/rust-lang/socket2/pull/639