### PR TITLE
feat(sctp,datachannel): plumb per-stream released-bytes for send back-pressure

### DIFF
--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -1310,6 +1310,18 @@ impl Association {
         }
 
         for (si, n_bytes_acked) in &bytes_acked_per_stream {
+            if *n_bytes_acked > 0 {
+                // Report the exact bytes released for this stream (acknowledged OR
+                // abandoned — both funnel through bytes_acked_per_stream) so upper
+                // layers can decrement their own send-buffer accounting. Unlike the
+                // edge-triggered BufferedAmountLow advisory below, this fires on
+                // every release with the byte delta.
+                self.events
+                    .push_back(Event::Stream(StreamEvent::BufferedAmountReleased {
+                        id: *si,
+                        n_bytes: *n_bytes_acked as usize,
+                    }));
+            }
             if let Some(s) = self.streams.get_mut(si)
                 && s.on_buffer_released(*n_bytes_acked)
             {

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -83,6 +83,7 @@ pub enum AssociationError {
 
 /// Events of interest to the application
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Event {
     /// Handshake was failed
     HandshakeFailed {

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -54,6 +54,17 @@ pub enum StreamEvent {
         /// Which stream is now readable
         id: StreamId,
     },
+    /// Outgoing buffered data was released (acknowledged OR abandoned), carrying
+    /// the exact number of user payload bytes freed for this stream. Unlike the
+    /// edge-triggered [`StreamEvent::BufferedAmountLow`], this fires on every
+    /// release with the byte delta, so upper layers can keep their own
+    /// send-buffer accounting (e.g. a synchronous back-pressure counter) exact.
+    BufferedAmountReleased {
+        /// Which stream released buffered bytes
+        id: StreamId,
+        /// User payload bytes released
+        n_bytes: usize,
+    },
 }
 
 /// Reliability type for stream

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -15,6 +15,7 @@ pub type StreamId = u16;
 
 /// Application events about streams
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StreamEvent {
     /// One or more new streams has been opened
     Opened { id: StreamId },

--- a/rtc-shared/src/error.rs
+++ b/rtc-shared/src/error.rs
@@ -1252,6 +1252,12 @@ pub enum Error {
     #[error("data channel not existed")]
     ErrDataChannelNotExisted,
 
+    /// ErrSendBufferFull indicates that a data-channel send was rejected because
+    /// the channel's outstanding send buffer exceeded the configured hard ceiling
+    /// (back-pressure). Retry after the buffer drains (e.g. on OnBufferedAmountLow).
+    #[error("data channel send buffer full")]
+    ErrSendBufferFull,
+
     /// ErrCertificateExpired indicates that an x509 certificate has expired.
     #[error("x509Cert expired")]
     ErrCertificateExpired,

--- a/rtc/src/data_channel/internal.rs
+++ b/rtc/src/data_channel/internal.rs
@@ -18,6 +18,13 @@ pub(crate) struct RTCDataChannelInternal {
     pub(crate) ready_state: RTCDataChannelState,
     pub(crate) buffered_amount_high_threshold: u32,
     pub(crate) buffered_amount_low_threshold: u32,
+    /// User payload bytes handed to `send()`/`send_text()` that SCTP has not yet
+    /// released (acknowledged or abandoned). Incremented synchronously at the app
+    /// send boundary and decremented on SCTP buffer-release events, so it accounts
+    /// for bytes still in the app→core→SCTP send pipeline — not just the SCTP
+    /// stream's own `buffered_amount`, which counts only post-packetization. Used
+    /// for synchronous send back-pressure.
+    pub(crate) outstanding_bytes: usize,
 
     pub(crate) data_channel: Option<::datachannel::data_channel::DataChannel>,
 }
@@ -35,6 +42,7 @@ impl Default for RTCDataChannelInternal {
             ready_state: RTCDataChannelState::default(),
             buffered_amount_high_threshold: u32::MAX,
             buffered_amount_low_threshold: 0,
+            outstanding_bytes: 0,
             data_channel: None,
         }
     }
@@ -54,6 +62,7 @@ impl RTCDataChannelInternal {
             ready_state: RTCDataChannelState::Connecting,
             buffered_amount_high_threshold: u32::MAX,
             buffered_amount_low_threshold: 0,
+            outstanding_bytes: 0,
             data_channel: None,
         }
     }

--- a/rtc/src/data_channel/mod.rs
+++ b/rtc/src/data_channel/mod.rs
@@ -243,34 +243,59 @@ where
 
     /// send sends the binary message to the DataChannel peer
     pub fn send(&mut self, data: BytesMut) -> Result<()> {
-        if self.peer_connection.data_channels.contains_key(&self.id) {
-            self.peer_connection
-                .handle_write(RTCMessage::DataChannelMessage(
-                    self.id,
-                    RTCDataChannelMessage {
-                        is_string: false,
-                        data,
-                    },
-                ))
-        } else {
-            Err(Error::ErrDataChannelClosed)
+        if !self.peer_connection.data_channels.contains_key(&self.id) {
+            return Err(Error::ErrDataChannelClosed);
         }
+        let data_len = data.len();
+        self.peer_connection
+            .handle_write(RTCMessage::DataChannelMessage(
+                self.id,
+                RTCDataChannelMessage {
+                    is_string: false,
+                    data,
+                },
+            ))?;
+        // Count only after a successful enqueue, so a failed send never leaks the
+        // counter upward (those bytes never entered the SCTP send pipeline). This
+        // is the synchronous send-boundary accounting used for back-pressure.
+        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.id) {
+            dc.outstanding_bytes += data_len;
+        }
+        Ok(())
     }
 
     /// send_text sends the text message to the DataChannel peer
     pub fn send_text(&mut self, s: impl Into<String>) -> Result<()> {
-        if self.peer_connection.data_channels.contains_key(&self.id) {
-            self.peer_connection
-                .handle_write(RTCMessage::DataChannelMessage(
-                    self.id,
-                    RTCDataChannelMessage {
-                        is_string: true,
-                        data: BytesMut::from(s.into().as_str()),
-                    },
-                ))
-        } else {
-            Err(Error::ErrDataChannelClosed)
+        if !self.peer_connection.data_channels.contains_key(&self.id) {
+            return Err(Error::ErrDataChannelClosed);
         }
+        let data = BytesMut::from(s.into().as_str());
+        let data_len = data.len();
+        self.peer_connection
+            .handle_write(RTCMessage::DataChannelMessage(
+                self.id,
+                RTCDataChannelMessage {
+                    is_string: true,
+                    data,
+                },
+            ))?;
+        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.id) {
+            dc.outstanding_bytes += data_len;
+        }
+        Ok(())
+    }
+
+    /// Bytes handed to [`send`](Self::send)/[`send_text`](Self::send_text) that
+    /// SCTP has not yet released (acknowledged or abandoned) — the true amount of
+    /// outstanding send-side memory for this channel, including bytes still queued
+    /// in the app→core→SCTP pipeline (the SCTP stream's own `buffered_amount`
+    /// counts only post-packetization). Used for synchronous send back-pressure.
+    pub fn outstanding_bytes(&self) -> usize {
+        self.peer_connection
+            .data_channels
+            .get(&self.id)
+            .map(|dc| dc.outstanding_bytes)
+            .unwrap_or(0)
     }
 
     /// Closes the data channel.

--- a/rtc/src/peer_connection/event/mod.rs
+++ b/rtc/src/peer_connection/event/mod.rs
@@ -551,4 +551,17 @@ pub(crate) enum RTCEventInternal {
     /// - Association handle
     /// - Stream ID
     SCTPStreamClosed(usize /*AssociationHandle*/, u16 /*StreamID*/),
+
+    /// SCTP released outgoing buffered bytes (acknowledged or abandoned) for a
+    /// stream, used to decrement the per-channel send back-pressure counter.
+    ///
+    /// Parameters:
+    /// - Association handle
+    /// - Stream ID
+    /// - Bytes released
+    SCTPBufferReleased(
+        usize, /*AssociationHandle*/
+        u16,   /*StreamID*/
+        usize, /*n_bytes*/
+    ),
 }

--- a/rtc/src/peer_connection/handler/datachannel.rs
+++ b/rtc/src/peer_connection/handler/datachannel.rs
@@ -309,6 +309,14 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                         ));
                 }
             }
+            RTCEventInternal::SCTPBufferReleased(_association_handle, stream_id, n_bytes) => {
+                // Pure accounting: SCTP released (acked or abandoned) `n_bytes` of
+                // this channel's outgoing buffer. Decrement the synchronous send
+                // back-pressure counter; do NOT forward the event further.
+                if let Some(dc) = self.data_channels.get_mut(&stream_id) {
+                    dc.outstanding_bytes = dc.outstanding_bytes.saturating_sub(n_bytes);
+                }
+            }
             _ => {
                 self.ctx.event_outs.push_back(evt);
             }

--- a/rtc/src/peer_connection/handler/sctp.rs
+++ b/rtc/src/peer_connection/handler/sctp.rs
@@ -228,6 +228,14 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
                                     ),
                                 );
                             }
+                            Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) => {
+                                // Forward the exact released byte count so the data
+                                // channel handler can decrement its synchronous
+                                // send back-pressure counter (see DataChannelHandler).
+                                self.ctx.event_outs.push_back(
+                                    RTCEventInternal::SCTPBufferReleased(ch.0, id, n_bytes),
+                                );
+                            }
                             _ => {}
                         }
                     }

--- a/rtc/tests/data_channels_negotiated_rtc2rtc.rs
+++ b/rtc/tests/data_channels_negotiated_rtc2rtc.rs
@@ -338,3 +338,209 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
 
     Ok(())
 }
+
+/// Exercises the synchronous `outstanding_bytes` send-back-pressure counter at the
+/// rtc layer (the accounting the superproject's `DataChannel::send` gate reads):
+/// `RTCDataChannel::send` increments it by the payload size at the send boundary,
+/// and it drains back to zero once SCTP acknowledges the bytes. Uses the same
+/// negotiated rtc2rtc harness so the whole send→ack→release cycle is real.
+#[tokio::test]
+async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let mut runner = PeerRunner::new().await?;
+
+    let init = RTCDataChannelInit {
+        ordered: true,
+        negotiated: Some(NEGOTIATED_ID),
+        ..Default::default()
+    };
+    runner
+        .offer_pc
+        .create_data_channel("negotiated", Some(init.clone()))?;
+    runner
+        .answer_pc
+        .create_data_channel("negotiated", Some(init))?;
+
+    let offer = runner.offer_pc.create_offer(None)?;
+    runner.offer_pc.set_local_description(offer.clone())?;
+    runner.answer_pc.set_remote_description(offer)?;
+    let answer = runner.answer_pc.create_answer(None)?;
+    runner.answer_pc.set_local_description(answer.clone())?;
+    runner.offer_pc.set_remote_description(answer)?;
+
+    const PAYLOAD: usize = 4096;
+    let mut offer_connected = false;
+    let mut answer_connected = false;
+    let mut offer_dc_open = false;
+    let mut answer_dc_open = false;
+    let mut sent = false;
+    let mut received = 0usize;
+    let mut peak_outstanding = 0usize;
+    let mut drained = false;
+
+    let mut offer_buf = vec![0u8; 2000];
+    let mut answer_buf = vec![0u8; 2000];
+
+    let start_time = Instant::now();
+    let test_timeout = Duration::from_secs(30);
+
+    while start_time.elapsed() < test_timeout {
+        while let Some(msg) = runner.offer_pc.poll_write() {
+            runner
+                .offer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+        while let Some(event) = runner.offer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => offer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
+                    assert_eq!(id, NEGOTIATED_ID);
+                    offer_dc_open = true;
+                }
+                _ => {}
+            }
+        }
+        // The offerer is the sender in this test; drain any reads so rwnd stays open.
+        while runner.offer_pc.poll_read().is_some() {}
+
+        while let Some(msg) = runner.answer_pc.poll_write() {
+            runner
+                .answer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+        while let Some(event) = runner.answer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => answer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
+                    assert_eq!(id, NEGOTIATED_ID);
+                    answer_dc_open = true;
+                }
+                _ => {}
+            }
+        }
+        while let Some(RTCMessage::DataChannelMessage(id, msg)) = runner.answer_pc.poll_read() {
+            assert_eq!(id, NEGOTIATED_ID);
+            received += msg.data.len();
+        }
+
+        // Once the channel is open, send one binary payload and assert the counter
+        // jumps by exactly the payload size synchronously at the send boundary.
+        if offer_connected && offer_dc_open && !sent {
+            let mut dc = runner
+                .offer_pc
+                .data_channel(NEGOTIATED_ID)
+                .expect("negotiated channel must exist once open");
+            assert_eq!(
+                dc.outstanding_bytes(),
+                0,
+                "outstanding_bytes must start at zero"
+            );
+            dc.send(BytesMut::from(&vec![7u8; PAYLOAD][..]))?;
+            assert_eq!(
+                dc.outstanding_bytes(),
+                PAYLOAD,
+                "outstanding_bytes must increment by the payload size at send()"
+            );
+            sent = true;
+        }
+
+        // After sending, watch the counter drain back to zero as SCTP acks the bytes.
+        if sent {
+            let outstanding = runner
+                .offer_pc
+                .data_channel(NEGOTIATED_ID)
+                .map(|dc| dc.outstanding_bytes())
+                .unwrap_or(0);
+            peak_outstanding = peak_outstanding.max(outstanding);
+            if outstanding == 0 && received >= PAYLOAD {
+                drained = true;
+                break;
+            }
+        }
+
+        let offer_timeout = runner
+            .offer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + DEFAULT_TIMEOUT_DURATION);
+        let answer_timeout = runner
+            .answer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + DEFAULT_TIMEOUT_DURATION);
+        let next_timeout = offer_timeout.min(answer_timeout);
+        let delay = next_timeout
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+
+        if delay.is_zero() {
+            runner.offer_pc.handle_timeout(Instant::now()).ok();
+            runner.answer_pc.handle_timeout(Instant::now()).ok();
+            continue;
+        }
+
+        let sleep = tokio::time::sleep(delay);
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            _ = sleep => {
+                runner.offer_pc.handle_timeout(Instant::now()).ok();
+                runner.answer_pc.handle_timeout(Instant::now()).ok();
+            }
+            Ok((n, peer_addr)) = runner.offer_socket.recv_from(&mut offer_buf) => {
+                runner.offer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: runner.offer_local_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&offer_buf[..n]),
+                }).ok();
+            }
+            Ok((n, peer_addr)) = runner.answer_socket.recv_from(&mut answer_buf) => {
+                runner.answer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: runner.answer_local_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&answer_buf[..n]),
+                }).ok();
+            }
+        }
+    }
+
+    assert!(offer_connected && answer_connected, "peers should connect");
+    assert!(offer_dc_open && answer_dc_open, "channels should open");
+    assert!(sent, "should have sent the binary payload");
+    assert_eq!(
+        received, PAYLOAD,
+        "answer should receive the whole binary payload"
+    );
+    assert!(
+        peak_outstanding >= PAYLOAD,
+        "counter should have reflected the in-flight payload (peak={peak_outstanding})"
+    );
+    assert!(
+        drained,
+        "outstanding_bytes should drain to 0 after SCTP acks (peak={peak_outstanding})"
+    );
+
+    runner.offer_pc.close()?;
+    runner.answer_pc.close()?;
+
+    Ok(())
+}


### PR DESCRIPTION
# PR 1 (webrtc-rs/**rtc**) — feat(sctp,datachannel): plumb per-stream released-bytes for send back-pressure

> **Base PR of a two-PR set.** The companion **webrtc** PR depends on this one (cross-linked
> below). **Merge this first.**
>
> Branch: `fix-datachannel-send-backpressure` · 2 commits on top of `origin/master`.

## This is PR 1 of 2 (send back-pressure)

Send back-pressure spans both repos of the sans-io stack. This PR is the **base**.

```
  PR 1  webrtc-rs/rtc      ── the sans-io core: the released-byte event +
  (this PR)  ─ merge first     the outstanding_bytes counter
       │
       │  depended on by
       ▼
  PR 2  webrtc-rs/webrtc   ── the send() gate + tests + benches;
                              bumps the rtc submodule to this PR
```

**PR 2 (webrtc) depends on this PR.** Merge this one first; PR 2's submodule bump is finalised
once this lands. Combined breaking-change summary for the set:

| PR | Breaking? | What |
|----|-----------|------|
| **PR 1 (this, rtc)** | **Yes — one-time source break** | `rtc-sctp`'s public `StreamEvent` and `Event` enums become `#[non_exhaustive]`; downstream exhaustive `match`es must add `_ => {}`. |
| PR 2 (webrtc) | No | new `DataChannel::outstanding_bytes()` has a default body; env vars + error mapping are additive. |

## Summary

The webrtc-rs data-channel **send** path has no synchronous back-pressure: `dc.send()` pushes
into unbounded queues, and SCTP's `pending_queue` is filled unconditionally. So a fast producer
against a **slow reactor** or a **slow/malicious peer** (advertising a tiny receive window) grows
send-side memory without bound — measured at ~7× the payload (~117 MB/connection for a 16 MB
transfer), i.e. a memory-exhaustion / DoS vector. Bounding it requires the sender to know how many
bytes it currently has *in flight* (queued but not yet acknowledged or abandoned by SCTP).

This PR adds exactly that signal to the **sans-io core**. It is inert on its own — the gate that
consumes the signal lives in the companion **webrtc** PR, which bumps the `rtc` submodule to this
branch.

## What this PR adds

**rtc-sctp**
- `StreamEvent::BufferedAmountReleased { id, n_bytes }` — emitted whenever outgoing buffered data
  is released (**acknowledged _or_ abandoned** — both funnel through `bytes_acked_per_stream`),
  carrying the exact user-payload bytes freed for that stream. Unlike the edge-triggered
  `BufferedAmountLow` advisory, it fires on **every** release with the byte delta.
- The SACK-processing loop emits it for each stream with `n_bytes_acked > 0`, using the **same**
  `n_bytes_acked` that already feeds the existing `on_buffer_released` (`buffered_amount`) decrement
  one line below.
- `StreamEvent` and its parent `Event` are marked `#[non_exhaustive]` (see Breaking changes).

**rtc-shared**
- `Error::ErrSendBufferFull` — the error the gate returns when the hard ceiling is exceeded.
  (`rtc-shared::Error` is already `#[non_exhaustive]`, so this addition is not breaking.)

**rtc**
- `RTCDataChannel::outstanding_bytes()` — an **inherent** getter (additive) over a new internal
  `outstanding_bytes` counter, incremented after a successful `send()`/`send_text()`.
- `RTCEventInternal::SCTPBufferReleased(assoc, stream, n_bytes)` plumbing: the SCTP handler
  translates `BufferedAmountReleased` → `SCTPBufferReleased`; the data-channel handler decrements
  the per-channel counter (`saturating_sub`).

```
 rtc-sctp/src/association/mod.rs                | 13 +++++
 rtc-sctp/src/association/stream.rs             | 12 +++++
 rtc-shared/src/error.rs                        |  6 +++
 rtc/src/data_channel/internal.rs               |  9 ++++
 rtc/src/data_channel/mod.rs                    | 69 ++++++++++++++++++--------
 rtc/src/peer_connection/event/mod.rs           | 13 +++++
 rtc/src/peer_connection/handler/datachannel.rs |  8 +++
 rtc/src/peer_connection/handler/sctp.rs        |  8 +++
 8 files changed, 116 insertions(+), 22 deletions(-)
```

Commits:
- `e86316b` feat(sctp,datachannel): plumb per-stream released-bytes for send back-pressure
- `4cb9f34` refactor(sctp): mark StreamEvent and Event #[non_exhaustive]

## Design / correctness

The new counter is a **mirror of the proven `buffered_amount` accounting**, not a parallel
mechanism. `on_buffer_released` has exactly one call site (the SACK loop), and `buffered_amount`
is released only through `bytes_acked_per_stream`, which sums acked bytes in **both** the
cumulative-ack pop and the gap-ack paths; abandoned / `max_retransmits:0` bytes funnel through the
same cumulative-ack advance after a forward-TSN. `BufferedAmountReleased` reuses the identical
`n_bytes_acked` values, so it releases exactly the same deltas. The only difference from
`buffered_amount` is **increment timing**: the consumer increments at `send()` (pre-packetization)
while `buffered_amount` increments at packetize time — both track user-payload bytes, so the
release side is byte-for-byte identical.

The decrement on the consumer side is `saturating_sub`, so any accounting skew can only drive the
counter **downward** (toward "less outstanding"), never wedge a sender by over-counting.

## ⚠️ Breaking changes

**`rtc-sctp::StreamEvent` and `rtc-sctp::Event` are now `#[non_exhaustive]`.**
A downstream crate that consumes `Association::poll()` and `match`es either enum **exhaustively**
(no `_ =>` arm) will fail to compile after this change and must add a wildcard arm:

```rust
match stream_event {
    StreamEvent::Readable { .. } => { /* ... */ }
    // ... existing variants ...
    _ => {}                     // <-- now required
}
```

This one-time break is deliberate: adding the `BufferedAmountReleased` variant to a
non-`#[non_exhaustive]` enum would *itself* be a source break, and every future variant would be
too. Marking the enums `#[non_exhaustive]` pays the cost once and makes all future additions
non-breaking. The sole in-tree consumer (the `rtc` crate) already has a `_ => {}` arm, so this is
inert within the workspace and only affects external direct consumers of `rtc-sctp`.

**Not breaking:**
- `Error::ErrSendBufferFull` — `rtc-shared::Error` is already `#[non_exhaustive]`.
- `RTCDataChannel::outstanding_bytes()` — an inherent method on a concrete type (additive).
- The `BufferedAmountReleased` variant itself — covered by the `#[non_exhaustive]` marker above.

Both crates are at `0.20.0-rc.x`, so a source break in a pre-release is low-impact.

## Dependency

This is the **base** PR. The companion **webrtc** PR (`02-webrtc-send-backpressure.md`) depends on
it: that PR's send gate calls `outstanding_bytes()`, matches on `BufferedAmountReleased`, and bumps
the `rtc` submodule pointer to this branch. It does **not** compile against `rtc` master.

## Tests

- `rtc-sctp` **116** unit tests, `rtc` **246** tests — all pass.
- `cargo fmt --check` + `cargo clippy` clean on the changed files.
- Runtime-agnostic (sans-io core); the end-to-end proof (peak-RSS A/B, conservation) lives in the
  webrtc PR, which exercises this plumbing.
