### PR TITLE
feat(peer-connection): configurable SCTP receive-buffer size (a_rwnd)

### DIFF
--- a/rtc/src/peer_connection/configuration/setting_engine.rs
+++ b/rtc/src/peer_connection/configuration/setting_engine.rs
@@ -350,6 +350,9 @@ pub struct SettingEngine {
     pub(crate) mid_generator: Option<Arc<dyn Fn(isize) -> String + Send + Sync>>,
     /// Determines the max size of any message that may be sent through an SCTP transport.
     pub(crate) sctp_max_message_size: SctpMaxMessageSize,
+    /// Overrides the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes.
+    /// `None` uses the rtc-sctp default (`INITIAL_RECV_BUF_SIZE`, 1 MiB).
+    pub(crate) sctp_max_receive_buffer_size: Option<u32>,
     pub(crate) ignore_rid_pause_for_recv: bool,
     pub(crate) write_ssrc_attributes_for_simulcast: bool,
 }
@@ -1116,6 +1119,40 @@ impl SettingEngine {
     /// - [RFC 8841 §6.1 - max-message-size](https://datatracker.ietf.org/doc/html/rfc8841#section-6.1)
     pub fn set_sctp_max_message_size(&mut self, max_message_size: SctpMaxMessageSize) {
         self.sctp_max_message_size = max_message_size;
+    }
+
+    /// Overrides the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes.
+    ///
+    /// This bounds how much unacknowledged data a peer may have in flight toward this
+    /// endpoint — a bandwidth-delay-product ceiling. Lowering it reduces per-connection
+    /// memory (the buffer fills only under load), which matters for servers holding many
+    /// connections; but a smaller window can throttle throughput on high-latency,
+    /// high-bandwidth paths, where more data must be in flight to keep the pipe full.
+    ///
+    /// **Bounds.** RFC 4960 §6 requires an advertised initial a_rwnd of at least **1500
+    /// bytes**; smaller values (including `0`) are raised to that floor here, because a
+    /// sub-1500 window makes the peer reject this endpoint's INIT/INIT-ACK and the SCTP
+    /// association never establishes. The window should also be **≥ the largest SCTP
+    /// message this endpoint will receive** ([`set_sctp_max_message_size`], default
+    /// 64 KiB): a buffer smaller than one message cannot hold it for reassembly, so a
+    /// full-size inbound message would stall that receive direction. `0` here is *not*
+    /// "unbounded" (unlike some other knobs) — to keep the default window, leave this
+    /// unset (the default is `INITIAL_RECV_BUF_SIZE`, 1 MiB).
+    pub fn set_sctp_max_receive_buffer_size(&mut self, size: u32) {
+        // RFC 4960 §6 (User Data Transfer) forbids advertising an initial a_rwnd below
+        // 1500 bytes ("An SCTP receiver MUST be able to receive a minimum of 1500 bytes in
+        // one SCTP packet. This means that an SCTP endpoint MUST NOT indicate less than
+        // 1500 bytes in its initial a_rwnd sent in the INIT or INIT ACK."). This crate
+        // enforces it in `ChunkInit::check()` (ErrInitAdvertisedReceiver1500), so a
+        // sub-1500 (or 0) value would silently break the handshake. Clamp up to that floor.
+        const MIN_SCTP_RECEIVE_BUFFER_SIZE: u32 = 1500;
+        if size < MIN_SCTP_RECEIVE_BUFFER_SIZE {
+            log::warn!(
+                "sctp receive buffer size {size} is below the RFC 4960 minimum; raising to \
+                 {MIN_SCTP_RECEIVE_BUFFER_SIZE} bytes"
+            );
+        }
+        self.sctp_max_receive_buffer_size = Some(size.max(MIN_SCTP_RECEIVE_BUFFER_SIZE));
     }
 
     /// Controls whether to ignore RID pause signals for receiving transceivers.

--- a/rtc/src/peer_connection/handler/sctp.rs
+++ b/rtc/src/peer_connection/handler/sctp.rs
@@ -846,7 +846,7 @@ mod tests {
         ch: AssociationHandle,
         conn: Association,
     ) -> SctpHandlerContext {
-        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default());
+        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default(), None);
         transport
             .internal_buffer
             .resize(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE as usize, 0);
@@ -994,7 +994,7 @@ mod tests {
             })
             .expect("queue DATA on B");
 
-        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default());
+        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default(), None);
         transport
             .internal_buffer
             .resize(SctpMaxMessageSize::DEFAULT_MESSAGE_SIZE as usize, 0);

--- a/rtc/src/peer_connection/internal.rs
+++ b/rtc/src/peer_connection/internal.rs
@@ -96,7 +96,10 @@ where
         )?;
 
         // Create the SCTP transport
-        let sctp_transport = RTCSctpTransport::new(setting_engine.sctp_max_message_size);
+        let sctp_transport = RTCSctpTransport::new(
+            setting_engine.sctp_max_message_size,
+            setting_engine.sctp_max_receive_buffer_size,
+        );
 
         // Create Pipeline Context
         let ice_handler_context = IceHandlerContext::new(ice_transport);

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -529,6 +529,18 @@ where
         self
     }
 
+    /// Overrides the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes,
+    /// on this builder's [`SettingEngine`].
+    ///
+    /// Convenience for [`SettingEngine::set_sctp_max_receive_buffer_size`]; see it for the
+    /// throughput/memory tradeoff. Applies to whichever `SettingEngine` is currently set,
+    /// so call it after [`with_setting_engine`](Self::with_setting_engine) if you also
+    /// supply a custom engine. Leaving it unset keeps the 1 MiB default.
+    pub fn with_sctp_receive_buffer_size(mut self, size: u32) -> Self {
+        self.setting_engine.set_sctp_max_receive_buffer_size(size);
+        self
+    }
+
     /// Configures the peer connection with an interceptor registry.
     ///
     /// Interceptors process RTP/RTCP packets as they flow through the pipeline,

--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -2260,3 +2260,28 @@ where
             .snapshot_with_selector(now, selector)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_sctp_receive_buffer_size_sets_and_clamps() {
+        let builder = RTCPeerConnectionBuilder::new().with_sctp_receive_buffer_size(200_000);
+        assert_eq!(
+            builder.setting_engine.sctp_max_receive_buffer_size,
+            Some(200_000)
+        );
+
+        // Values below the RFC 4960 §6 floor (1500 bytes), including 0, are clamped up so
+        // they cannot break the SCTP handshake.
+        for input in [0u32, 500, 1499] {
+            let builder = RTCPeerConnectionBuilder::new().with_sctp_receive_buffer_size(input);
+            assert_eq!(
+                builder.setting_engine.sctp_max_receive_buffer_size,
+                Some(1500),
+                "input {input} should clamp up to the 1500-byte floor"
+            );
+        }
+    }
+}

--- a/rtc/src/peer_connection/transport/sctp/mod.rs
+++ b/rtc/src/peer_connection/transport/sctp/mod.rs
@@ -31,6 +31,10 @@ pub(crate) struct RTCSctpTransport {
     // return the value of the [[MaxMessageSize]] slot.
     pub(crate) max_message_size: SctpMaxMessageSize,
 
+    // Optional override for the SCTP receive-buffer size (a_rwnd flow-control window),
+    // in bytes. None uses the sctp crate default (INITIAL_RECV_BUF_SIZE, 1 MiB).
+    pub(crate) max_receive_buffer_size: Option<u32>,
+
     // max_channels represents the maximum amount of DataChannel's that can
     // be used simultaneously.
     pub(crate) max_channels: u16,
@@ -39,7 +43,10 @@ pub(crate) struct RTCSctpTransport {
 }
 
 impl RTCSctpTransport {
-    pub(crate) fn new(max_message_size: SctpMaxMessageSize) -> Self {
+    pub(crate) fn new(
+        max_message_size: SctpMaxMessageSize,
+        max_receive_buffer_size: Option<u32>,
+    ) -> Self {
         Self {
             sctp_endpoint: None,
             sctp_transport_config: None,
@@ -48,6 +55,7 @@ impl RTCSctpTransport {
             state: RTCSctpTransportState::Connecting,
             is_started: false,
             max_message_size,
+            max_receive_buffer_size,
             max_channels: SCTP_MAX_CHANNELS,
             internal_buffer: vec![],
         }
@@ -91,9 +99,12 @@ impl RTCSctpTransport {
         self.internal_buffer.resize(max_message_size as usize, 0u8);
 
         let sctp_endpoint_config = ::sctp::EndpointConfig::default();
-        let sctp_transport_config = ::sctp::TransportConfig::default()
+        let mut sctp_transport_config = ::sctp::TransportConfig::default()
             .with_max_message_size(max_message_size)
             .with_sctp_port(local_port);
+        if let Some(recv_buf) = self.max_receive_buffer_size {
+            sctp_transport_config = sctp_transport_config.with_max_receive_buffer_size(recv_buf);
+        }
         //TODO: add remote_port support
 
         if dtls_role == RTCDtlsRole::Client {

--- a/rtc/src/peer_connection/transport/sctp/mod.rs
+++ b/rtc/src/peer_connection/transport/sctp/mod.rs
@@ -127,3 +127,55 @@ impl RTCSctpTransport {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Starting a Client transport stores the built TransportConfig on the struct, so we
+    // can assert the configured (or default) receive-buffer size flowed through `start()`.
+    #[test]
+    fn start_applies_configured_receive_buffer_size() {
+        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default(), Some(200_000));
+        transport
+            .start(
+                RTCDtlsRole::Client,
+                SCTPTransportCapabilities {
+                    max_message_size: 0,
+                },
+                5000,
+                5000,
+            )
+            .expect("start");
+        assert_eq!(
+            transport
+                .sctp_transport_config
+                .expect("client transport config")
+                .max_receive_buffer_size(),
+            200_000
+        );
+    }
+
+    #[test]
+    fn start_without_override_uses_default_receive_buffer_size() {
+        let mut transport = RTCSctpTransport::new(SctpMaxMessageSize::default(), None);
+        transport
+            .start(
+                RTCDtlsRole::Client,
+                SCTPTransportCapabilities {
+                    max_message_size: 0,
+                },
+                5000,
+                5000,
+            )
+            .expect("start");
+        // `None` keeps the sctp crate default (INITIAL_RECV_BUF_SIZE = 1 MiB).
+        assert_eq!(
+            transport
+                .sctp_transport_config
+                .expect("client transport config")
+                .max_receive_buffer_size(),
+            1024 * 1024
+        );
+    }
+}


### PR DESCRIPTION
## What

Make the SCTP **receive-buffer size** (the advertised receiver window,
`a_rwnd`) configurable, instead of the hard-wired 1 MiB default
(`INITIAL_RECV_BUF_SIZE`). This lets memory-bound deployments — e.g. servers
holding many connections — shrink per-connection receive buffering; the buffer
fills only under load, so the current 1 MiB costs resident memory exactly when
a connection saturates it.

## How

- `SettingEngine`: new `sctp_max_receive_buffer_size: Option<u32>` field +
  `set_sctp_max_receive_buffer_size(u32)` (mirrors `set_sctp_max_message_size`).
- `RTCPeerConnectionBuilder::with_sctp_receive_buffer_size(u32)` convenience.
- Plumbed through `RTCSctpTransport::new` → `start()` into the existing
  `TransportConfig::with_max_receive_buffer_size` (which was already public but
  never wired).

## Safety / validation

Values below the **RFC 4960 §6 (User Data Transfer)** floor of **1500 bytes**
(including `0`) are clamped up, with a `log::warn!`, so an out-of-spec window
can't silently break the handshake — `ChunkInit::check()` rejects a sub-1500
`a_rwnd` (`ErrInitAdvertisedReceiver1500`), which would otherwise fail the INIT
on the peer with no local diagnostic.

## Compatibility

Additive and non-breaking. Leaving the setter unset keeps the 1 MiB default
(zero behaviour change). `RTCSctpTransport::new` is `pub(crate)` so its new
2nd parameter is not a public break.

## Tests

`cargo test` green. (The consuming `webrtc` crate adds a data-channel
round-trip test that also exercises a sub-1500 value being clamped — see the
paired webrtc PR.)

---

Base half of a cross-repo pair: the dependent `webrtc` superproject PR
webrtc-rs/webrtc#819 (bounded reactor pool + this receive-window builder knob)
depends on this and re-pins the submodule once merged.