### PR TITLE
perf(sctp): reduce control-chunk marshal allocations (SACK / FORWARD-TSN)

### DIFF
--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -103,6 +103,49 @@ fn test_create_forward_tsn_omits_unordered_streams() -> Result<()> {
     Ok(())
 }
 
+// The allocation-avoiding marshal_control_chunk() must produce byte-identical wire
+// output to create_packet(vec![Box::new(chunk)]).marshal(). A 2-stream FORWARD-TSN
+// also exercises ChunkForwardTsn::marshal_to's per-stream marshal_to loop, and a
+// SACK covers the other call site.
+#[test]
+fn test_marshal_control_chunk_byte_identical_to_create_packet() -> Result<()> {
+    let mut a = Association::default();
+    a.peer_verification_tag = 0x1234_5678;
+    a.source_port = 5000;
+    a.destination_port = 5001;
+
+    let fwd_tsn = ChunkForwardTsn {
+        new_cumulative_tsn: 42,
+        streams: vec![
+            ChunkForwardTsnStream {
+                identifier: 1,
+                sequence: 7,
+            },
+            ChunkForwardTsnStream {
+                identifier: 3,
+                sequence: 9,
+            },
+        ],
+    };
+    // Borrow for the helper, then move into create_packet (chunks are not Clone).
+    let via_helper = a.marshal_control_chunk(&fwd_tsn)?;
+    let via_packet = a.create_packet(vec![Box::new(fwd_tsn)]).marshal()?;
+    assert_eq!(
+        via_helper, via_packet,
+        "FORWARD-TSN: marshal_control_chunk must match create_packet(..).marshal()"
+    );
+
+    let sack = a.create_selective_ack_chunk();
+    let sack_via_helper = a.marshal_control_chunk(&sack)?;
+    let sack_via_packet = a.create_packet(vec![Box::new(sack)]).marshal()?;
+    assert_eq!(
+        sack_via_helper, sack_via_packet,
+        "SACK: marshal_control_chunk must match create_packet(..).marshal()"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_handle_forward_tsn_forward_3unreceived_chunks() -> Result<()> {
     let mut a = Association::default();

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2,6 +2,7 @@ use crate::association::{
     state::{AckMode, AckState, AssociationState},
     stats::AssociationStats,
 };
+use crate::chunk::chunk_header::CHUNK_HEADER_SIZE;
 use crate::chunk::{
     Chunk, ErrorCauseUnrecognizedChunkType, USER_INITIATED_ABORT, chunk_abort::ChunkAbort,
     chunk_cookie_ack::ChunkCookieAck, chunk_cookie_echo::ChunkCookieEcho, chunk_error::ChunkError,
@@ -2013,6 +2014,26 @@ impl Association {
         }
     }
 
+    /// Marshal a single control chunk into one SCTP packet, bypassing the
+    /// `Vec<Box<dyn Chunk>>` + `Packet` allocations of `create_packet(..).marshal()`.
+    /// Feeds the borrowed chunk straight to the shared framing path
+    /// ([`Packet::write_framed`]). Used on the hot SACK / FORWARD-TSN send path
+    /// (a SACK is emitted roughly every 1-2 inbound DATA chunks). The caller holds
+    /// the lock.
+    fn marshal_control_chunk(&self, chunk: &dyn Chunk) -> Result<Bytes> {
+        let common_header = CommonHeader {
+            verification_tag: self.peer_verification_tag,
+            source_port: self.source_port,
+            destination_port: self.destination_port,
+        };
+        // common header + chunk header + value + up to 3 bytes of trailing padding.
+        let mut buf = BytesMut::with_capacity(
+            COMMON_HEADER_SIZE as usize + CHUNK_HEADER_SIZE + chunk.value_length() + 3,
+        );
+        Packet::write_framed(&common_header, std::iter::once(chunk), &mut buf)?;
+        Ok(buf.freeze())
+    }
+
     /// create_stream creates a stream. The caller should hold the lock and check no stream exists for this id.
     fn create_stream(
         &mut self,
@@ -2280,7 +2301,7 @@ impl Association {
             self.ack_state = AckState::Idle;
             let sack = self.create_selective_ack_chunk();
             debug!("[{}] sending SACK: {}", self.side, sack);
-            if let Ok(raw) = self.create_packet(vec![Box::new(sack)]).marshal() {
+            if let Ok(raw) = self.marshal_control_chunk(&sack) {
                 raw_packets.push(raw);
             } else {
                 warn!("[{}] failed to serialize a SACK packet", self.side);
@@ -2303,7 +2324,7 @@ impl Association {
                 self.cumulative_tsn_ack_point,
             ) {
                 let fwd_tsn = self.create_forward_tsn();
-                if let Ok(raw) = self.create_packet(vec![Box::new(fwd_tsn)]).marshal() {
+                if let Ok(raw) = self.marshal_control_chunk(&fwd_tsn) {
                     raw_packets.push(raw);
                 } else {
                     warn!("[{}] failed to serialize a Forward TSN packet", self.side);

--- a/rtc-sctp/src/chunk/chunk_forward_tsn.rs
+++ b/rtc-sctp/src/chunk/chunk_forward_tsn.rs
@@ -94,7 +94,11 @@ impl Chunk for ChunkForwardTsn {
         writer.put_u32(self.new_cumulative_tsn);
 
         for s in &self.streams {
-            writer.extend_from_slice(&s.marshal()?);
+            // Marshal each 4-byte stream entry straight into `writer` instead of
+            // `extend_from_slice(&s.marshal()?)`, which heap-allocates a throwaway
+            // `Bytes` per stream just to copy it back out. FORWARD-TSN is on the hot
+            // send path for unreliable (PR-SCTP) data channels.
+            s.marshal_to(writer)?;
         }
 
         Ok(writer.len())


### PR DESCRIPTION
## Summary

Two small, byte-identical allocation reductions on the SCTP control-chunk marshal path:

1. **FORWARD-TSN stream entries** (`ChunkForwardTsn::marshal_to`) — write each 4-byte stream entry straight into the packet buffer via `marshal_to`, instead of `extend_from_slice(&s.marshal()?)` which heap-allocates a throwaway `Bytes` per stream just to copy it back out. FORWARD-TSN is on the hot send path for unreliable (PR-SCTP / `max_retransmits`) data channels.

2. **SACK / FORWARD-TSN packets** (`marshal_control_chunk`) — `create_packet(vec![Box::new(chunk)]).marshal()` allocates a `Vec` and a `Box` and builds a `Packet` per control packet. A SACK is emitted roughly every 1–2 inbound DATA chunks on a bulk transfer, so this is hot. The new helper feeds the borrowed chunk straight to the shared framing path (`Packet::write_framed`) into one pre-sized buffer, dropping the `Vec` + `Box`.

## Correctness

Both produce **byte-identical wire output** (`write_framed` is the same framing `marshal()` uses). Proven by a new unit test asserting `marshal_control_chunk(chunk)` equals `create_packet(vec![Box::new(chunk)]).marshal()` for a 2-stream FORWARD-TSN (also exercising `ChunkForwardTsn::marshal_to`'s per-stream loop) and a SACK. **117 rtc-sctp tests pass**; clippy/fmt clean.

## Performance

rtc-sctp has no standalone throughput benchmark, so this was measured **end-to-end through the webrtc superproject's `data-channels-flow-control-multi` example** with [`poop`](https://github.com/andrewrk/poop). Two binaries were built from the same `webrtc` tree, differing **only** in whether rtc carries these two trims (baseline = rtc `master`, "+ trims" = this branch), so the delta isolates them.

- Harness: `examples/data-channels-flow-control-multi`, env `FLOW_PAIRS=10 FLOW_MSG_KB=1 FLOW_DEDICATED_REACTOR=1 FLOW_WARMUP_MB=16 FLOW_STOP_MB=64` — 10 in-process connection pairs, 1 KB messages, unordered/no-retransmit (PR-SCTP, so FORWARD-TSN is on the hot path), dedicated reactor, loopback, ~800 MB fixed work per run.
- Box: Ryzen 7 1700, 26 runs per binary.

Every counter is **within noise** — the control-chunk marshal is a small fraction of per-byte cost (the bulk is DTLS crypto + kernel UDP), so these are correctness-preserving allocation reductions that compound with other work and help under allocator pressure, rather than a standalone throughput win.

| measurement | baseline (26 runs) | + trims (26 runs) | delta |
|---|---|---|---|
| wall_time | 2.77s ± 187ms | 2.77s ± 207ms | −0.0% ± 4.0% |
| peak_rss | 144MB ± 7.20MB | 143MB ± 7.18MB | −1.0% ± 2.8% |
| cpu_cycles | 47.6G ± 748M | 47.8G ± 551M | +0.5% ± 0.8% |
| instructions | 48.4G ± 320M | 48.3G ± 267M | −0.2% ± 0.3% |
| cache_references | 4.43G ± 75.8M | 4.39G ± 89.5M | −0.9% ± 1.0% |
| cache_misses | 796M ± 30.9M | 799M ± 37.7M | +0.3% ± 2.4% |
| branch_misses | 190M ± 8.07M | 187M ± 6.70M | −1.2% ± 2.2% |

Independent of the companion webrtc-rs/webrtc UDP GSO/GRO PR.
