### PR TITLE
open data channels immediately when SCTP is already connected

### DIFF
--- a/rtc/src/peer_connection/mod.rs
+++ b/rtc/src/peer_connection/mod.rs
@@ -248,6 +248,7 @@ pub mod transport;
 
 use crate::data_channel::init::RTCDataChannelInit;
 use crate::data_channel::parameters::DataChannelParameters;
+use crate::data_channel::state::RTCDataChannelState;
 use crate::data_channel::{RTCDataChannel, RTCDataChannelId, internal::RTCDataChannelInternal};
 use crate::media_stream::track::MediaStreamTrack;
 use crate::peer_connection::configuration::media_engine::MediaEngine;
@@ -1840,7 +1841,21 @@ where
             }
         }
 
-        let data_channel = RTCDataChannelInternal::new(id, params);
+        let mut data_channel = RTCDataChannelInternal::new(id, params);
+
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #23)
+        // Open the channel's data transport immediately when an SCTP association already exists.
+        if let Some(handle) = self
+            .sctp_transport()
+            .sctp_associations
+            .keys()
+            .next()
+            .copied()
+            && data_channel.ready_state == RTCDataChannelState::Connecting
+            && data_channel.data_channel.is_none()
+        {
+            data_channel.dial(handle.0)?;
+        }
 
         self.data_channels.insert(id, data_channel);
 
@@ -2264,6 +2279,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data_channel::state::RTCDataChannelState;
+    use sctp::AssociationHandle;
 
     #[test]
     fn with_sctp_receive_buffer_size_sets_and_clamps() {
@@ -2283,5 +2300,26 @@ mod tests {
                 "input {input} should clamp up to the 1500-byte floor"
             );
         }
+    }
+
+    #[test]
+    fn create_data_channel_dials_immediately_when_sctp_association_present() {
+        let mut pc = RTCPeerConnectionBuilder::new().build().unwrap();
+
+        // Simulate an SCTP association so create_data_channel sees a transport
+        // that is ready to open streams.
+        pc.sctp_transport_mut()
+            .sctp_associations
+            .insert(AssociationHandle(0), sctp::Association::default());
+
+        let _dc = pc.create_data_channel("test", None).unwrap();
+
+        let internal = pc
+            .data_channels
+            .values()
+            .next()
+            .expect("data channel must be stored internally");
+        assert!(internal.data_channel.is_some());
+        assert_eq!(internal.ready_state, RTCDataChannelState::Open);
     }
 }


### PR DESCRIPTION
Made some spec-compliant changes to fix my WebUI from getting stuck in a "connecting..." state when connecting to a webrtc-rs `0.20` peer (this did not happen with version `0.17`).

I tried my best to keep this PR as tight as possible!

## Summary

Implements [W3C WebRTC §6.1 `createDataChannel`, step 22 & 23](https://w3c.github.io/webrtc-pc/#dom-peerconnection-createdatachannel):

> Return `channel` and continue the following steps **in parallel**.

> Create `channel`'s associated **underlying data transport** and configure it according to the relevant properties of `channel`.

Before this change, calling `RTCPeerConnection::create_data_channel()` **after** the SCTP association had already finished its handshake left the new channel stuck in `RTCDataChannelState::Connecting` indefinitely. The §6.1.1.3 *RTCSctpTransport connected procedure* only opens channels that already exist at the moment the association transitions to `connected`, so post-handshake channels never had their underlying SCTP stream created.

This patch dials the data channel immediately when an SCTP association is already present, satisfying the spec's requirement to create the underlying data transport in parallel.

## Changes

- `rtc/src/peer_connection/mod.rs`
  - Import `RTCDataChannelState`.
  - After creating the new `RTCDataChannelInternal`, check whether the SCTP transport already has an association. If so, and the new channel is still in `Connecting` with no underlying data channel, call `dial()` on it before inserting it into `data_channels`.
  - Then insert the channel and fire `trigger_negotiation_needed()` as before.

## Test

- `rtc/src/peer_connection/mod.rs` tests
  - Added `create_data_channel_dials_immediately_when_sctp_association_present`.
  - The test injects a default `sctp::Association` into the peer connection's `sctp_transport.sctp_associations`, calls `create_data_channel`, and asserts that the stored internal channel has `data_channel: Some(_)` and `ready_state: Open`.
  - The regression test fails before the fix and passes after it.

## Verification

```bash
cd rtc/
cargo test --lib
cargo clippy -- -D warnings
```

Both commands pass (190 lib tests; clippy clean).

