### PR TITLE
ice: send srflx/prflx checks from the candidate base, not the mapped address

### DIFF
--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2879,3 +2879,60 @@ fn test_query_only_agent_queries_mdns_remote_candidate() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test: connectivity checks for a server-reflexive local candidate
+/// must be tagged with the candidate's base (the bound host socket), not the
+/// NAT-mapped srflx address (RFC 8445 §6.1.2). Drivers that route outbound
+/// transmits by `transport.local_addr` otherwise have no socket to send from
+/// and drop the packet.
+#[test]
+fn test_send_stun_from_srflx_uses_base_addr() -> Result<()> {
+    let mut a = Agent::new(Arc::new(AgentConfig::default()))?;
+
+    let srflx_local = CandidateServerReflexiveConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "10.79.12.1".to_owned(), // NAT mapping; no local socket here
+            port: 60823,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "192.168.0.2".to_owned(), // base: bound host socket
+        rel_port: 5000,
+        ..Default::default()
+    }
+    .new_candidate_server_reflexive()?;
+    a.add_local_candidate(srflx_local)?;
+
+    let host_remote = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "10.79.11.1".to_owned(),
+            port: 37983,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    a.add_remote_candidate(host_remote)?;
+
+    a.write_outs.clear();
+
+    let msg = Message::new();
+    a.send_stun(&msg, 0, 0);
+
+    let transmit = a.write_outs.pop_front().expect("send_stun must emit");
+    assert_eq!(
+        transmit.transport.local_addr,
+        "192.168.0.2:5000".parse().unwrap(),
+        "srflx checks must be sent from the candidate's base, not the mapped address"
+    );
+    assert_eq!(
+        transmit.transport.peer_addr,
+        "10.79.11.1:37983".parse().unwrap()
+    );
+
+    a.close()?;
+    Ok(())
+}

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -1381,7 +1381,10 @@ impl Agent {
 
     pub(crate) fn send_stun(&mut self, msg: &Message, local_index: usize, remote_index: usize) {
         let peer_addr = self.remote_candidates[remote_index].addr();
-        let local_addr = self.local_candidates[local_index].addr();
+        // RFC 8445 §6.1.2: checks for a (server/peer-)reflexive candidate must
+        // be sent from its base, the bound local socket the candidate was
+        // derived from; the mapped address is not a local socket.
+        let local_addr = self.local_candidates[local_index].base_addr();
         let transport_protocol = if self.local_candidates[local_index].network_type().is_tcp() {
             TransportProtocol::TCP
         } else {

--- a/rtc-ice/src/candidate/candidate_test.rs
+++ b/rtc-ice/src/candidate/candidate_test.rs
@@ -1,5 +1,9 @@
 use super::*;
+use crate::candidate::candidate_host::CandidateHostConfig;
 use crate::candidate::candidate_pair::CandidatePairState;
+use crate::candidate::candidate_peer_reflexive::CandidatePeerReflexiveConfig;
+use crate::candidate::candidate_relay::CandidateRelayConfig;
+use crate::candidate::candidate_server_reflexive::CandidateServerReflexiveConfig;
 use crate::candidate::{Candidate, unmarshal_candidate};
 use std::time::Instant;
 
@@ -426,6 +430,101 @@ fn test_candidate_marshal() -> Result<()> {
             assert!(actual_candidate.is_err(), "expected error");
         }
     }
+
+    Ok(())
+}
+
+/// Regression test: a candidate's base address must be the local (bound)
+/// transport address. For server/peer-reflexive candidates that is the
+/// related address, not the NAT-mapped candidate address (RFC 8445 §5.1.1).
+#[test]
+fn test_candidate_base_addr() -> Result<()> {
+    let host = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "192.168.0.2".to_owned(),
+            port: 5000,
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    assert_eq!(host.base_addr(), host.addr(), "host base is itself");
+
+    let srflx = CandidateServerReflexiveConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "10.79.12.1".to_owned(),
+            port: 60823,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "192.168.0.2".to_owned(),
+        rel_port: 5000,
+        ..Default::default()
+    }
+    .new_candidate_server_reflexive()?;
+    assert_eq!(
+        srflx.base_addr(),
+        "192.168.0.2:5000".parse().unwrap(),
+        "srflx base must be the related (host) address"
+    );
+    assert_ne!(srflx.base_addr(), srflx.addr());
+
+    let prflx = CandidatePeerReflexiveConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "10.79.12.1".to_owned(),
+            port: 60824,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "192.168.0.2".to_owned(),
+        rel_port: 5000,
+        ..Default::default()
+    }
+    .new_candidate_peer_reflexive()?;
+    assert_eq!(
+        prflx.base_addr(),
+        "192.168.0.2:5000".parse().unwrap(),
+        "prflx base must be the related (host) address"
+    );
+
+    // Missing/unparseable related address falls back to the candidate address.
+    let prflx_no_rel = CandidatePeerReflexiveConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "10.79.12.1".to_owned(),
+            port: 60825,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "".to_owned(),
+        rel_port: 0,
+        ..Default::default()
+    }
+    .new_candidate_peer_reflexive()?;
+    assert_eq!(prflx_no_rel.base_addr(), prflx_no_rel.addr());
+
+    let relay = CandidateRelayConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: "50.0.0.1".to_owned(),
+            port: 5000,
+            component: 1,
+            ..Default::default()
+        },
+        rel_addr: "192.168.0.2".to_owned(),
+        rel_port: 5001,
+        ..Default::default()
+    }
+    .new_candidate_relay()?;
+    assert_eq!(
+        relay.base_addr(),
+        relay.addr(),
+        "relay base is the relayed address itself"
+    );
 
     Ok(())
 }

--- a/rtc-ice/src/candidate/mod.rs
+++ b/rtc-ice/src/candidate/mod.rs
@@ -327,6 +327,29 @@ impl Candidate {
         self.resolved_addr
     }
 
+    /// Returns the candidate's base address: the local transport address the
+    /// candidate was derived from, i.e. the address packets for this candidate
+    /// must be sent from (RFC 8445 §5.1.1).
+    ///
+    /// For server-reflexive and peer-reflexive candidates this is the related
+    /// (host) address; for host and relay candidates the base is the candidate
+    /// address itself.
+    pub fn base_addr(&self) -> SocketAddr {
+        match self.candidate_type {
+            CandidateType::ServerReflexive | CandidateType::PeerReflexive => self
+                .related_address
+                .as_ref()
+                .and_then(|ra| {
+                    ra.address
+                        .parse::<IpAddr>()
+                        .ok()
+                        .map(|ip| SocketAddr::new(ip, ra.port))
+                })
+                .unwrap_or(self.resolved_addr),
+            _ => self.resolved_addr,
+        }
+    }
+
     pub fn seen(&mut self, outbound: bool) {
         let now = Instant::now();
 

--- a/src/peer_connection/handler/ice.rs
+++ b/src/peer_connection/handler/ice.rs
@@ -121,7 +121,10 @@ impl<'a> sansio::Protocol<TaggedRTCMessageInternal, TaggedRTCMessageInternal, RT
             // transmits stay stamped UDP even when the selected pair is TCP,
             // and consumers routing poll_write() output by transport_protocol
             // send every non-STUN packet down the wrong transport.
-            msg.transport.local_addr = local.addr();
+            // Use the local candidate's base address: for (server/peer-)
+            // reflexive candidates the candidate address is the NAT mapping,
+            // not a bound local socket (RFC 8445 §5.1.1).
+            msg.transport.local_addr = local.base_addr();
             msg.transport.peer_addr = remote.addr();
             msg.transport.transport_protocol = local.network_type().to_protocol();
             debug!("Bypass ice write {:?}", msg.transport.peer_addr);


### PR DESCRIPTION
Connectivity checks and data writes for a server-reflexive local candidate were tagged with the candidate's NAT-mapped address, which no local socket is bound to; drivers routing outbound transmits by transport.local_addr had to drop them, so ICE never connected when the srflx path was the only viable one.

Per RFC 8445 sec 6.1.2, checks for a reflexive candidate must be sent from its base. Add Candidate::base_addr() (related address for srflx/prflx, addr() otherwise) and use it in Agent::send_stun and the peer connection ICE handler write path.