### PR TITLE
fix(data_channel): reject sends the write path cannot carry out

### DIFF
--- a/rtc-shared/src/error.rs
+++ b/rtc-shared/src/error.rs
@@ -1247,6 +1247,12 @@ pub enum Error {
     #[error("data channel closed")]
     ErrDataChannelClosed,
 
+    /// ErrDataChannelNotOpen indicates a send was attempted on a data channel
+    /// whose underlying SCTP stream has not been established yet — its
+    /// `ready_state` is still `connecting`. Wait for the channel to open.
+    #[error("data channel is not open yet")]
+    ErrDataChannelNotOpen,
+
     /// ErrDataChannelNonExist indicates an operation executed when the data
     /// channel not existed.
     #[error("data channel not existed")]

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -241,11 +241,37 @@ where
         }
     }
 
-    /// send sends the binary message to the DataChannel peer
-    pub fn send(&mut self, data: BytesMut) -> Result<()> {
-        if !self.peer_connection.data_channels.contains_key(&self.id) {
-            return Err(Error::ErrDataChannelClosed);
+    /// Rejects a send the write path could not carry out.
+    ///
+    /// The condition mirrors what `DataChannelHandler::handle_write` requires: the channel
+    /// must be registered *and* its SCTP stream established. Checking it here, synchronously,
+    /// is what makes the failure visible — the handler runs later, on the pipeline's write
+    /// pass, where an `Err` is only logged and cannot reach the caller.
+    fn ensure_sendable(&self) -> Result<()> {
+        let dc = self
+            .peer_connection
+            .data_channels
+            .get(&self.id)
+            .ok_or(Error::ErrDataChannelClosed)?;
+
+        if dc.data_channel.is_none() {
+            // No stream yet: either it is still being negotiated, or it is already gone.
+            return Err(if dc.ready_state == RTCDataChannelState::Connecting {
+                Error::ErrDataChannelNotOpen
+            } else {
+                Error::ErrDataChannelClosed
+            });
         }
+
+        Ok(())
+    }
+
+    /// send sends the binary message to the DataChannel peer
+    ///
+    /// Returns [`Error::ErrDataChannelNotOpen`] if the channel's SCTP stream has not been
+    /// established yet, and [`Error::ErrDataChannelClosed`] once it is gone.
+    pub fn send(&mut self, data: BytesMut) -> Result<()> {
+        self.ensure_sendable()?;
         let data_len = data.len();
         self.peer_connection
             .handle_write(RTCMessage::DataChannelMessage(
@@ -265,10 +291,10 @@ where
     }
 
     /// send_text sends the text message to the DataChannel peer
+    ///
+    /// Error contract matches [`send`](Self::send).
     pub fn send_text(&mut self, s: impl Into<String>) -> Result<()> {
-        if !self.peer_connection.data_channels.contains_key(&self.id) {
-            return Err(Error::ErrDataChannelClosed);
-        }
+        self.ensure_sendable()?;
         let data = BytesMut::from(s.into().as_str());
         let data_len = data.len();
         self.peer_connection

--- a/tests/data_channel_send_before_open.rs
+++ b/tests/data_channel_send_before_open.rs
@@ -1,0 +1,84 @@
+//! `send` must not report success for data it cannot carry.
+//!
+//! Until the SCTP stream backing a channel exists, the write path cannot deliver anything. That
+//! failure used to be invisible: `send` checked only that the channel was *registered*, so it
+//! returned `Ok(())`, and the real rejection happened later inside
+//! `DataChannelHandler::handle_write` — on the pipeline's write pass, where an `Err` is logged
+//! and discarded rather than returned to anyone.
+//!
+//! The caller was therefore told its message went out while it was dropped on the floor. That is
+//! the worst of the three possible contracts: buffering (what [W3C `send()`] prescribes for a
+//! `connecting` channel) and erroring are both recoverable, silence is not.
+//!
+//! [W3C `send()`]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-send
+
+use anyhow::Result;
+use bytes::BytesMut;
+use rtc::data_channel::{RTCDataChannelInit, RTCDataChannelState};
+use rtc::peer_connection::RTCPeerConnectionBuilder;
+use rtc::shared::error::Error;
+
+#[test]
+fn send_before_the_stream_exists_is_rejected() -> Result<()> {
+    let mut pc = RTCPeerConnectionBuilder::new().build()?;
+
+    let mut dc = pc.create_data_channel("probe", Some(RTCDataChannelInit::default()))?;
+    assert_eq!(
+        dc.ready_state(),
+        RTCDataChannelState::Connecting,
+        "a freshly created channel has no stream yet"
+    );
+
+    assert_eq!(
+        dc.send(BytesMut::from(&b"dropped"[..])),
+        Err(Error::ErrDataChannelNotOpen),
+        "send must not claim success before the channel opens"
+    );
+    assert_eq!(
+        dc.send_text("dropped"),
+        Err(Error::ErrDataChannelNotOpen),
+        "send_text must not claim success before the channel opens"
+    );
+
+    Ok(())
+}
+
+/// A rejected send must not be counted against the back-pressure budget: those bytes never
+/// entered the SCTP pipeline, so nothing will ever release them. Leaking the counter would
+/// permanently shrink the channel's send window.
+#[test]
+fn rejected_send_does_not_charge_outstanding_bytes() -> Result<()> {
+    let mut pc = RTCPeerConnectionBuilder::new().build()?;
+
+    let mut dc = pc.create_data_channel("probe", Some(RTCDataChannelInit::default()))?;
+
+    let _ = dc.send(BytesMut::from(&b"dropped"[..]));
+
+    assert_eq!(
+        dc.outstanding_bytes(),
+        0,
+        "a send that never reached SCTP must not be charged"
+    );
+
+    Ok(())
+}
+
+/// Sending on an id that was never registered is a different failure from sending too early,
+/// and the two should stay distinguishable — a caller can retry the second but not the first.
+#[test]
+fn send_on_a_closed_channel_reports_closed() -> Result<()> {
+    let mut pc = RTCPeerConnectionBuilder::new().build()?;
+
+    let mut dc = pc.create_data_channel("probe", Some(RTCDataChannelInit::default()))?;
+    let id = dc.id();
+    dc.close()?;
+
+    let mut dc = pc.data_channel(id).expect("handle survives close");
+    assert_ne!(
+        dc.send(BytesMut::from(&b"dropped"[..])),
+        Ok(()),
+        "send on a closed channel must fail"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes the silent data loss reported in webrtc-rs/webrtc#826 (filed there before I had traced it
to this repo).

## Problem

`RTCDataChannel::send` checked only that the channel was *registered*:

```rust
if !self.peer_connection.data_channels.contains_key(&self.id) {
    return Err(Error::ErrDataChannelClosed);
}
```

which it is from `create_data_channel` onwards. The condition that actually decides whether the
message can go anywhere — whether the SCTP stream exists — was checked later, in
`DataChannelHandler::handle_write`:

```rust
let data_channel = self.data_channels.get_mut(&channel_id)
    .ok_or(Error::ErrDataChannelNotExisted)?
    .data_channel.as_mut()
    .ok_or(Error::ErrDataChannelNotExisted)?;   // <- fails here
```

And that runs on the pipeline's write pass, where the error is logged and discarded:

```rust
// src/peer_connection/handler/mod.rs
if let Err(err) = handler.handle_write(msg) {
    warn!("{}.handle_write got error: {}", handler.name(), err);
}
```

So the rejection *did* happen — it just could not reach anyone. Observed on master:

```
send result: Ok(())
[WARN rtc::peer_connection::handler] DataChannelHandler.handle_write got error: data channel not existed
```

The caller is told the message went out. It did not. Sending on an already closed channel has the
same shape — also `Ok(())`.

This is the worst of the three possible contracts. Buffering (what [W3C `send()`][w3c] prescribes
for a `connecting` channel) and erroring are both recoverable; silence is not. It cost me a long
debugging session in a libp2p WebRTC transport: the first Noise handshake message was written the
moment the peer connection reported `Connected` and vanished, so the handshake hung with no error
anywhere in the stack.

[w3c]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-send

## Change

Check the real condition at the send boundary, where the error can still be returned:

```rust
fn ensure_sendable(&self) -> Result<()> {
    let dc = self.peer_connection.data_channels.get(&self.id)
        .ok_or(Error::ErrDataChannelClosed)?;

    if dc.data_channel.is_none() {
        return Err(if dc.ready_state == RTCDataChannelState::Connecting {
            Error::ErrDataChannelNotOpen
        } else {
            Error::ErrDataChannelClosed
        });
    }

    Ok(())
}
```

The predicate is deliberately the same one `handle_write` uses, so the two cannot disagree — a
send that passes this guard is one the write path will accept.

`ErrDataChannelNotOpen` is a new variant. `Error` is `#[non_exhaustive]` and documents that new
variants are not semver-breaking. Keeping it distinct from `ErrDataChannelClosed` is the point:
the first is worth retrying once the channel opens, the second never is.

This also stops a rejected send from charging `outstanding_bytes`. Those bytes never entered the
SCTP pipeline, so nothing would ever release them — the leaked counter would permanently shrink
the channel's send window.

## On the W3C contract

This errors where the spec prescribes buffering for a `connecting` channel:

> if `readyState` is `connecting`, then the user agent MUST enqueue the message [...] and transmit
> it once the underlying transport is established.

Buffering is the better contract, and I would be glad to follow up with it. But it needs an
unbounded-growth policy and a flush point, and it is a much larger change than this. Erroring is
the smallest step that stops the silent loss, and it only surfaces the decision the write path was
already making. Happy to go the buffering route instead if you would prefer that as the first
move.

## Tests

`tests/data_channel_send_before_open.rs` — three cases, all failing on master:

- `send_before_the_stream_exists_is_rejected` — `send`/`send_text` on a `connecting` channel
- `rejected_send_does_not_charge_outstanding_bytes` — the counter must stay at 0
- `send_on_a_closed_channel_reports_closed` — closed is a distinct failure, not `Ok(())`

`cargo fmt --check` and `cargo clippy -p rtc` are clean. `cargo test --workspace` passes except
`ice_restart_by_webrtc_interop::test_ice_restart_interop`, which fails identically on unmodified
master here (it fails in 0.03s, so it looks environmental rather than related).

## Disclosure

This change was developed with AI assistance (Claude Code). I found the behaviour building a
WebRTC-Direct libp2p transport on 0.20, traced it through the handler pipeline to the swallowed
`Err` shown above, and confirmed both the diagnosis and the fix end-to-end against that transport
before opening this. I have read every line of the diff and can explain it in review.