### PR TITLE
fix(data_channel): default `ordered` to true, as documented

### DIFF
--- a/src/data_channel/init.rs
+++ b/src/data_channel/init.rs
@@ -21,7 +21,7 @@
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct RTCDataChannelInit {
     /// If set to `false`, data is allowed to be delivered out of order.
     ///
@@ -76,4 +76,26 @@ pub struct RTCDataChannelInit {
     ///
     /// [W3C specification]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-negotiated
     pub negotiated: Option<u16>,
+}
+
+impl Default for RTCDataChannelInit {
+    /// The defaults defined by [W3C `RTCDataChannelInit`].
+    ///
+    /// Note `ordered`: it defaults to `true`, so `..Default::default()` yields an ordered,
+    /// reliable channel — what an application asking for "a plain data channel" expects.
+    /// A derived `Default` would make it `false`, and an unordered channel does more than
+    /// reorder application messages: unordered chunks bypass SCTP's ordered-delivery queue,
+    /// so a first message can overtake the `DATA_CHANNEL_OPEN` sent on the same stream and
+    /// be dropped by the peer as data on a stream it has not accepted yet.
+    ///
+    /// [W3C `RTCDataChannelInit`]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit
+    fn default() -> Self {
+        Self {
+            ordered: true,
+            max_packet_life_time: None,
+            max_retransmits: None,
+            protocol: String::new(),
+            negotiated: None,
+        }
+    }
 }

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1812,38 +1812,40 @@ where
 
         let mut id = self.generate_data_channel_id()?;
 
-        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #19)
-        if let Some(options) = options {
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #16)
-            if options.max_packet_life_time.is_some() && options.max_retransmits.is_some() {
-                return Err(Error::ErrRetransmitsOrPacketLifeTime);
-            }
+        // `None` means "the dictionary defaults", which is what `RTCDataChannelInit::default()`
+        // spells out. Taking that route rather than leaving `params` on its derived default
+        // keeps a single definition of those defaults — notably `ordered`, which is `true`.
+        let options = options.unwrap_or_default();
 
-            // Ordered indicates if data is allowed to be delivered out of order. The
-            // default value of true, guarantees that data will be delivered in order.
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #9)
-            params.ordered = options.ordered;
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #16)
+        if options.max_packet_life_time.is_some() && options.max_retransmits.is_some() {
+            return Err(Error::ErrRetransmitsOrPacketLifeTime);
+        }
 
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #7)
-            params.max_packet_life_time = options.max_packet_life_time;
+        // Ordered indicates if data is allowed to be delivered out of order. The
+        // default value of true, guarantees that data will be delivered in order.
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #9)
+        params.ordered = options.ordered;
 
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #8)
-            params.max_retransmits = options.max_retransmits;
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #7)
+        params.max_packet_life_time = options.max_packet_life_time;
 
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #10)
-            params.protocol = options.protocol;
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #8)
+        params.max_retransmits = options.max_retransmits;
 
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #11)
-            if params.protocol.len() > 65535 {
-                return Err(Error::ErrProtocolTooLarge);
-            }
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #10)
+        params.protocol = options.protocol;
 
-            // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #12)
-            params.negotiated = options.negotiated;
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #11)
+        if params.protocol.len() > 65535 {
+            return Err(Error::ErrProtocolTooLarge);
+        }
 
-            if let Some(negotiated_id) = &params.negotiated {
-                id = *negotiated_id;
-            }
+        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #12)
+        params.negotiated = options.negotiated;
+
+        if let Some(negotiated_id) = &params.negotiated {
+            id = *negotiated_id;
         }
 
         let mut data_channel = RTCDataChannelInternal::new(id, params);

--- a/tests/data_channel_init_defaults.rs
+++ b/tests/data_channel_init_defaults.rs
@@ -1,0 +1,61 @@
+//! `RTCDataChannelInit`'s defaults must match what its documentation promises.
+//!
+//! `ordered` is the one that matters. A derived `Default` makes it `false`, so
+//! `create_data_channel(label, None)` — the natural way to ask for a plain data channel —
+//! would hand back an *unordered* one, contradicting both the field's own doc comment and
+//! [W3C `RTCDataChannelInit`], where `ordered` is defined as `= true`.
+//!
+//! The consequence is not merely out-of-order application messages. Unordered chunks bypass
+//! SCTP's ordered-delivery queue, so a first message can overtake the `DATA_CHANNEL_OPEN`
+//! sent on the same stream; the peer then receives user data on a stream id it has not
+//! accepted yet and drops it.
+//!
+//! [W3C `RTCDataChannelInit`]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit
+
+use anyhow::Result;
+use rtc::data_channel::RTCDataChannelInit;
+use rtc::peer_connection::RTCPeerConnectionBuilder;
+
+#[test]
+fn default_init_is_ordered() {
+    assert!(
+        RTCDataChannelInit::default().ordered,
+        "the documented default for `ordered` is true"
+    );
+}
+
+/// The default reaches the channel: passing `None` must not quietly opt out of ordering.
+#[test]
+fn channel_created_without_options_is_ordered() -> Result<()> {
+    let mut pc = RTCPeerConnectionBuilder::new().build()?;
+
+    let dc = pc.create_data_channel("plain", None)?;
+
+    assert!(
+        dc.ordered(),
+        "a channel created without options must be ordered"
+    );
+
+    Ok(())
+}
+
+/// Opting out still works — this is a default, not a policy.
+#[test]
+fn unordered_can_still_be_requested() -> Result<()> {
+    let mut pc = RTCPeerConnectionBuilder::new().build()?;
+
+    let dc = pc.create_data_channel(
+        "unordered",
+        Some(RTCDataChannelInit {
+            ordered: false,
+            ..Default::default()
+        }),
+    )?;
+
+    assert!(
+        !dc.ordered(),
+        "an explicit `ordered: false` must be honored"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #139.

## Problem

`RTCDataChannelInit` derived `Default`, so `ordered` came out `false`. Its own doc
comment, three lines above, says otherwise:

> The default value of `true` guarantees that data will be delivered in order.

So does [W3C `RTCDataChannelInit`](https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-ordered),
where the member is declared `boolean ordered = true;`.

There is a second, independent site: `create_data_channel(label, None)` never consulted
`RTCDataChannelInit::default()` at all. It left `params` on `DataChannelParameters`'
derived default — also `false` — and only copied fields when `options` was `Some`. So
even after fixing the dictionary's `Default`, passing `None` still produced an unordered
channel. Both are fixed here.

## Why it matters

An unordered channel does not merely reorder application messages. Unordered chunks
bypass SCTP's ordered-delivery queue, so the first user message can overtake the
`DATA_CHANNEL_OPEN` sent on the same stream. The peer then receives user data on a
stream id it has not accepted yet, and `handle_read` routes it to
`RTCDataChannelInternal::accept`, which requires DCEP:

```rust
if ppi != PayloadProtocolIdentifier::Dcep {
    return Err(Error::InvalidPayloadProtocolIdentifier(ppi as u8));
}
```

That `Err` surfaces on the handler pipeline's read pass, where it is logged and
discarded. The message is dropped with no error reaching either peer — `send()` returned
`Ok(())` and the only trace is:

```
WARN rtc::peer_connection::handler: DataChannelHandler.handle_read got error:
     Unknown PayloadProtocolIdentifier 53
```

PPID 53 is `WebRTC Binary`, an entirely valid value; the log line reads like the remote
misbehaved.

Found while building a libp2p WebRTC transport on `webrtc` 0.20 / `rtc` 0.20: every
substream lost its first message, so multistream-select never completed and both peers
timed out after 10s.

## Changes

- `RTCDataChannelInit`: hand-written `Default` with `ordered: true`, documenting why it
  is not derived.
- `create_data_channel`: `options.unwrap_or_default()`, so `None` means the dictionary
  defaults and those defaults have one definition rather than two that disagree.
- `tests/data_channel_init_defaults.rs`: the default is ordered; a channel created with
  `None` is ordered; an explicit `ordered: false` is still honored.

## Compatibility

This changes behaviour for callers who pass `None` or use `..Default::default()` and
relied on getting an unordered channel. That seems very unlikely to be deliberate — the
doc example in the same file writes `ordered: false` explicitly, which only makes sense
if the default were `true`. Callers who do want unordered delivery keep it by saying so,
which the third test pins.

## Testing

`cargo test` passes except `ice_restart_by_webrtc_interop::test_ice_restart_interop`,
which fails identically on unmodified `master` (0.03s, same assertion) — verified by
stashing this branch and re-running. `cargo fmt --all --check` is clean.

## AI Assistance Disclosure

This change was developed with assistance from Claude (Anthropic). The root cause was
established empirically — instrumenting the send path to confirm `send()` returned `Ok`
while the peer never received the bytes, then locating the swallowed
`InvalidPayloadProtocolIdentifier(53)` under `RUST_LOG=rtc=debug`. The second site
(`create_data_channel` ignoring the dictionary default) was found because the first test
written still failed after fixing only `Default`. Each test was checked to fail without
the corresponding fix. All code and prose were reviewed by a human before submission.
