### PR TITLE
fix(interceptor): deliver inbound RTCP to the application

### DIFF
--- a/rtc-interceptor/src/nack/responder.rs
+++ b/rtc-interceptor/src/nack/responder.rs
@@ -485,7 +485,7 @@ mod tests {
         nack.now = now;
         chain.handle_read(nack).unwrap();
         let out = chain.poll_read();
-        assert!(out.is_none());
+        assert!(out.is_some());
     }
 
     #[test]

--- a/rtc-interceptor/src/noop.rs
+++ b/rtc-interceptor/src/noop.rs
@@ -1,7 +1,7 @@
 //! NoOp Interceptor - A pass-through terminal for interceptor chains.
 
 use crate::stream_info::StreamInfo;
-use crate::{Interceptor, Packet, TaggedPacket};
+use crate::{Interceptor, TaggedPacket};
 use shared::error::Error;
 use std::collections::VecDeque;
 use std::time::Instant;
@@ -57,11 +57,7 @@ impl sansio::Protocol<TaggedPacket, TaggedPacket, ()> for NoopInterceptor {
     type Time = Instant;
 
     fn handle_read(&mut self, msg: TaggedPacket) -> Result<(), Self::Error> {
-        if let Packet::Rtp(_) = &msg.message {
-            self.read_queue.push_back(msg);
-        }
-        // RTCP message read must end here. If any rtcp packet needs to be forwarded to PeerConnection,
-        // just add a new interceptor to forward it by using self.interceptor.poll_read()
+        self.read_queue.push_back(msg);
         Ok(())
     }
 
@@ -137,9 +133,11 @@ mod tests {
         let pkt1 = dummy_rtp_packet();
         let pkt1_message = pkt1.message.clone();
         let pkt2 = dummy_rtcp_packet();
+        let pkt2_message = pkt2.message.clone();
         noop.handle_read(pkt1).unwrap();
         noop.handle_read(pkt2).unwrap();
         assert_eq!(noop.poll_read().unwrap().message, pkt1_message);
+        assert_eq!(noop.poll_read().unwrap().message, pkt2_message);
         assert!(noop.poll_read().is_none());
 
         // Test write
@@ -152,6 +150,40 @@ mod tests {
         assert_eq!(noop.poll_write().unwrap().message, pkt3_message);
         assert_eq!(noop.poll_write().unwrap().message, pkt4_message);
         assert!(noop.poll_write().is_none());
+    }
+
+    /// RTCP feedback about a stream we are *sending* — PLI, FIR, Receiver Reports —
+    /// arrives on the read path and has to survive the whole chain, or a sender never
+    /// learns that the remote peer wants a keyframe.
+    #[test]
+    fn test_inbound_rtcp_survives_a_full_chain() {
+        let mut chain = crate::Registry::new()
+            .with(crate::NackGeneratorBuilder::new().build())
+            .with(crate::NackResponderBuilder::new().build())
+            .with(crate::SenderReportBuilder::new().build())
+            .with(crate::ReceiverReportBuilder::new().build())
+            .build();
+
+        let pli = TaggedPacket {
+            now: Instant::now(),
+            transport: Default::default(),
+            message: crate::Packet::Rtcp(vec![Box::new(
+                rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication {
+                    sender_ssrc: 1,
+                    media_ssrc: 0xDEAD_BEEF,
+                },
+            )]),
+        };
+
+        chain.handle_read(pli).unwrap();
+
+        assert!(
+            matches!(
+                chain.poll_read().map(|p| p.message),
+                Some(crate::Packet::Rtcp(_))
+            ),
+            "inbound PLI must reach the application"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`NoopInterceptor::handle_read` queues only `Packet::Rtp`; every `Packet::Rtcp` falls through to `Ok(())` and is discarded. `NoopInterceptor` terminates every chain built by `Registry`, and no built-in interceptor re-emits RTCP from `poll_read` — so **no inbound RTCP can reach the application**, including PLI, FIR and Receiver Reports about streams the application is *sending*.

That makes `webrtc`'s `TrackLocalEvent::OnRtcpPacket` unreachable in any stock configuration, including `register_default_interceptors`.

## This contradicts the crate's own stated behaviour, in three places

**1. `NoopInterceptor`'s doc comment** describes unconditional pass-through:

> A no-operation interceptor that simply queues messages for pass-through. […] It accepts messages via `handle_read`/`handle_write`/etc and returns them unchanged via `poll_read`/`poll_write`/etc.

**2. `test_nack_responder_passthrough` states the intent and then asserts the opposite:**

```rust
// RTCP packets should pass through to read
let mut nack = make_nack_packet(999, 12345, vec![(1, 0)]);
nack.now = now;
chain.handle_read(nack).unwrap();
let out = chain.poll_read();
assert!(out.is_none());          // <- contradicts the comment directly above
```

**3. The consuming stack is fully built for RTCP that never arrives:**

| Layer | State |
|---|---|
| `webrtc` `TrackLocalEvent::OnRtcpPacket` | documented as "Fired when RTCP feedback about this sent track is received from the remote peer — e.g. Receiver Reports, or PLI/FIR keyframe requests" |
| `webrtc` driver | has a dedicated branch routing that event to the track |
| `rtc` `endpoint.rs` `find_track_id_by_ssrc` | carries a sender-side fallback that exists only to resolve *inbound* RTCP to a local track |
| `rtc` `InterceptorHandler::poll_read` | contains `trace!("Interceptor forwarded a RTCP packet {:?}", …)` — unreachable as shipped |
| `register_default_interceptors` | `configure_nack` + `configure_rtcp_reports` + `configure_twcc_receiver_only`; no forwarder |

`noop.rs` does carry a comment suggesting applications add their own forwarding interceptor. If that is the intended contract, then `NoopInterceptor`'s doc, the NACK responder test's comment, `register_default_interceptors` and the `OnRtcpPacket` docs are all inconsistent with it. This PR takes the other reading — that the terminal should pass messages through as documented — but I'm happy to rework it as an added interceptor instead if you prefer that shape.

## Reproduction

Fails on `main` and on 0.20.0; three dependencies, no peer connection, no network:

```rust
let mut chain = Registry::new()
    .with(NackGeneratorBuilder::new().build())
    .with(NackResponderBuilder::new().build())
    .with(SenderReportBuilder::new().build())
    .with(ReceiverReportBuilder::new().build())
    .build();

chain.handle_read(/* inbound PLI */).unwrap();

assert!(chain.poll_read().is_some(), "inbound PLI never reaches the application");
```

## The change

Four lines of production code become one. No public API change; `register_default_interceptors` keeps its signature.

```diff
 fn handle_read(&mut self, msg: TaggedPacket) -> Result<(), Self::Error> {
-    if let Packet::Rtp(_) = &msg.message {
-        self.read_queue.push_back(msg);
-    }
-    // RTCP message read must end here. If any rtcp packet needs to be forwarded to PeerConnection,
-    // just add a new interceptor to forward it by using self.interceptor.poll_read()
+    self.read_queue.push_back(msg);
     Ok(())
 }
```

**Test changes**, all of which move assertions onto the behaviour their own comments already describe:

- `noop::tests::test_noop_read_write` — now asserts the RTCP packet comes back out.
- `nack::responder::tests::test_nack_responder_passthrough` — `is_none()` → `is_some()`, matching its comment.
- `noop::tests::test_inbound_rtcp_survives_a_full_chain` — **new**, drives an inbound PLI through the same layers `register_default_interceptors` installs, so a regression fails loudly rather than silently.

`cargo test --workspace` → **1474 passed, 0 failed**. `cargo clippy -p rtc-interceptor --lib` and `cargo fmt` clean.

## Impact

Any sender-side application currently loses all remote feedback: PLI/FIR (encoder never told to emit a keyframe), Receiver Reports (no loss/jitter signal for ABR), REMB (no receiver bandwidth estimate).

We hit this upgrading from `webrtc` 0.17.1, where `RtpSender::read()` delivered the same feedback. In a real session: Chrome received 9,514 video RTP packets (2.5 MB) and assembled `framesReceived=0, framesDecoded=0, keyFramesDecoded=0` while sending **342 unanswered PLIs**. Sender side, SRTP decrypted 488 inbound packets with no errors and `handle_rtcp_message` was called zero times. Without PLI nothing forces an IDR, so the stream never becomes decodable — permanently black video.

It fails quietly: SDP negotiates `nack pli` / `ccm fir` normally, RTP flows, the connection reports `connected`, and RTCP decrypts fine. Only the frame counters reveal it.

Validated end to end by running the equivalent forwarder as an application-level innermost interceptor — same emission point in the chain, same `poll_read` — which restored the session to 60 fps, 2,196 frames, 5 dropped, PLI answered on connect.