### PR TITLE
chore: upgrade nix to 0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MIME_TYPE_ULP_FEC`, which remains public. **This changes the default offer's SDP**: payload
   type 116 is no longer present. ULPFEC will return to the defaults once receive-side recovery
   is implemented.
+- Upgrade `nix` to the newer version that allow compile `ohos` targets.
 
 ### Deprecated
 

--- a/rtc-shared/Cargo.toml
+++ b/rtc-shared/Cargo.toml
@@ -26,7 +26,7 @@ rand.workspace = true
 serde.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.26.2"
+nix = { version = "0.31", default-features = false, features = ["net"] }
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.3"


### PR DESCRIPTION
Upgrade `nix` to 0.31 that can compile `ohos` targets.  Nix start to support `ohos` from `0.30`