### PR TITLE
Stop scheduling ICE checks in terminal states

### DIFF
--- a/rtc-ice/src/agent/agent_proto.rs
+++ b/rtc-ice/src/agent/agent_proto.rs
@@ -139,7 +139,11 @@ impl sansio::Protocol<TaggedBytesMut, (), ()> for Agent {
             None
         };
 
-        let ice_timeout = if self.ufrag_pwd.remote_credentials.is_some() {
+        let ice_timeout = if self.ufrag_pwd.remote_credentials.is_some()
+            && !matches!(
+                self.connection_state,
+                ConnectionState::Failed | ConnectionState::Closed
+            ) {
             if self.force_candidate_contact {
                 // A connectivity check was requested; ask the driver to call
                 // `handle_timeout` as soon as possible. `last_checking_time` is in the

--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2974,6 +2974,70 @@ fn test_query_only_agent_queries_mdns_remote_candidate() -> Result<()> {
     Ok(())
 }
 
+/// A terminal ICE agent must not keep advertising its last connectivity-check deadline.
+///
+/// `contact` intentionally returns without updating `last_checking_time` after the agent fails.
+/// If `poll_timeout` continues to derive a deadline from that value, every call after failure
+/// returns the same instant in the past and a Sans-I/O driver can spin indefinitely.
+#[test]
+fn test_failed_agent_stops_and_restart_resumes_connectivity_check_timer() -> Result<()> {
+    let base = Instant::now();
+    let mut agent = Agent::new(
+        base,
+        Arc::new(AgentConfig {
+            multicast_dns_mode: crate::mdns::MulticastDnsMode::Disabled,
+            ..Default::default()
+        }),
+        test_crypto_provider(),
+    )?;
+
+    agent.start_connectivity_checks(
+        base,
+        true,
+        "remote-ufrag".to_owned(),
+        "remote-password".to_owned(),
+    )?;
+    agent.update_connection_state(
+        Some(base + Duration::from_secs(190)),
+        ConnectionState::Failed,
+    );
+
+    assert_eq!(
+        agent.poll_timeout(),
+        None,
+        "a failed agent has no more connectivity checks to schedule"
+    );
+    agent.handle_timeout(base + Duration::from_secs(191))?;
+    assert_eq!(
+        agent.poll_timeout(),
+        None,
+        "handling time after failure must not recreate the stale deadline"
+    );
+
+    let restart_time = base + Duration::from_secs(200);
+    agent.apply_restart(restart_time, true)?;
+    agent.start_connectivity_checks(
+        restart_time,
+        true,
+        "new-remote-ufrag".to_owned(),
+        "new-remote-password".to_owned(),
+    )?;
+
+    assert!(
+        agent.poll_timeout().is_some(),
+        "an ICE restart must resume connectivity-check scheduling"
+    );
+
+    agent.close()?;
+    assert_eq!(
+        agent.poll_timeout(),
+        None,
+        "a closed agent has no more connectivity checks to schedule"
+    );
+
+    Ok(())
+}
+
 /// Regression test: connectivity checks for a server-reflexive local candidate
 /// must be tagged with the candidate's base (the bound host socket), not the
 /// NAT-mapped srflx address (RFC 8445 §6.1.2). Drivers that route outbound


### PR DESCRIPTION
Fixes #158 

### Summary

- suppress connectivity-check deadlines while the ICE agent is `Failed` or `Closed`;
- continue polling independent mDNS deadlines;
- add a deterministic regression covering failure, repeated timeout handling, restart, and
  close.

### Why

`contact()` returns early in `Failed` without advancing `last_checking_time`, while
`poll_timeout()` previously kept deriving a deadline from that stale value. Drivers that
immediately service overdue deadlines could spin continuously without producing network writes
or RTC events.

An ICE restart is unaffected: `apply_restart()` transitions the agent out of the terminal state,
and `start_connectivity_checks()` installs remote credentials and resumes timer scheduling.

### Validation

Validation has been done on the devices mentioned in the issue

### AI disclosue
This PR was co-authored by GPT-5.6-sol