### PR TITLE
Rebase overdue TURN refresh deadlines from now

### DIFF
--- a/rtc-turn/src/client/client_test.rs
+++ b/rtc-turn/src/client/client_test.rs
@@ -239,15 +239,63 @@ fn test_relay_refresh_timers_run_on_injected_time() -> Result<()> {
     msg.decode()?;
     assert_eq!(msg.typ.method, METHOD_REFRESH);
 
-    // Both timers advance by a fixed step from where they were, rather than being recomputed
-    // against the wall clock: permissions are next again at 360s, the allocation at 600s.
-    assert_eq!(client.relay(relayed_addr)?.poll_timeout(), Some(t(360)));
+    // The late permission refresh at t(299) is rescheduled from the time it was handled, so its
+    // next deadline is t(419). The allocation remains due at t(600).
+    assert_eq!(client.relay(relayed_addr)?.poll_timeout(), Some(t(419)));
 
     client.relay(relayed_addr)?.handle_timeout(t(600));
     let transmit = client
         .poll_write()
         .expect("the allocation must be refreshed again a half-lifetime later");
     assert_eq!(transmit.now, t(600));
+
+    client.close()
+}
+
+/// Handling an overdue relay timer once must put every refreshed deadline back in the future.
+/// A runtime may be suspended for longer than several refresh intervals on a mobile platform;
+/// replaying each missed interval makes a Sans-I/O driver spin through historical deadlines.
+#[test]
+fn test_overdue_relay_refreshes_are_rescheduled_from_now() -> Result<()> {
+    let base = Instant::now();
+    let t = |secs| base + Duration::from_secs(secs);
+
+    let udp_socket = UdpSocket::bind("0.0.0.0:0")?;
+    let mut client = Client::new(
+        ClientConfig {
+            stun_serv_addr: String::new(),
+            turn_serv_addr: "127.0.0.1:3478".to_owned(),
+            local_addr: udp_socket.local_addr()?,
+            transport_protocol: TransportProtocol::UDP,
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+            realm: "realm".to_owned(),
+            software: "TEST SOFTWARE".to_owned(),
+            rto_in_ms: 0,
+        },
+        test_crypto_provider(),
+    )?;
+
+    let relayed_addr: RelayedAddr = "127.0.0.1:50000".parse().unwrap();
+    client.relays.insert(
+        relayed_addr,
+        RelayState::new(
+            t(0),
+            relayed_addr,
+            vec![0u8; 16],
+            Nonce::new(ATTR_NONCE, "nonce".to_owned()),
+            Duration::from_secs(600),
+        ),
+    );
+
+    let resumed_at = t(1000);
+    client.relay(relayed_addr)?.handle_timeout(resumed_at);
+
+    assert_eq!(
+        client.relay(relayed_addr)?.poll_timeout(),
+        Some(t(1120)),
+        "one timeout pass must move the permission and allocation deadlines past now"
+    );
 
     client.close()
 }

--- a/rtc-turn/src/client/relay.rs
+++ b/rtc-turn/src/client/relay.rs
@@ -136,30 +136,29 @@ impl Relay<'_> {
     }
 
     pub(crate) fn handle_timeout(&mut self, now: Instant) {
-        let (refresh_alloc_timer, refresh_perms_timer) = if let Some(relay) =
-            self.client.relays.get_mut(&self.relayed_addr)
-        {
-            let refresh_alloc_timer = if relay.refresh_alloc_timer <= now {
-                // Floored so the timer always moves. A zero step would leave it pinned to an
-                // instant already in the past — see `MIN_ALLOC_REFRESH_INTERVAL`.
-                let step = (relay.lifetime / 2).max(MIN_ALLOC_REFRESH_INTERVAL);
-                relay.refresh_alloc_timer = relay.refresh_alloc_timer.add(step);
-                Some(relay.lifetime)
-            } else {
-                None
-            };
+        let (refresh_alloc_timer, refresh_perms_timer) =
+            if let Some(relay) = self.client.relays.get_mut(&self.relayed_addr) {
+                let refresh_alloc_timer = if relay.refresh_alloc_timer <= now {
+                    // Floored so the timer always moves. A zero step would leave it pinned to an
+                    // instant already in the past — see `MIN_ALLOC_REFRESH_INTERVAL`.
+                    let step = (relay.lifetime / 2).max(MIN_ALLOC_REFRESH_INTERVAL);
+                    relay.refresh_alloc_timer = now.add(step);
+                    Some(relay.lifetime)
+                } else {
+                    None
+                };
 
-            let refresh_perms_timer = if relay.refresh_perms_timer <= now {
-                relay.refresh_perms_timer = relay.refresh_perms_timer.add(PERM_REFRESH_INTERVAL);
-                true
-            } else {
-                false
-            };
+                let refresh_perms_timer = if relay.refresh_perms_timer <= now {
+                    relay.refresh_perms_timer = now.add(PERM_REFRESH_INTERVAL);
+                    true
+                } else {
+                    false
+                };
 
-            (refresh_alloc_timer, refresh_perms_timer)
-        } else {
-            (None, false)
-        };
+                (refresh_alloc_timer, refresh_perms_timer)
+            } else {
+                (None, false)
+            };
 
         if let Some(lifetime) = refresh_alloc_timer {
             let _ = self.refresh_allocation(now, lifetime);


### PR DESCRIPTION
Fixes #160 

### Summary

- reschedule overdue allocation Refresh deadlines from the handled `now`;
- reschedule overdue permission refresh deadlines from the handled `now`;
- add a fake-clock regression covering a runtime that resumes several intervals late.

### Why

Adding one interval to an old deadline is appropriate while a runtime is driven continuously,
but it can keep producing deadlines in the past after suspension. Rebasing once from `now`
prevents a catch-up loop while preserving the configured cadence from that point forward.

AI disclosue

This PR was co-authored by GPT-5.6-sol