### PR TITLE
Allow capping TURN allocation Refresh intervals

### DIFF
--- a/examples/trickle-ice-relay/trickle-ice-relay.rs
+++ b/examples/trickle-ice-relay/trickle-ice-relay.rs
@@ -187,6 +187,7 @@ async fn run_main_loop(
         realm: turn_realm.to_string(),
         software: String::new(),
         rto_in_ms: 0,
+        allocation_refresh_interval_cap: None,
     };
 
     // An application is the outside caller, so it selects the crypto provider explicitly.

--- a/examples/trickle-ice/trickle-ice.rs
+++ b/examples/trickle-ice/trickle-ice.rs
@@ -284,6 +284,7 @@ async fn run_main_loop(cli: Cli) -> Result<()> {
                     realm: cli.turn_realm.to_string(),
                     software: String::new(),
                     rto_in_ms: 0,
+                    allocation_refresh_interval_cap: None,
                 };
 
                 let mut client = TurnClient::new(cfg, crypto::default_provider()?)?;

--- a/rtc-turn/examples/turn_client_udp.rs
+++ b/rtc-turn/examples/turn_client_udp.rs
@@ -92,6 +92,7 @@ fn main() -> Result<()> {
         realm: realm.to_string(),
         software: String::new(),
         rto_in_ms: 0,
+        allocation_refresh_interval_cap: None,
     };
 
     // An application selects the crypto provider; library code never resolves a default.

--- a/rtc-turn/src/client/client_test.rs
+++ b/rtc-turn/src/client/client_test.rs
@@ -22,6 +22,7 @@ fn create_listening_test_client(rto_in_ms: u64) -> Result<(UdpSocket, Client)> {
             realm: String::new(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;
@@ -43,6 +44,7 @@ fn create_listening_test_client_with_stun_serv() -> Result<(UdpSocket, Client)> 
             realm: String::new(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms: 0,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;
@@ -192,6 +194,7 @@ fn test_relay_refresh_timers_run_on_injected_time() -> Result<()> {
             realm: "realm".to_owned(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms: 0,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;
@@ -207,6 +210,7 @@ fn test_relay_refresh_timers_run_on_injected_time() -> Result<()> {
             vec![0u8; 16],
             Nonce::new(ATTR_NONCE, "nonce".to_owned()),
             lifetime,
+            None,
         ),
     );
 
@@ -252,6 +256,68 @@ fn test_relay_refresh_timers_run_on_injected_time() -> Result<()> {
     client.close()
 }
 
+/// Applications may refresh an otherwise idle allocation more frequently than half its server
+/// lifetime so the client-to-server NAT mapping does not sit idle for several minutes.
+#[test]
+fn test_allocation_refresh_interval_cap_is_applied() -> Result<()> {
+    let base = Instant::now();
+    let t = |secs| base + Duration::from_secs(secs);
+
+    let udp_socket = UdpSocket::bind("0.0.0.0:0")?;
+    let mut client = Client::new(
+        ClientConfig {
+            stun_serv_addr: String::new(),
+            turn_serv_addr: "127.0.0.1:3478".to_owned(),
+            local_addr: udp_socket.local_addr()?,
+            transport_protocol: TransportProtocol::UDP,
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+            realm: "realm".to_owned(),
+            software: "TEST SOFTWARE".to_owned(),
+            rto_in_ms: 0,
+            allocation_refresh_interval_cap: Some(Duration::from_secs(30)),
+        },
+        test_crypto_provider(),
+    )?;
+
+    let relayed_addr: RelayedAddr = "127.0.0.1:50000".parse().unwrap();
+    let mut response = Message::new();
+    response.build(&[
+        Box::new(TransactionId::new()),
+        Box::new(MessageType::new(METHOD_ALLOCATE, CLASS_SUCCESS_RESPONSE)),
+        Box::new(RelayedAddress {
+            ip: relayed_addr.ip(),
+            port: relayed_addr.port(),
+        }),
+        Box::new(crate::proto::lifetime::Lifetime(Duration::from_secs(600))),
+    ])?;
+    client.handle_allocate_response(
+        base,
+        response,
+        TransactionType::AllocateRequest(Nonce::new(ATTR_NONCE, "nonce".to_owned())),
+    )?;
+
+    for expected_secs in [30, 60, 90, 120, 150, 180] {
+        assert_eq!(
+            client.relay(relayed_addr)?.poll_timeout(),
+            Some(t(expected_secs))
+        );
+        client.relay(relayed_addr)?.handle_timeout(t(expected_secs));
+
+        let transmit = client
+            .poll_write()
+            .expect("the configured cadence must emit an allocation Refresh");
+        let mut message = Message::new();
+        message.raw = transmit.message.to_vec();
+        message.decode()?;
+        assert_eq!(message.typ.method, METHOD_REFRESH);
+    }
+
+    assert_eq!(client.relay(relayed_addr)?.poll_timeout(), Some(t(210)));
+
+    client.close()
+}
+
 /// A relay whose lifetime has gone to zero must not hand the caller a deadline that never
 /// advances.
 ///
@@ -289,6 +355,7 @@ fn test_zero_lifetime_relay_does_not_freeze_its_deadline() -> Result<()> {
             realm: "realm".to_owned(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms: 0,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;
@@ -302,6 +369,7 @@ fn test_zero_lifetime_relay_does_not_freeze_its_deadline() -> Result<()> {
             vec![0u8; 16],
             Nonce::new(ATTR_NONCE, "nonce".to_owned()),
             Duration::from_secs(600),
+            None,
         ),
     );
 
@@ -357,6 +425,7 @@ fn test_zero_lifetime_response_drops_the_relay() -> Result<()> {
             realm: "realm".to_owned(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms: 0,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;
@@ -370,6 +439,7 @@ fn test_zero_lifetime_response_drops_the_relay() -> Result<()> {
             vec![0u8; 16],
             Nonce::new(ATTR_NONCE, "nonce".to_owned()),
             Duration::from_secs(600),
+            None,
         ),
     );
     assert!(client.relay(relayed_addr)?.poll_timeout().is_some());
@@ -423,6 +493,7 @@ fn test_zero_lifetime_allocate_response_is_an_error() -> Result<()> {
             realm: "realm".to_owned(),
             software: "TEST SOFTWARE".to_owned(),
             rto_in_ms: 0,
+            allocation_refresh_interval_cap: None,
         },
         test_crypto_provider(),
     )?;

--- a/rtc-turn/src/client/mod.rs
+++ b/rtc-turn/src/client/mod.rs
@@ -132,6 +132,12 @@ pub struct ClientConfig {
     pub software: String,
     /// The initial retransmission timeout in milliseconds; each retry doubles it.
     pub rto_in_ms: u64,
+    /// Optional upper bound for the interval between allocation Refresh requests.
+    ///
+    /// By default, allocations are refreshed at half the lifetime advertised by the server.
+    /// A shorter cap can also keep the client-to-server NAT mapping active when an allocation
+    /// waits without carrying application traffic. Values below one second are rounded up.
+    pub allocation_refresh_interval_cap: Option<Duration>,
 }
 
 /// Client is a STUN client
@@ -148,6 +154,7 @@ pub struct Client {
     tr_map: TransactionMap,
     binding_mgr: BindingManager,
     rto_in_ms: u64,
+    allocation_refresh_interval_cap: Option<Duration>,
 
     relays: HashMap<RelayedAddr, RelayState>,
     transmits: VecDeque<TransportMessage<BytesMut>>,
@@ -194,6 +201,7 @@ impl Client {
             } else {
                 DEFAULT_RTO_IN_MS
             },
+            allocation_refresh_interval_cap: config.allocation_refresh_interval_cap,
             relays: HashMap::new(),
             transmits: VecDeque::new(),
             events: VecDeque::new(),
@@ -694,6 +702,7 @@ impl Client {
                         )?,
                         nonce,
                         lifetime.0,
+                        self.allocation_refresh_interval_cap,
                     ),
                 );
                 self.events.push_back(Event::AllocateResponse(

--- a/rtc-turn/src/client/relay.rs
+++ b/rtc-turn/src/client/relay.rs
@@ -35,12 +35,20 @@ const MAX_RETRY_ATTEMPTS: u16 = 3;
 /// [webrtc#862](https://github.com/webrtc-rs/webrtc/issues/862).
 const MIN_ALLOC_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
+fn allocation_refresh_interval(lifetime: Duration, interval_cap: Option<Duration>) -> Duration {
+    let half_lifetime = lifetime / 2;
+    interval_cap
+        .map_or(half_lifetime, |cap| half_lifetime.min(cap))
+        .max(MIN_ALLOC_REFRESH_INTERVAL)
+}
+
 // RelayState is a set of params use by Relay
 pub(crate) struct RelayState {
     pub(crate) relayed_addr: RelayedAddr,
     pub(crate) long_term_integrity_key: Vec<u8>,
     pub(crate) nonce: Nonce,
     pub(crate) lifetime: Duration,
+    allocation_refresh_interval_cap: Option<Duration>,
     perm_map: HashMap<SocketAddr, Permission>,
     refresh_alloc_timer: Instant,
     refresh_perms_timer: Instant,
@@ -53,6 +61,7 @@ impl RelayState {
         long_term_integrity_key: Vec<u8>,
         nonce: Nonce,
         lifetime: Duration,
+        allocation_refresh_interval_cap: Option<Duration>,
     ) -> Self {
         debug!("initial lifetime: {} seconds", lifetime.as_secs());
 
@@ -61,8 +70,12 @@ impl RelayState {
             long_term_integrity_key,
             nonce,
             lifetime,
+            allocation_refresh_interval_cap,
             perm_map: HashMap::new(),
-            refresh_alloc_timer: now.add(lifetime / 2),
+            refresh_alloc_timer: now.add(allocation_refresh_interval(
+                lifetime,
+                allocation_refresh_interval_cap,
+            )),
             refresh_perms_timer: now.add(PERM_REFRESH_INTERVAL),
         }
     }
@@ -142,7 +155,10 @@ impl Relay<'_> {
             let refresh_alloc_timer = if relay.refresh_alloc_timer <= now {
                 // Floored so the timer always moves. A zero step would leave it pinned to an
                 // instant already in the past — see `MIN_ALLOC_REFRESH_INTERVAL`.
-                let step = (relay.lifetime / 2).max(MIN_ALLOC_REFRESH_INTERVAL);
+                let step = allocation_refresh_interval(
+                    relay.lifetime,
+                    relay.allocation_refresh_interval_cap,
+                );
                 relay.refresh_alloc_timer = relay.refresh_alloc_timer.add(step);
                 Some(relay.lifetime)
             } else {

--- a/rtc-turn/src/lib.rs
+++ b/rtc-turn/src/lib.rs
@@ -36,6 +36,7 @@
 //!     stun_serv_addr: String::new(), // optional: only for Binding requests
 //!     software: String::new(),
 //!     rto_in_ms: 0, // 0 selects the default retransmission timeout
+//!     allocation_refresh_interval_cap: None,
 //! };
 //! assert_eq!(config.turn_serv_addr, "turn.example.com:3478");
 //! ```


### PR DESCRIPTION
Closes #162 

### Summary

- add `ClientConfig::allocation_refresh_interval_cap`;
- preserve the existing half-lifetime cadence when the option is `None`;
- apply the opt-in cap to initial and subsequent allocation Refresh deadlines;
- retain the existing one-second minimum interval;
- add a fake-clock regression covering six 30-second Refreshes through 180 seconds.

### Why

The client-to-server NAT mapping may expire well before the TURN server's allocation. An optional
cap lets applications keep that path active without increasing traffic for callers that do not
need it.


### AI disclosue

This PR was co-authored by GPT-5.6-sol