### PR TITLE
fix(ice): honor zero failed timeout while checking

### DIFF
--- a/rtc-ice/src/agent/agent_test.rs
+++ b/rtc-ice/src/agent/agent_test.rs
@@ -2038,6 +2038,32 @@ fn test_lite_lifecycle() -> Result<()> {
 }
 */
 
+#[test]
+fn test_zero_failed_timeout_keeps_checking_agent_recoverable() -> Result<()> {
+    let base = Instant::now();
+    let mut agent = Agent::new(
+        base,
+        Arc::new(AgentConfig {
+            disconnected_timeout: Some(Duration::from_secs(5)),
+            failed_timeout: Some(Duration::ZERO),
+            ..Default::default()
+        }),
+        test_crypto_provider(),
+    )?;
+
+    agent.connection_state = ConnectionState::Checking;
+    agent.last_connection_state = ConnectionState::Checking;
+    agent.checking_duration = base;
+    agent.contact(base + Duration::from_secs(3600));
+
+    assert_eq!(
+        agent.connection_state,
+        ConnectionState::Checking,
+        "a zero failed timeout is documented to disable the terminal transition"
+    );
+    Ok(())
+}
+
 /// Test role conflict when both agents are controlling
 /// RFC 8445 Section 7.3.1.1 - Agent with smaller tiebreaker should switch to controlled
 #[test]
@@ -2819,8 +2845,8 @@ fn test_handle_inbound_request_defers_failing_connectivity_check() -> Result<()>
     use sansio::Protocol as _;
 
     let cfg = AgentConfig {
-        disconnected_timeout: Some(Duration::from_secs(0)),
-        failed_timeout: Some(Duration::from_secs(0)),
+        disconnected_timeout: Some(Duration::from_secs(1)),
+        failed_timeout: Some(Duration::from_secs(1)),
         ..Default::default()
     };
     let mut a = Agent::new(Instant::now(), Arc::new(cfg), test_crypto_provider())?;

--- a/rtc-ice/src/agent/mod.rs
+++ b/rtc-ice/src/agent/mod.rs
@@ -776,10 +776,11 @@ impl Agent {
             }
 
             // We have been in checking longer then Disconnect+Failed timeout, set the connection to Failed
-            if now
-                .checked_duration_since(self.checking_duration)
-                .unwrap_or_else(|| Duration::from_secs(0))
-                > self.disconnected_timeout + self.failed_timeout
+            if self.failed_timeout != ZERO_DURATION
+                && now
+                    .checked_duration_since(self.checking_duration)
+                    .unwrap_or_else(|| Duration::from_secs(0))
+                    > self.disconnected_timeout + self.failed_timeout
             {
                 self.update_connection_state(Some(now), ConnectionState::Failed);
                 self.last_connection_state = self.connection_state;


### PR DESCRIPTION
Fixes #164 
### Summary

- prevent `Checking → Failed` when `failed_timeout` is zero;
- add a deterministic regression for the documented zero-timeout behavior;
- update an existing test that relied on zero meaning immediate failure to
  use explicit finite timeouts.

### Why

`AgentConfig` documents zero as “never go to failed,” but the initial
checking timeout path did not apply that sentinel. Applications using
asynchronous signaling could therefore lose every candidate before the
remote peer received the answer.

### Compatibility

Behavior changes only when callers explicitly configure a zero failed
timeout. Default timeout behavior is unchanged.

### AI disclosure

This change was developed with GPT-5.6-sol assistance.
