### PR TITLE
feat(peer-connection): expose ICE restart generation

### DIFF
--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -195,6 +195,7 @@ where
             last_offer: String::new(),
             last_answer: String::new(),
             ice_restart_requested: None,
+            ice_restart_generation: 0,
             negotiation_needed_state: NegotiationNeededState::Empty,
             is_negotiation_ongoing: false,
         })
@@ -1290,8 +1291,13 @@ where
             .setting_engine
             .candidates
             .discard_local_candidates_during_ice_restart;
+        let restart_staged = self.ice_transport().has_pending_restart();
         self.ice_transport_mut()
-            .apply_restart(now, keep_local_candidates)
+            .apply_restart(now, keep_local_candidates)?;
+        if restart_staged {
+            self.ice_restart_generation = self.ice_restart_generation.wrapping_add(1);
+        }
+        Ok(())
     }
 
     pub(super) fn start_transports(

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -729,6 +729,7 @@ where
     last_answer: String,
 
     ice_restart_requested: Option<RTCOfferOptions>,
+    ice_restart_generation: u64,
     negotiation_needed_state: NegotiationNeededState,
     is_negotiation_ongoing: bool,
 }
@@ -1781,6 +1782,15 @@ where
     /// See [restartIce](https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-restartice)
     pub fn restart_ice(&mut self) {
         self.ice_restart_requested = Some(RTCOfferOptions { ice_restart: true });
+    }
+
+    /// Returns the number of ICE restarts applied to this peer connection.
+    ///
+    /// Wrappers that own the network sockets can compare this value before and
+    /// after an operation to detect implicit restarts, such as an answerer
+    /// applying an offer with new remote ICE credentials.
+    pub fn ice_restart_generation(&self) -> u64 {
+        self.ice_restart_generation
     }
 
     /// Returns the current configuration of this peer connection.


### PR DESCRIPTION
## Summary

- expose a per-`RTCPeerConnection` ICE restart generation counter
- increment it when the sans-I/O peer connection actually applies a staged restart
- make the counter observable to async wrappers that own ICE/UDP socket resources

## Motivation

An ICE restart can be requested explicitly by the local application, but it can
also be applied implicitly while an answerer processes a remote offer with new
ICE credentials. The async wrapper needs a reliable signal for both cases so it
can coordinate transport resources with the new ICE generation.

The counter is incremented from `apply_ice_restart` only after a pending restart
has been applied successfully. Requests that merely stage a restart do not
advance it, and failed applications do not advance it. Callers can compare the
value before and after an operation to detect a completed restart.

This is an additive API change and does not alter ICE negotiation or candidate
behavior for existing callers.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --lib --bins --all-targets`
- Full test suite not run locally.

This hook is intended to support the corresponding async transport fix in
webrtc-rs/webrtc#871.
