### PR TITLE
defer data channel open until DCEP handshake completes

### DIFF
--- a/rtc-datachannel/src/data_channel/data_channel_test.rs
+++ b/rtc-datachannel/src/data_channel/data_channel_test.rs
@@ -249,6 +249,10 @@ fn test_data_channel_negotiated_opens_stream_without_dcep_handshake() -> Result<
         dc.poll_write().is_none(),
         "no further DCEP messages expected for a negotiated channel"
     );
+    assert!(
+        dc.is_handshake_complete(),
+        "an out-of-band negotiated channel is open immediately (no DCEP handshake)"
+    );
 
     Ok(())
 }
@@ -272,6 +276,101 @@ fn test_data_channel_in_band_open_is_transmitted() -> Result<()> {
     assert!(
         !msg.negotiated,
         "an in-band DATA_CHANNEL_OPEN must be transmitted to the peer"
+    );
+    assert!(
+        !dc.is_handshake_complete(),
+        "an in-band channel is not open until the peer's DATA_CHANNEL_ACK arrives"
+    );
+
+    Ok(())
+}
+
+/// An in-band channel becomes open the moment its `DATA_CHANNEL_ACK` is processed.
+#[test]
+fn test_data_channel_in_band_open_on_data_channel_ack() -> Result<()> {
+    let (a0, _a1) = create_new_association_pair()?;
+
+    let cfg = DataChannelConfig {
+        channel_type: ChannelType::Reliable,
+        label: "in-band".to_string(),
+        negotiated: false,
+        ..Default::default()
+    };
+
+    let mut dc = DataChannel::dial(cfg, a0, 100)?;
+    assert!(!dc.is_handshake_complete());
+
+    // The dialed channel is a Protocol<DataChannelMessage, ...>; feed it the peer's ACK.
+    let ack_bytes = Message::DataChannelAck(DataChannelAck {}).marshal()?;
+    dc.handle_read(DataChannelMessage {
+        association_handle: a0,
+        stream_id: 100,
+        ppi: PayloadProtocolIdentifier::Dcep,
+        payload: BytesMut::from(&ack_bytes[..]),
+        negotiated: false,
+    })?;
+
+    assert!(
+        dc.is_handshake_complete(),
+        "receiving DATA_CHANNEL_ACK must mark the local channel as open"
+    );
+
+    Ok(())
+}
+
+/// A remote channel is open from `accept()`: the peer's `DATA_CHANNEL_OPEN` has
+/// been processed and the ACK is written out, completing the handshake.
+#[test]
+fn test_data_channel_accept_marks_remote_channel_open() -> Result<()> {
+    let (a0, _a1) = create_new_association_pair()?;
+
+    let open_bytes = Message::DataChannelOpen(DataChannelOpen {
+        channel_type: ChannelType::Reliable,
+        priority: CHANNEL_PRIORITY_NORMAL,
+        reliability_parameter: 0,
+        label: b"remote".to_vec(),
+        protocol: Vec::new(),
+    })
+    .marshal()?;
+
+    let dc = DataChannel::accept(
+        DataChannelConfig::default(),
+        a0,
+        100,
+        PayloadProtocolIdentifier::Dcep,
+        &open_bytes[..],
+    )?;
+
+    assert!(
+        dc.is_handshake_complete(),
+        "accept() processing the peer's DATA_CHANNEL_OPEN must mark the remote channel as open"
+    );
+
+    Ok(())
+}
+
+/// Closing an open channel clears the handshake-complete flag.
+#[test]
+fn test_data_channel_close_resets_handshake_complete_flag() -> Result<()> {
+    let (a0, _a1) = create_new_association_pair()?;
+
+    let cfg = DataChannelConfig {
+        channel_type: ChannelType::Reliable,
+        label: "negotiated".to_string(),
+        negotiated: true,
+        ..Default::default()
+    };
+
+    let mut dc = DataChannel::dial(cfg, a0, 100)?;
+    assert!(
+        dc.is_handshake_complete(),
+        "an out-of-band negotiated channel is open immediately (no DCEP handshake)"
+    );
+
+    dc.close()?;
+    assert!(
+        !dc.is_handshake_complete(),
+        "closing an open channel must clear the handshake-complete flag"
     );
 
     Ok(())

--- a/rtc-datachannel/src/data_channel/mod.rs
+++ b/rtc-datachannel/src/data_channel/mod.rs
@@ -78,6 +78,9 @@ pub struct DataChannel {
     read_outs: VecDeque<DataChannelMessage>,
     write_outs: VecDeque<DataChannelMessage>,
 
+    /// Whether the DCEP handshake for this channel has completed.
+    handshake_complete: bool,
+
     // stats
     messages_sent: usize,
     messages_received: usize,
@@ -129,6 +132,11 @@ impl DataChannel {
             negotiated: config.negotiated,
         });
 
+        // Out-of-band `negotiated` channels have no handshake, so they are
+        // handshake-complete immediately. In-band channels stay incomplete until
+        // `handle_dcep` processes the peer's `DATA_CHANNEL_ACK`.
+        data_channel.handshake_complete = config.negotiated;
+
         Ok(data_channel)
     }
 
@@ -160,6 +168,10 @@ impl DataChannel {
         let mut data_channel = DataChannel::new(config, association_handle, stream_id);
 
         data_channel.write_data_channel_ack()?;
+
+        // The remote side's OPEN has been processed and the ACK is written out,
+        // so the handshake is complete.
+        data_channel.handshake_complete = true;
 
         Ok(data_channel)
     }
@@ -199,6 +211,15 @@ impl DataChannel {
         &self.config
     }
 
+    /// Whether the DCEP handshake for this channel has completed.
+    ///
+    /// For a locally-created in-band channel this becomes `true` only when the peer's
+    /// `DATA_CHANNEL_ACK` is received; for a remote channel it is `true` from `accept()`;
+    /// for an out-of-band `negotiated` channel it is `true` from `dial()`.
+    pub fn is_handshake_complete(&self) -> bool {
+        self.handshake_complete
+    }
+
     fn handle_dcep<B>(&mut self, data: &mut B) -> Result<()>
     where
         B: Buf,
@@ -214,6 +235,8 @@ impl DataChannel {
             }
             Message::DataChannelAck(_) => {
                 debug!("Received DATA_CHANNEL_ACK");
+                // The initiator's DCEP handshake is complete.
+                self.handshake_complete = true;
             }
             _ => {
                 return Err(Error::InvalidMessageType(msg.message_type() as u8));
@@ -442,6 +465,8 @@ impl sansio::Protocol<DataChannelMessage, DataChannelMessage, ()> for DataChanne
         // a corresponding notification to the application layer that the reset
         // has been performed.  Streams are available for reuse after a reset
         // has been performed.
+        // Closing resets the handshake-complete flag.
+        self.handshake_complete = false;
         self.write_data_channel_close()
     }
 }

--- a/src/data_channel/internal.rs
+++ b/src/data_channel/internal.rs
@@ -5,6 +5,7 @@ use datachannel::data_channel::DataChannelConfig;
 use sansio::Protocol;
 use sctp::PayloadProtocolIdentifier;
 use shared::error::Result;
+use std::time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct RTCDataChannelInternal {
@@ -26,6 +27,14 @@ pub(crate) struct RTCDataChannelInternal {
     /// for synchronous send back-pressure.
     pub(crate) outstanding_bytes: usize,
 
+    /// Deadline by which an in-band channel's DCEP handshake must complete.
+    /// Set when the channel is dialed; cleared on handshake completion or close.
+    pub(crate) handshake_deadline: Option<Instant>,
+
+    /// Set when the DCEP handshake times out and `OnClose` has already been
+    /// emitted. Prevents `SCTPStreamClosed` from emitting/counting a second close.
+    pub(crate) close_emitted: bool,
+
     pub(crate) data_channel: Option<::datachannel::data_channel::DataChannel>,
 }
 
@@ -43,6 +52,8 @@ impl Default for RTCDataChannelInternal {
             buffered_amount_high_threshold: u32::MAX,
             buffered_amount_low_threshold: 0,
             outstanding_bytes: 0,
+            handshake_deadline: None,
+            close_emitted: false,
             data_channel: None,
         }
     }
@@ -63,6 +74,8 @@ impl RTCDataChannelInternal {
             buffered_amount_high_threshold: u32::MAX,
             buffered_amount_low_threshold: 0,
             outstanding_bytes: 0,
+            handshake_deadline: None,
+            close_emitted: false,
             data_channel: None,
         }
     }
@@ -90,7 +103,15 @@ impl RTCDataChannelInternal {
         data_channel.set_buffered_amount_high_threshold(self.buffered_amount_high_threshold)?;
 
         self.data_channel = Some(data_channel);
-        self.ready_state = RTCDataChannelState::Open;
+
+        // An in-band channel stays `Connecting` until the peer's `DATA_CHANNEL_ACK`
+        // is processed in `DataChannelHandler::handle_read`. An out-of-band
+        // `negotiated` channel has no DCEP handshake, so it is open immediately.
+        self.ready_state = if self.negotiated {
+            RTCDataChannelState::Open
+        } else {
+            RTCDataChannelState::Connecting
+        };
 
         Ok(())
     }
@@ -137,6 +158,7 @@ impl RTCDataChannelInternal {
         if let Some(data_channel) = self.data_channel.as_mut() {
             data_channel.close()?;
         }
+        self.handshake_deadline = None;
         self.ready_state = RTCDataChannelState::Closed;
         Ok(())
     }

--- a/src/peer_connection/configuration/setting_engine.rs
+++ b/src/peer_connection/configuration/setting_engine.rs
@@ -167,6 +167,22 @@ pub struct Timeout {
     pub ice_relay_acceptance_min_wait: Option<Duration>,
 }
 
+/// Data-channel configuration for in-band channels.
+#[derive(Clone)]
+pub struct DataChannel {
+    /// Maximum time to wait for a peer's `DATA_CHANNEL_ACK` before failing an
+    /// in-band data channel. `None` disables the timeout.
+    pub dcep_handshake_timeout: Option<Duration>,
+}
+
+impl Default for DataChannel {
+    fn default() -> Self {
+        Self {
+            dcep_handshake_timeout: Some(Duration::from_secs(30)),
+        }
+    }
+}
+
 /// MulticastDNS configuration for mDNS.
 #[derive(Clone)]
 pub struct MulticastDNS {
@@ -334,6 +350,7 @@ impl Default for SctpMaxMessageSize {
 pub struct SettingEngine {
     pub(crate) crypto_provider: Option<Arc<dyn RTCCryptoProvider>>,
     pub(crate) timeout: Timeout,
+    pub(crate) data_channel: DataChannel,
     pub(crate) turn_allocation_refresh_interval_cap: Option<Duration>,
     pub(crate) candidates: Candidates,
     pub(crate) multicast_dns: MulticastDNS,
@@ -552,6 +569,17 @@ impl SettingEngineBuilder {
         self.0.timeout.ice_disconnected_timeout = disconnected_timeout;
         self.0.timeout.ice_failed_timeout = failed_timeout;
         self.0.timeout.ice_keepalive_interval = keep_alive_interval;
+        self
+    }
+
+    /// Configures the DCEP handshake timeout for in-band data channels.
+    ///
+    /// # Parameters
+    ///
+    /// * `timeout` - Maximum time to wait for the peer's `DATA_CHANNEL_ACK`,
+    ///   or `None` to disable the timeout.
+    pub fn with_dcep_handshake_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.0.data_channel.dcep_handshake_timeout = timeout;
         self
     }
 

--- a/src/peer_connection/handler/datachannel.rs
+++ b/src/peer_connection/handler/datachannel.rs
@@ -15,7 +15,7 @@ use sctp::PayloadProtocolIdentifier;
 use shared::TransportContext;
 use shared::error::{Error, Result};
 use std::collections::{HashMap, VecDeque};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub(crate) struct DataChannelHandlerContext {
     pub(crate) read_outs: VecDeque<TaggedRTCMessageInternal>,
@@ -53,6 +53,8 @@ pub(crate) struct DataChannelHandler<'a> {
     ctx: &'a mut DataChannelHandlerContext,
     data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
     stats: &'a mut RTCStatsAccumulator,
+    /// Configured DCEP handshake timeout for in-band channels. `None` disables it.
+    dcep_handshake_timeout: Option<Duration>,
 }
 
 impl<'a> DataChannelHandler<'a> {
@@ -60,16 +62,49 @@ impl<'a> DataChannelHandler<'a> {
         ctx: &'a mut DataChannelHandlerContext,
         data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
         stats: &'a mut RTCStatsAccumulator,
+        dcep_handshake_timeout: Option<Duration>,
     ) -> Self {
         DataChannelHandler {
             ctx,
             data_channels,
             stats,
+            dcep_handshake_timeout,
         }
     }
 
     pub(crate) fn name(&self) -> &'static str {
         "DataChannelHandler"
+    }
+
+    /// Emit the `DataChannelEvent::Open` application message and record the
+    /// corresponding peer-connection and per-channel statistics.
+    ///
+    /// The caller must have already ensured the channel's `ready_state` is `Open`.
+    fn emit_data_channel_opened(
+        &mut self,
+        now: Instant,
+        transport: TransportContext,
+        id: RTCDataChannelId,
+    ) -> Result<()> {
+        let dc = self
+            .data_channels
+            .get(&id)
+            .ok_or(Error::ErrDataChannelNotExisted)?;
+
+        self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
+            now,
+            transport,
+            message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(ApplicationMessage {
+                data_channel_id: id,
+                data_channel_event: DataChannelEvent::Open,
+            })),
+        });
+
+        self.stats.peer_connection.on_data_channel_opened();
+        self.stats
+            .get_or_create_data_channel(id, &dc.label, &dc.protocol)
+            .on_state_changed(RTCDataChannelState::Open);
+        Ok(())
     }
 }
 
@@ -94,13 +129,32 @@ impl<'a>
             );
 
             let stream_id = message.stream_id;
+            let transport = msg.transport;
 
-            if let Some(data_channel_internal) = self.data_channels.get_mut(&stream_id) {
+            let opened = if let Some(data_channel_internal) = self.data_channels.get_mut(&stream_id)
+            {
+                // A closed channel is terminal: ignore any late DCEP or user data.
+                if data_channel_internal.ready_state == RTCDataChannelState::Closed {
+                    return Ok(());
+                }
+
+                // Process the inbound message, then check whether a still-connecting
+                // in-band channel just completed its DCEP handshake (initiator side).
+                // If so, promote it to Open and emit the open event.
+                let mut opened = false;
                 let data_channel = data_channel_internal
                     .data_channel
                     .as_mut()
                     .ok_or(Error::ErrDataChannelNotExisted)?;
                 data_channel.handle_read(message)?;
+                if data_channel.is_handshake_complete()
+                    && data_channel_internal.ready_state == RTCDataChannelState::Connecting
+                {
+                    data_channel_internal.ready_state = RTCDataChannelState::Open;
+                    data_channel_internal.handshake_deadline = None;
+                    opened = true;
+                }
+                opened
             } else {
                 let data_channel_internal = RTCDataChannelInternal::accept(
                     message.association_handle,
@@ -109,30 +163,13 @@ impl<'a>
                     &message.payload,
                 )?;
 
-                self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                    now: msg.now,
-                    transport: msg.transport,
-                    message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
-                        ApplicationMessage {
-                            data_channel_id: message.stream_id,
-                            data_channel_event: DataChannelEvent::Open,
-                        },
-                    )),
-                });
-
-                // Track data channel opened
-                self.stats.peer_connection.on_data_channel_opened();
-                // Initialize data channel stats
-                self.stats
-                    .get_or_create_data_channel(
-                        stream_id,
-                        &data_channel_internal.label,
-                        &data_channel_internal.protocol,
-                    )
-                    .on_state_changed(RTCDataChannelState::Open);
-
                 self.data_channels
                     .insert(message.stream_id, data_channel_internal);
+                true
+            };
+
+            if opened {
+                self.emit_data_channel_opened(now, transport, stream_id)?;
             }
 
             // Get label/protocol before taking mutable borrow for the loop
@@ -144,6 +181,15 @@ impl<'a>
                 (dc.label.clone(), dc.protocol.clone())
             };
 
+            // Only deliver application messages once the channel is Open. Messages that
+            // arrive while it is still Connecting stay buffered in the underlying
+            // DataChannel's read queue; they drain once the channel opens, or are
+            // discarded on close/timeout.
+            let is_open = self
+                .data_channels
+                .get(&stream_id)
+                .is_some_and(|dc| dc.ready_state == RTCDataChannelState::Open);
+
             let data_channel = self
                 .data_channels
                 .get_mut(&stream_id)
@@ -152,45 +198,50 @@ impl<'a>
                 .as_mut()
                 .ok_or(Error::ErrDataChannelNotExisted)?;
 
-            while let Some(data_channel_message) = data_channel.poll_read() {
-                let payload_len = data_channel_message.payload.len();
-                debug!("recv application message {:?}", msg.transport.peer_addr);
+            if is_open {
+                while let Some(data_channel_message) = data_channel.poll_read() {
+                    let payload_len = data_channel_message.payload.len();
+                    debug!("recv application message {:?}", msg.transport.peer_addr);
 
-                // Track received message stats
-                self.stats
-                    .get_or_create_data_channel(stream_id, &label, &protocol)
-                    .on_message_received(payload_len);
+                    // Track received message stats
+                    self.stats
+                        .get_or_create_data_channel(stream_id, &label, &protocol)
+                        .on_message_received(payload_len);
 
-                // https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-12#section-6.6
-                // When receiving an SCTP user message with one of these [Empty]
-                // PPIDs, the receiver MUST ignore the SCTP user message and
-                // process it as an empty message.
-                let message_data = if matches!(
-                    data_channel_message.ppi,
-                    PayloadProtocolIdentifier::StringEmpty | PayloadProtocolIdentifier::BinaryEmpty
-                ) {
-                    Default::default()
-                } else {
-                    data_channel_message.payload
-                };
+                    // https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-12#section-6.6
+                    // When receiving an SCTP user message with one of these [Empty]
+                    // PPIDs, the receiver MUST ignore the SCTP user message and
+                    // process it as an empty message.
+                    let message_data = if matches!(
+                        data_channel_message.ppi,
+                        PayloadProtocolIdentifier::StringEmpty
+                            | PayloadProtocolIdentifier::BinaryEmpty
+                    ) {
+                        Default::default()
+                    } else {
+                        data_channel_message.payload
+                    };
 
-                self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                    now: msg.now,
-                    transport: msg.transport,
-                    message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
-                        ApplicationMessage {
-                            data_channel_id: stream_id,
-                            data_channel_event: DataChannelEvent::Message(RTCDataChannelMessage {
-                                is_string: matches!(
-                                    data_channel_message.ppi,
-                                    PayloadProtocolIdentifier::String
-                                        | PayloadProtocolIdentifier::StringEmpty
+                    self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
+                        now: msg.now,
+                        transport: msg.transport,
+                        message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
+                            ApplicationMessage {
+                                data_channel_id: stream_id,
+                                data_channel_event: DataChannelEvent::Message(
+                                    RTCDataChannelMessage {
+                                        is_string: matches!(
+                                            data_channel_message.ppi,
+                                            PayloadProtocolIdentifier::String
+                                                | PayloadProtocolIdentifier::StringEmpty
+                                        ),
+                                        data: message_data,
+                                    },
                                 ),
-                                data: message_data,
-                            }),
-                        },
-                    )),
-                });
+                            },
+                        )),
+                    });
+                }
             }
 
             while let Some(data_channel_message) = data_channel.poll_write() {
@@ -296,35 +347,32 @@ impl<'a>
         let now = evt.now;
         match evt.event {
             RTCEventInternal::SCTPHandshakeComplete(association_handle) => {
+                // Out-of-band negotiated channels have no DCEP handshake, so they are
+                // open immediately and fire the open event here. In-band channels stay
+                // connecting until their `DATA_CHANNEL_ACK` arrives in `handle_read`.
+                let mut opened = Vec::new();
                 for data_channel_internal in self.data_channels.values_mut() {
-                    if data_channel_internal.ready_state == RTCDataChannelState::Connecting {
+                    // Only dial channels that have not been dialed yet. An in-band channel stays
+                    // Connecting after dialing, so the ready_state guard alone does not
+                    // exclude it from a second SCTPHandshakeComplete.
+                    if data_channel_internal.ready_state == RTCDataChannelState::Connecting
+                        && data_channel_internal.data_channel.is_none()
+                    {
                         data_channel_internal.dial(association_handle)?;
+
+                        if data_channel_internal.negotiated {
+                            opened.push(data_channel_internal.id);
+                        } else {
+                            // In-band channels have a DCEP handshake to complete; arm a
+                            // deadline so a lost ACK cannot leave them Connecting forever.
+                            data_channel_internal.handshake_deadline =
+                                self.dcep_handshake_timeout.map(|timeout| now + timeout);
+                        }
 
                         let data_channel = data_channel_internal
                             .data_channel
                             .as_mut()
                             .ok_or(Error::ErrDataChannelNotExisted)?;
-
-                        self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                            now,
-                            transport: TransportContext::default(),
-                            message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
-                                ApplicationMessage {
-                                    data_channel_id: data_channel_internal.id,
-                                    data_channel_event: DataChannelEvent::Open,
-                                },
-                            )),
-                        });
-
-                        // Track data channel opened (initiator side)
-                        self.stats.peer_connection.on_data_channel_opened();
-                        self.stats
-                            .get_or_create_data_channel(
-                                data_channel_internal.id,
-                                &data_channel_internal.label,
-                                &data_channel_internal.protocol,
-                            )
-                            .on_state_changed(RTCDataChannelState::Open);
 
                         while let Some(data_channel_message) = data_channel.poll_write() {
                             debug!("send data channel message from handle_event");
@@ -338,26 +386,35 @@ impl<'a>
                         }
                     }
                 }
+
+                for id in opened {
+                    self.emit_data_channel_opened(now, TransportContext::default(), id)?;
+                }
             }
 
             RTCEventInternal::SCTPStreamClosed(_association_handle, stream_id) => {
-                if self.data_channels.remove(&stream_id).is_some() {
-                    // Track data channel closed
-                    self.stats.peer_connection.on_data_channel_closed();
-                    if let Some(dc_stats) = self.stats.data_channels.get_mut(&stream_id) {
-                        dc_stats.on_state_changed(RTCDataChannelState::Closed);
-                    }
+                if let Some(dc) = self.data_channels.remove(&stream_id) {
+                    // A channel already closed by handshake timeout has already fired OnClose
+                    // and been counted; do not emit or count it twice.
+                    if !dc.close_emitted {
+                        // Track data channel closed
+                        self.stats.peer_connection.on_data_channel_closed();
+                        if let Some(dc_stats) = self.stats.data_channels.get_mut(&stream_id) {
+                            dc_stats.on_state_changed(RTCDataChannelState::Closed);
+                        }
 
-                    self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                        now,
-                        event: RTCEventInternal::RTCPeerConnectionEvent(
-                            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(
-                                stream_id,
-                            )),
-                        ),
-                    });
+                        self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                            now,
+                            event: RTCEventInternal::RTCPeerConnectionEvent(
+                                RTCPeerConnectionEvent::OnDataChannel(
+                                    RTCDataChannelEvent::OnClose(stream_id),
+                                ),
+                            ),
+                        });
+                    }
                 }
             }
+
             RTCEventInternal::SCTPBufferReleased(_association_handle, stream_id, n_bytes) => {
                 // Pure accounting: SCTP released (acked or abandoned) `n_bytes` of
                 // this channel's outgoing buffer. Decrement the synchronous send
@@ -383,14 +440,581 @@ impl<'a>
 
     fn handle_timeout(&mut self, now: Instant) -> Result<()> {
         self.ctx.observe(now);
+
+        // Close in-band channels whose DCEP handshake did not complete in time.
+        let mut timed_out = Vec::new();
+        for dc in self.data_channels.values() {
+            if let Some(deadline) = dc.handshake_deadline
+                && dc.ready_state == RTCDataChannelState::Connecting
+                && deadline <= now
+            {
+                timed_out.push(dc.id);
+            }
+        }
+
+        for id in timed_out {
+            if let Some(dc) = self.data_channels.get_mut(&id) {
+                dc.handshake_deadline = None;
+                dc.ready_state = RTCDataChannelState::Closed;
+                if let Some(data_channel) = dc.data_channel.as_mut() {
+                    data_channel.close()?;
+                }
+
+                self.stats.peer_connection.on_data_channel_closed();
+                self.stats
+                    .get_or_create_data_channel(id, &dc.label, &dc.protocol)
+                    .on_state_changed(RTCDataChannelState::Closed);
+
+                dc.close_emitted = true;
+                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(id)),
+                    ),
+                });
+            }
+        }
+
         Ok(())
     }
 
     fn poll_timeout(&mut self) -> Option<Instant> {
-        None
+        self.data_channels
+            .values()
+            .filter_map(|dc| {
+                if dc.ready_state == RTCDataChannelState::Connecting {
+                    dc.handshake_deadline
+                } else {
+                    None
+                }
+            })
+            .min()
     }
 
     fn close(&mut self) -> Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Timing contract for the DCEP handshake-complete signal.
+    //!
+    //! These drive `DataChannelHandler` directly and pin
+    //! *when* the open event fires and `ready_state` flips, which the integration
+    //! tests cannot see: they only require the open event to fire *eventually*, so
+    //! they pass whether the channel is promoted at dial time or on the ACK.
+
+    use super::*;
+    use crate::data_channel::parameters::DataChannelParameters;
+    use crate::statistics::accumulator::RTCStatsAccumulator;
+    use bytes::BytesMut;
+    use datachannel::data_channel::DataChannelMessage;
+    use datachannel::message::Message;
+    use datachannel::message::message_channel_ack::DataChannelAck;
+    use sansio::Protocol;
+    use shared::marshal::Marshal;
+
+    fn in_band_channel(id: u16) -> RTCDataChannelInternal {
+        RTCDataChannelInternal::new(
+            id,
+            DataChannelParameters {
+                label: "timing-test".to_string(),
+                protocol: String::new(),
+                ordered: true,
+                max_packet_life_time: None,
+                max_retransmits: None,
+                negotiated: None,
+            },
+        )
+    }
+
+    fn negotiated_channel(id: u16) -> RTCDataChannelInternal {
+        RTCDataChannelInternal::new(
+            id,
+            DataChannelParameters {
+                label: "timing-test".to_string(),
+                protocol: String::new(),
+                ordered: true,
+                max_packet_life_time: None,
+                max_retransmits: None,
+                negotiated: Some(id),
+            },
+        )
+    }
+
+    fn ack(association_handle: usize, stream_id: u16) -> DataChannelMessage {
+        let ack = Message::DataChannelAck(DataChannelAck {})
+            .marshal()
+            .unwrap();
+        DataChannelMessage {
+            association_handle,
+            stream_id,
+            ppi: PayloadProtocolIdentifier::Dcep,
+            payload: BytesMut::from(&ack[..]),
+            negotiated: false,
+        }
+    }
+
+    fn data_message(association_handle: usize, stream_id: u16, data: &[u8]) -> DataChannelMessage {
+        DataChannelMessage {
+            association_handle,
+            stream_id,
+            ppi: PayloadProtocolIdentifier::String,
+            payload: BytesMut::from(data),
+            negotiated: false,
+        }
+    }
+
+    fn message_events(ctx: &DataChannelHandlerContext) -> Vec<DataChannelEvent> {
+        ctx.read_outs
+            .iter()
+            .filter_map(|m| match &m.message {
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app)) => {
+                    Some(app.data_channel_event.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// An in-band channel is dialed at `SCTPHandshakeComplete` but stays
+    /// `Connecting` with no open event; the open event fires exactly once, and
+    /// `ready_state` flips to `Open`, only when the peer's `DATA_CHANNEL_ACK`
+    /// is processed.
+    #[test]
+    fn in_band_channel_fires_open_only_when_ack_is_processed() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, in_band_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        let dc = data_channels.get(&1).unwrap();
+        assert!(
+            dc.data_channel.is_some(),
+            "SCTPHandshakeComplete must dial the in-band channel"
+        );
+        assert_eq!(
+            dc.ready_state,
+            RTCDataChannelState::Connecting,
+            "an in-band channel must stay Connecting after the SCTP handshake"
+        );
+        assert!(
+            ctx.read_outs.iter().all(|m| !matches!(
+                &m.message,
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
+                    if matches!(app.data_channel_event, DataChannelEvent::Open)
+            )),
+            "no open event may fire at SCTPHandshakeComplete time"
+        );
+
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: TransportContext::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(ack(0, 1))),
+                })
+                .unwrap();
+        }
+
+        assert_eq!(
+            data_channels.get(&1).unwrap().ready_state,
+            RTCDataChannelState::Open,
+            "ready_state flips to Open exactly when the ACK is processed"
+        );
+
+        let open_events: Vec<u16> = ctx
+            .read_outs
+            .iter()
+            .filter_map(|m| match &m.message {
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
+                    if matches!(app.data_channel_event, DataChannelEvent::Open) =>
+                {
+                    Some(app.data_channel_id)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            open_events,
+            vec![1],
+            "exactly one open event, fired on the ACK"
+        );
+        assert_eq!(
+            stats.peer_connection.data_channels_opened, 1,
+            "open stats recorded exactly once"
+        );
+    }
+
+    /// A negotiated (out-of-band) channel has no DCEP handshake: it dials open
+    /// immediately and fires the open event at `SCTPHandshakeComplete`.
+    #[test]
+    fn negotiated_channel_fires_open_at_handshake_complete() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, negotiated_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        handler
+            .handle_event(TaggedRTCEventInternal {
+                now,
+                event: RTCEventInternal::SCTPHandshakeComplete(0),
+            })
+            .unwrap();
+
+        let dc = data_channels.get(&1).unwrap();
+        assert_eq!(
+            dc.ready_state,
+            RTCDataChannelState::Open,
+            "a negotiated channel is open immediately at SCTPHandshakeComplete"
+        );
+        assert!(
+            dc.handshake_deadline.is_none(),
+            "a negotiated channel has no DCEP handshake deadline"
+        );
+
+        let open_events: Vec<u16> = ctx
+            .read_outs
+            .iter()
+            .filter_map(|m| match &m.message {
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
+                    if matches!(app.data_channel_event, DataChannelEvent::Open) =>
+                {
+                    Some(app.data_channel_id)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            open_events,
+            vec![1],
+            "exactly one open event at SCTPHandshakeComplete for a negotiated channel"
+        );
+        assert_eq!(
+            stats.peer_connection.data_channels_opened, 1,
+            "open stats recorded for the negotiated channel"
+        );
+    }
+
+    /// `emit_data_channel_opened` returns an error when the channel does not exist.
+    #[test]
+    fn emit_data_channel_opened_missing_channel_returns_error() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        let mut stats = RTCStatsAccumulator::new();
+
+        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let err = handler
+            .emit_data_channel_opened(now, TransportContext::default(), 99)
+            .unwrap_err();
+        assert_eq!(err, Error::ErrDataChannelNotExisted);
+    }
+
+    /// A second `SCTPHandshakeComplete` must not re-dial an already-dialed
+    /// in-band channel: it stays Connecting after dialing, so the
+    /// `data_channel.is_none()` guard is what excludes it.
+    #[test]
+    fn sctp_handshake_complete_does_not_redial() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, in_band_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        // Fire SCTPHandshakeComplete once; this dials the channel and queues its OPEN.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+        let first_writes = ctx.write_outs.len();
+        assert!(
+            first_writes >= 1,
+            "dialing must queue the DATA_CHANNEL_OPEN"
+        );
+        ctx.write_outs.clear();
+
+        // Fire it again: no new dial, so nothing new is queued.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            ctx.write_outs.len(),
+            0,
+            "a second SCTPHandshakeComplete must not re-dial the channel"
+        );
+    }
+
+    /// A straggler `DATA_CHANNEL_ACK` on a channel that has already been closed
+    /// must be ignored: it must not flip state or emit an open event.
+    #[test]
+    fn ack_on_closed_channel_is_ignored() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        let mut dc = in_band_channel(1);
+        dc.ready_state = RTCDataChannelState::Closed;
+        data_channels.insert(1, dc);
+        let mut stats = RTCStatsAccumulator::new();
+
+        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        handler
+            .handle_read(TaggedRTCMessageInternal {
+                now,
+                transport: TransportContext::default(),
+                message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(ack(0, 1))),
+            })
+            .unwrap();
+
+        assert_eq!(
+            data_channels.get(&1).unwrap().ready_state,
+            RTCDataChannelState::Closed,
+            "a closed channel must ignore a late ACK"
+        );
+        assert!(
+            !message_events(&ctx)
+                .iter()
+                .any(|e| matches!(e, DataChannelEvent::Open)),
+            "no open event may fire for a closed channel"
+        );
+    }
+
+    /// An in-band channel whose ACK never arrives must time out: it transitions
+    /// to Closed, fires OnClose and is counted exactly once (closed without opened).
+    #[test]
+    fn in_band_channel_times_out_without_ack() {
+        let now = Instant::now();
+        let timeout = Duration::from_millis(100);
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, in_band_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        // Dial the in-band channel and arm a deadline.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        // A deadline must be reported.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let deadline = handler
+                .poll_timeout()
+                .expect("a dialed in-band channel must have a deadline");
+            assert!(deadline <= now + timeout);
+        }
+
+        // Advance past the deadline and let handle_timeout fire.
+        let later = now + timeout + Duration::from_secs(1);
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            handler.handle_timeout(later).unwrap();
+        }
+
+        let dc = data_channels.get(&1).unwrap();
+        assert_eq!(
+            dc.ready_state,
+            RTCDataChannelState::Closed,
+            "a timed-out channel must be Closed"
+        );
+        assert!(
+            dc.handshake_deadline.is_none(),
+            "timeout must clear the deadline"
+        );
+        assert!(
+            !message_events(&ctx)
+                .iter()
+                .any(|e| matches!(e, DataChannelEvent::Open)),
+            "no open event for a timed-out channel"
+        );
+
+        let closes = ctx
+            .event_outs
+            .iter()
+            .filter(|e| {
+                matches!(
+                    &e.event,
+                    RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(1))
+                    )
+                )
+            })
+            .count();
+        assert_eq!(closes, 1, "exactly one OnClose for the timed-out channel");
+
+        assert_eq!(stats.peer_connection.data_channels_opened, 0);
+        assert_eq!(stats.peer_connection.data_channels_closed, 1);
+
+        // No further deadlines remain.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            assert!(
+                handler.poll_timeout().is_none(),
+                "no deadline after the timeout fired"
+            );
+        }
+    }
+
+    /// A user message arriving before the ACK is buffered and delivered only
+    /// after the channel opens, with the open event first.
+    #[test]
+    fn pre_open_data_is_buffered_until_open() {
+        let now = Instant::now();
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, in_band_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        // Dial first.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        // A user data message arrives while the channel is still Connecting.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: TransportContext::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_message(
+                        0, 1, b"hello",
+                    ))),
+                })
+                .unwrap();
+        }
+
+        // No message event yet.
+        assert!(
+            !message_events(&ctx)
+                .iter()
+                .any(|e| matches!(e, DataChannelEvent::Message(_))),
+            "no message may be delivered before the channel is open"
+        );
+
+        // The ACK arrives: the channel opens and the buffered message is delivered,
+        // with the open event first.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            handler
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: TransportContext::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(ack(0, 1))),
+                })
+                .unwrap();
+        }
+
+        let events = message_events(&ctx);
+        assert!(
+            matches!(events.first(), Some(DataChannelEvent::Open)),
+            "open event must fire first"
+        );
+        assert!(
+            matches!(events.get(1), Some(DataChannelEvent::Message(_))),
+            "the buffered message must be delivered after the open event"
+        );
+    }
+
+    /// A user message buffered before the ACK is discarded if the channel times
+    /// out: it must never be delivered to the application.
+    #[test]
+    fn pre_open_data_is_dropped_on_timeout() {
+        let now = Instant::now();
+        let timeout = Duration::from_millis(100);
+        let mut ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = HashMap::new();
+        data_channels.insert(1, in_band_channel(1));
+        let mut stats = RTCStatsAccumulator::new();
+
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        // Buffer a user message while Connecting.
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            handler
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: TransportContext::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_message(
+                        0, 1, b"bye",
+                    ))),
+                })
+                .unwrap();
+        }
+
+        // Time out; the channel closes and the buffered message must not be delivered.
+        let later = now + timeout + Duration::from_secs(1);
+        {
+            let mut handler =
+                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            handler.handle_timeout(later).unwrap();
+        }
+
+        assert!(
+            !message_events(&ctx)
+                .iter()
+                .any(|e| matches!(e, DataChannelEvent::Message(_))),
+            "a buffered message must never be delivered after the timeout"
+        );
     }
 }

--- a/src/peer_connection/handler/mod.rs
+++ b/src/peer_connection/handler/mod.rs
@@ -202,6 +202,7 @@ where
             &mut self.pipeline_context.datachannel_handler_context,
             &mut self.data_channels,
             &mut self.pipeline_context.stats,
+            self.setting_engine.data_channel.dcep_handshake_timeout,
         )
     }
 

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -2674,7 +2674,11 @@ mod tests {
             .next()
             .expect("data channel must be stored internally");
         assert!(internal.data_channel.is_some());
-        assert_eq!(internal.ready_state, RTCDataChannelState::Open);
+        assert_eq!(
+            internal.ready_state,
+            RTCDataChannelState::Connecting,
+            "a dialed in-band channel stays Connecting until its DATA_CHANNEL_ACK arrives"
+        );
     }
 
     // ---- Rollback (RFC 8829, Section 5.7) ----


### PR DESCRIPTION
A locally-created in-band data channel is currently promoted to `Open` as soon as it is dialed, before the peer's `DATA_CHANNEL_ACK` arrives. This misreports state: `ready_state` reads `Open` and the open event fires while the channel is still handshaking, making handshake completion unobservable.

Keep in-band channels in `Connecting` until the DCEP handshake completes. Out-of-band `negotiated` channels remain `Open` immediately because they have no handshake.

## Changes

In `rtc-datachannel`, `DataChannel` now tracks handshake completion with an `open` flag and an `is_open()` accessor:

- `dial()` sets it `false` for in-band channels and `true` for negotiated channels.
- `accept()` sets it `true` for remote channels once `DATA_CHANNEL_OPEN` is processed and the ACK is queued.
- `handle_dcep()` sets it `true` when a `DATA_CHANNEL_ACK` arrives.
- `close()` resets it to `false`.

In `rtc`, `RTCDataChannelInternal::dial()` leaves in-band channels in `RTCDataChannelState::Connecting`; only `negotiated` channels move straight to `Open`. `DataChannelHandler::handle_read()` detects the handshake-complete transition, flips `ready_state`, emits `DataChannelEvent::Open`, and records open stats. As a result, `SCTPHandshakeComplete` no longer emits the open event for in-band channels at dial time.

Sending is unaffected: `ensure_sendable()` still gates on the SCTP stream's existence, not `ready_state`, and the WebRTC spec allows `send()` on a `connecting` channel.

## Spec references

- [W3C WebRTC §6.2 RTCDataChannel](https://www.w3.org/TR/webrtc/#rtcdatachannel): a data channel is initially `connecting` and is announced as open when its underlying data transport is ready.
- [W3C WebRTC §6.1 createDataChannel](https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel): creates the channel's underlying data transport (step 23).
- [W3C WebRTC §6.2.2 announcing a data channel as open](https://www.w3.org/TR/webrtc/#announcing-a-data-channel-as-open): sets `[[ReadyState]]` to `"open"` and fires the `open` event.
- [RFC 8832 §4 Protocol Overview](https://www.rfc-editor.org/rfc/rfc8832.html#name-protocol-overview): the channel is open only after `DATA_CHANNEL_OPEN` is answered by `DATA_CHANNEL_ACK`.
- [RFC 8832 §5.2 DATA_CHANNEL_ACK Message](https://www.rfc-editor.org/rfc/rfc8832.html#name-data_channel_ack-message): reception of the ACK tells the opener the handshake is complete.

## Verification

```bash
cd rtc/
cargo test -p rtc-datachannel --lib
cargo test --lib create_data_channel_dials_immediately_when_sctp_association_present
cargo clippy -- -D warnings
```
