### PR TITLE
Lower default SCTP MTU to 1191 and enforce it on marshalled packet sizes

### DIFF
--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -551,3 +551,104 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
 
     Ok(())
 }
+
+// The MTU-split rule in `bundle_data_chunks_into_packets` must bound every
+// marshalled datagram: bundle decisions are made on padded wire sizes (the
+// chunk header + payload, rounded up to the SCTP 4-byte boundary), never on
+// raw payload sizes. These tests marshal real packets and measure the emitted
+// bytes, so any accounting drift fails here rather than as silent on-path
+// datagram loss.
+
+use crate::EndpointConfig;
+use crate::config::INITIAL_MTU;
+
+fn create_association_with_mtu(mtu: u32) -> Association {
+    Association::new(
+        None,
+        Arc::new(TransportConfig::default()),
+        mtu - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE),
+        0,
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        TransportProtocol::UDP,
+        Instant::now(),
+    )
+}
+
+fn payload_chunk(tsn: u32, len: usize) -> ChunkPayloadData {
+    ChunkPayloadData {
+        beginning_fragment: true,
+        ending_fragment: true,
+        tsn,
+        stream_identifier: 0,
+        stream_sequence_number: 0,
+        user_data: Bytes::from(vec![0u8; len]),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn bundle_split_decides_on_padded_wire_sizes() {
+    // Payloads of 1147 + 16 bytes pass a payload-only boundary check at
+    // exactly an MTU of 1191, but the two chunks marshal to
+    // 12 + 1164 + 32 = 1208 bytes — past the MTU the association promised.
+    let a = create_association_with_mtu(1191);
+    let chunks = vec![payload_chunk(1, 1147), payload_chunk(2, 16)];
+    let mut raw_packets = vec![];
+    a.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
+    assert_eq!(
+        raw_packets.len(),
+        2,
+        "a bundle that only fits unpadded must split"
+    );
+    for p in &raw_packets {
+        assert!(
+            p.len() as u32 <= a.mtu,
+            "emitted packet is {} bytes, mtu is {}",
+            p.len(),
+            a.mtu
+        );
+    }
+}
+
+#[test]
+fn single_maximum_size_chunk_marshals_within_initial_mtu() {
+    let max_payload = EndpointConfig::default().get_max_payload_size();
+    let a = create_association_with_mtu(max_payload + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE);
+    let chunks = vec![payload_chunk(1, max_payload as usize)];
+    let mut raw_packets = vec![];
+    a.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
+    assert_eq!(raw_packets.len(), 1);
+    assert!(
+        raw_packets[0].len() as u32 <= INITIAL_MTU,
+        "a single maximum-size chunk is {} bytes, INITIAL_MTU is {}",
+        raw_packets[0].len(),
+        INITIAL_MTU
+    );
+}
+
+#[test]
+fn many_small_chunks_bundle_within_mtu() {
+    // Per-chunk padding (17-byte payloads: 33 raw, 36 padded) compounds; a
+    // payload-only accounting packed bundles that marshalled well past the
+    // MTU once dozens of small chunks rode one flight.
+    let a = create_association_with_mtu(1191);
+    let chunks: Vec<ChunkPayloadData> = (0..60).map(|i| payload_chunk(i, 17)).collect();
+    let mut raw_packets = vec![];
+    a.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
+    assert!(raw_packets.len() >= 2);
+    let total: usize = raw_packets.iter().map(|p| p.len()).sum();
+    for p in &raw_packets {
+        assert!(
+            p.len() as u32 <= a.mtu,
+            "emitted packet is {} bytes, mtu is {}",
+            p.len(),
+            a.mtu
+        );
+    }
+    // Nothing was dropped: at least every chunk's unpadded wire size plus one
+    // common header per emitted packet.
+    let min_expected = 60 * (DATA_CHUNK_HEADER_SIZE as usize + 17)
+        + raw_packets.len() * COMMON_HEADER_SIZE as usize;
+    assert!(total >= min_expected);
+}

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2279,7 +2279,11 @@ impl Association {
                     //      of cwnd and SHOULD NOT delay retransmission for this single
                     //		packet.
 
-                    let data_chunk_size = DATA_CHUNK_HEADER_SIZE + c.user_data.len() as u32;
+                    // Padded wire size, the same accounting
+                    // bundle_data_chunks_into_packets uses for bundle
+                    // decisions.
+                    let data_chunk_size =
+                        (DATA_CHUNK_HEADER_SIZE + c.user_data.len() as u32).next_multiple_of(4);
                     if self.mtu < fast_retrans_size + data_chunk_size {
                         break;
                     }
@@ -2596,22 +2600,24 @@ impl Association {
         let mut bundles: Vec<(usize, usize)> = Vec::new();
         let mut total_len = 0usize;
         let mut bundle_start = 0;
-        let mut bytes_in_packet = COMMON_HEADER_SIZE;
         let mut bundle_len = hdr;
         for (i, chunk) in chunks.iter().enumerate() {
-            let data_len = chunk.user_data.len() as u32;
-            // Close the current bundle before a chunk that would exceed the MTU.
-            if bytes_in_packet + data_len > self.mtu && i > bundle_start {
+            // Marshalled chunk size: header + payload, padded up to the SCTP
+            // 4-byte boundary. Bundle decisions must use this wire size —
+            // deciding on raw payload sizes admitted bundles that marshalled
+            // past the MTU (e.g. payloads of 1147 + 16 pass a payload-only
+            // check at an MTU of 1191 but serialize to a 1208-byte packet).
+            let wire =
+                (DATA_CHUNK_HEADER_SIZE as usize + chunk.user_data.len()).next_multiple_of(4);
+            // Close the current bundle before a chunk whose padded wire size
+            // would push the datagram past the MTU.
+            if bundle_len + wire > self.mtu as usize && i > bundle_start {
                 bundles.push((bundle_start, i));
                 total_len += bundle_len;
                 bundle_start = i;
-                bytes_in_packet = COMMON_HEADER_SIZE;
                 bundle_len = hdr;
             }
-            bytes_in_packet += DATA_CHUNK_HEADER_SIZE + data_len;
-            // Marshalled chunk size, padded up to the SCTP 4-byte boundary.
-            let wire = (DATA_CHUNK_HEADER_SIZE + data_len) as usize;
-            bundle_len += (wire + 3) & !3;
+            bundle_len += wire;
         }
         bundles.push((bundle_start, chunks.len()));
         total_len += bundle_len;

--- a/rtc-sctp/src/config.rs
+++ b/rtc-sctp/src/config.rs
@@ -6,8 +6,18 @@ use std::sync::Arc;
 
 /// MTU for inbound packet (from DTLS)
 pub(crate) const RECEIVE_MTU: usize = 8192;
-/// initial MTU for outgoing packets (to DTLS)
-pub(crate) const INITIAL_MTU: u32 = 1228;
+/// Initial MTU for outgoing packets (to DTLS): bounds the assembled SCTP
+/// packet (common header + bundled chunks). Each SCTP packet becomes one
+/// DTLS record carried in one UDP datagram, so the wire size is roughly
+/// `INITIAL_MTU` + ~37 bytes of DTLS record overhead + 48 bytes of IPv6/UDP
+/// headers. 1191 keeps that within the 1280-byte IPv6 minimum MTU advertised
+/// by common tunnel paths (WireGuard, Tailscale); the previous 1228
+/// overflowed it (~1313 wire bytes), and because retransmissions re-bundle
+/// to the same oversized packet, a dropped flight stalled forever with no
+/// surfaced error. 1191 is the exact TURN-relayed IPv6 budget
+/// (1280 - 40 IPv6 - 8 UDP - 4 TURN ChannelData - 37 DTLS), the derivation
+/// from pion/sctp#476, adopted by webrtc-rs/webrtc#807 (webrtc v0.17.2).
+pub(crate) const INITIAL_MTU: u32 = 1191;
 pub(crate) const INITIAL_RECV_BUF_SIZE: u32 = 1024 * 1024;
 pub(crate) const COMMON_HEADER_SIZE: u32 = 12;
 pub(crate) const DATA_CHUNK_HEADER_SIZE: u32 = 16;
@@ -133,7 +143,11 @@ impl EndpointConfig {
         let aid_factory: fn() -> Box<dyn AssociationIdGenerator + Send> =
             || Box::<RandomAssociationIdGenerator>::default();
         Self {
-            max_payload_size: INITIAL_MTU - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE),
+            // Rounded down to the SCTP 4-byte chunk-padding boundary (as
+            // pion/sctp does) so a single maximum-size DATA chunk — common
+            // header plus the padded chunk — marshals to at most INITIAL_MTU
+            // bytes.
+            max_payload_size: (INITIAL_MTU - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3,
             aid_generator_factory: Arc::new(aid_factory),
         }
     }
@@ -243,5 +257,29 @@ impl ClientConfig {
         ClientConfig {
             transport: Arc::new(transport),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_max_payload_size_fits_ipv6_min_mtu() {
+        // INITIAL_MTU bounds the assembled SCTP packet. The default is the
+        // exact TURN-relayed IPv6 budget (pion/sctp#476, webrtc-rs/webrtc#807):
+        // the 1280-byte IPv6 minimum MTU (RFC 8200) minus IPv6, UDP, and TURN
+        // ChannelData headers and DTLS record overhead.
+        assert_eq!(INITIAL_MTU, 1280 - 40 - 8 - 4 - 37);
+        let config = EndpointConfig::default();
+        assert_eq!(
+            config.get_max_payload_size(),
+            (INITIAL_MTU - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3
+        );
+        // A single maximum-size DATA chunk must marshal within INITIAL_MTU:
+        // common header + the chunk header and payload, padded to 4 bytes.
+        let padded_chunk =
+            (DATA_CHUNK_HEADER_SIZE + config.get_max_payload_size()).next_multiple_of(4);
+        assert!(COMMON_HEADER_SIZE + padded_chunk <= INITIAL_MTU);
     }
 }


### PR DESCRIPTION
Fixes #178.

One commit, in two halves matching the issue:

**1. Lower `INITIAL_MTU` from 1228 to 1191.** 1228-byte SCTP packets become ~1265-byte DTLS records — ~1313 wire bytes with IPv6/UDP headers, overflowing the 1280-byte IPv6 minimum MTU used by common tunnel paths (Tailscale's default; a common conservative WireGuard setting). Dropped datagrams are retransmitted as the same oversized bundle, so the flight is lost for the life of the association while `send` keeps returning `Ok`. 1191 is the exact TURN-relayed IPv6 budget (1280 − 40 IPv6 − 8 UDP − 4 TURN ChannelData − 37 DTLS) — the pion/sctp#476 derivation that webrtc-rs/webrtc#807 adopted and shipped in webrtc v0.17.2, reverted when the 0.20 architecture replaced that sctp implementation with `rtc-sctp`. A test pins the derivation; the constant's comment records the wire math.

**2. Enforce the MTU on marshalled sizes.** The bundler decided bundle boundaries on unpadded payload sizes and omitted the candidate chunk's 16-byte DATA header — payloads of 1147 + 16 bytes pass that check at exactly 1191 and serialize to a 1208-byte packet, so lowering the default alone doesn't close the hole. Bundle decisions and the fast-retransmit sizing loop now use the padded wire length (chunk header + payload, rounded to the SCTP 4-byte boundary), and the default `max_payload_size` is rounded down to the padding boundary (as pion/sctp does) so a single maximum-size chunk also marshals within `INITIAL_MTU`. The tests measure real emitted packets: the 1147+16 counterexample must split, a single maximum-size chunk must fit, and a 60-small-chunk burst must keep every emitted packet within the MTU.

Compatibility: the default per-fragment payload drops from 1200 to 1160 bytes — ~3.4% more fragments for large messages — in exchange for datachannels actually delivering on 1280-MTU paths. A `SettingEngineBuilder::with_sctp_mtu` knob for unusual paths is a follow-up we'd propose separately, so this stays a focused correctness fix.

Assisted-by: claude:claude-fable-5
