### PR TITLE
Bind declared remote streams after codec discovery

### DIFF
--- a/src/peer_connection/handler/endpoint.rs
+++ b/src/peer_connection/handler/endpoint.rs
@@ -408,6 +408,17 @@ where
                     let new_entry = receiver.track_mut().set_codec_by_ssrc(codec, ssrc);
                     assert!(!new_entry);
 
+                    // The eager bind performed while applying the remote SDP
+                    // skipped this declared SSRC because its codec was deferred.
+                    // Bind this exact coding now, before OnTrack is emitted;
+                    // the empty-codec guard above makes this once-only.
+                    receiver.interceptor_remote_stream_by_ssrc_op(
+                        self.media_engine,
+                        self.interceptor,
+                        true,
+                        ssrc,
+                    );
+
                     // Get RTX and FEC SSRCs from coding parameters
                     let (rtx_ssrc, fec_ssrc) = receiver
                         .get_coding_parameters()
@@ -808,15 +819,23 @@ mod rtx_tests {
         TrackPacket, TransportContext, deencapsulate_rtx, resolve_rtx_primary,
     };
     use crate::media_stream::track::MediaStreamTrack;
+    use crate::peer_connection::configuration::interceptor_registry::configure_twcc_receiver_only;
     use crate::peer_connection::configuration::media_engine::MediaEngine;
     use crate::rtp_transceiver::rtp_sender::{
-        RTCRtpCodec, RTCRtpEncodingParameters, RTCRtpRtxParameters, RtpCodecKind,
+        RTCRtpCodec, RTCRtpEncodingParameters, RTCRtpFecParameters, RTCRtpRtxParameters,
+        RtpCodecKind,
     };
     use crate::rtp_transceiver::{RTCRtpTransceiverDirection, RTCRtpTransceiverInit};
     use crate::statistics::accumulator::RTCStatsAccumulator;
     use bytes::Bytes;
-    use interceptor::NoopInterceptor;
+    use interceptor::{
+        Interceptor, NoopInterceptor, Registry, StreamInfo, TaggedPacket, interceptor,
+    };
+    use rtcp::transport_feedbacks::transport_layer_cc::TransportLayerCc;
+    use sansio::Protocol;
     use shared::TransportProtocol;
+    use shared::error::Error;
+    use std::time::Duration;
 
     fn coding(primary_ssrc: u32, rtx_ssrc: Option<u32>) -> RTCRtpCodingParameters {
         RTCRtpCodingParameters {
@@ -1117,6 +1136,276 @@ mod rtx_tests {
         assert!(
             ctx.read_outs.is_empty(),
             "an RTX probe packet with no OSN should be dropped, not dispatched"
+        );
+    }
+
+    fn deferred_codec_receiver_transceiver<I: Interceptor>(
+        codings: Vec<RTCRtpCodingParameters>,
+        payload_type: u8,
+    ) -> RTCRtpTransceiverInternal<I> {
+        let mut transceiver = RTCRtpTransceiverInternal::<I>::new(
+            RtpCodecKind::Video,
+            None,
+            RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Recvonly,
+                streams: vec![],
+                send_encodings: vec![],
+            },
+        );
+
+        let receiver = transceiver.receiver_mut().as_mut().unwrap();
+        receiver.set_coding_parameters(codings.clone());
+        receiver.set_codec_preferences(vec![codec(payload_type, "video/VP8", "")]);
+        receiver.set_track(MediaStreamTrack::new(
+            "stream".to_string(),
+            "track".to_string(),
+            "label".to_string(),
+            RtpCodecKind::Video,
+            codings
+                .into_iter()
+                .map(|rtp_coding_parameters| RTCRtpEncodingParameters {
+                    rtp_coding_parameters,
+                    codec: Default::default(),
+                    ..Default::default()
+                })
+                .collect(),
+        ));
+        transceiver
+    }
+
+    #[derive(Interceptor)]
+    struct RecordingInterceptor<P: Interceptor> {
+        #[next]
+        inner: P,
+        remote_bindings: Vec<StreamInfo>,
+    }
+
+    #[interceptor]
+    impl<P: Interceptor> RecordingInterceptor<P> {
+        #[overrides]
+        fn bind_remote_stream(&mut self, info: &StreamInfo) {
+            self.remote_bindings.push(info.clone());
+            self.inner.bind_remote_stream(info);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn deliver_declared_rtp<I: Interceptor>(
+        ctx: &mut EndpointHandlerContext,
+        transceivers: &mut Vec<RTCRtpTransceiverInternal<I>>,
+        media_engine: &MediaEngine,
+        interceptor: &mut I,
+        stats: &mut RTCStatsAccumulator,
+        ssrc: u32,
+        sequence_number: u16,
+        payload_type: u8,
+    ) {
+        EndpointHandler::new(ctx, transceivers, media_engine, interceptor, stats)
+            .handle_rtp_message(
+                Instant::now(),
+                test_transport(),
+                rtp::Packet {
+                    header: rtp::Header {
+                        payload_type,
+                        sequence_number,
+                        ssrc,
+                        ..Default::default()
+                    },
+                    payload: Bytes::from_static(&[0x01]),
+                },
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn declared_ssrc_binds_twcc_after_first_packet_resolves_codec() {
+        const SSRC: u32 = 0x1122_3344;
+        const PAYLOAD_TYPE: u8 = 96;
+
+        let mut media_engine = MediaEngine::default();
+        media_engine.register_default_codecs().unwrap();
+        let registry = configure_twcc_receiver_only(Registry::new(), &mut media_engine).unwrap();
+        let mut interceptor = registry.build();
+        let mut transceivers = vec![deferred_codec_receiver_transceiver::<_>(
+            vec![coding(SSRC, None)],
+            PAYLOAD_TYPE,
+        )];
+        let mut stats = RTCStatsAccumulator::new();
+        let mut ctx = EndpointHandlerContext::default();
+
+        // This is the eager bind attempted while applying an SDP that declares
+        // the SSRC. It cannot bind yet because the track codec is intentionally
+        // deferred until the first RTP packet identifies its payload type.
+        transceivers[0]
+            .receiver_mut()
+            .as_mut()
+            .unwrap()
+            .interceptor_remote_streams_op(&media_engine, &mut interceptor, true);
+
+        let twcc_extension_id = media_engine
+            .get_rtp_parameters_by_kind(RtpCodecKind::Video, RTCRtpTransceiverDirection::Recvonly)
+            .header_extensions
+            .into_iter()
+            .find(|extension| extension.uri == sdp::extmap::TRANSPORT_CC_URI)
+            .expect("TWCC header extension should be configured")
+            .id as u8;
+
+        let start = Instant::now();
+        interceptor
+            .handle_read(TaggedPacket {
+                now: start,
+                transport: test_transport(),
+                message: Packet::Rtp(rtp::Packet {
+                    header: rtp::Header {
+                        payload_type: PAYLOAD_TYPE,
+                        sequence_number: 1,
+                        ssrc: SSRC,
+                        ..Default::default()
+                    },
+                    payload: Bytes::from_static(&[0x01]),
+                }),
+            })
+            .unwrap();
+        let first_packet = match interceptor.poll_read().unwrap().message {
+            Packet::Rtp(packet) => packet,
+            Packet::Rtcp(_) => panic!("expected the first RTP packet"),
+        };
+
+        EndpointHandler::new(
+            &mut ctx,
+            &mut transceivers,
+            &media_engine,
+            &mut interceptor,
+            &mut stats,
+        )
+        .handle_rtp_message(start, test_transport(), first_packet)
+        .unwrap();
+
+        let mut second_packet = rtp::Packet {
+            header: rtp::Header {
+                payload_type: PAYLOAD_TYPE,
+                sequence_number: 2,
+                ssrc: SSRC,
+                ..Default::default()
+            },
+            payload: Bytes::from_static(&[0x02]),
+        };
+        second_packet
+            .header
+            .set_extension(
+                twcc_extension_id,
+                Bytes::copy_from_slice(&2u16.to_be_bytes()),
+            )
+            .unwrap();
+        interceptor
+            .handle_read(TaggedPacket {
+                now: start + Duration::from_millis(10),
+                transport: test_transport(),
+                message: Packet::Rtp(second_packet),
+            })
+            .unwrap();
+        interceptor
+            .handle_timeout(start + Duration::from_millis(150))
+            .unwrap();
+
+        let generated_twcc = std::iter::from_fn(|| interceptor.poll_write()).any(|packet| {
+            matches!(packet.message, Packet::Rtcp(ref packets) if packets
+                .iter()
+                .any(|packet| packet.as_any().is::<TransportLayerCc>()))
+        });
+        assert!(generated_twcc, "declared SSRC was not bound to TWCC");
+    }
+
+    #[test]
+    fn declared_simulcast_ssrcs_bind_once_with_repair_streams() {
+        const PAYLOAD_TYPE: u8 = 96;
+        const PRIMARY_1: u32 = 1001;
+        const RTX_1: u32 = 2001;
+        const FEC_1: u32 = 3001;
+        const PRIMARY_2: u32 = 1002;
+        const RTX_2: u32 = 2002;
+        const FEC_2: u32 = 3002;
+
+        let coding_with_repair = |primary, rtx, fec| RTCRtpCodingParameters {
+            fec: Some(RTCRtpFecParameters { ssrc: fec }),
+            ..coding(primary, Some(rtx))
+        };
+        let codings = vec![
+            coding_with_repair(PRIMARY_1, RTX_1, FEC_1),
+            coding_with_repair(PRIMARY_2, RTX_2, FEC_2),
+        ];
+
+        let mut media_engine = MediaEngine::default();
+        media_engine.register_default_codecs().unwrap();
+        let mut interceptor = RecordingInterceptor {
+            inner: NoopInterceptor::new(),
+            remote_bindings: vec![],
+        };
+        let mut transceivers = vec![deferred_codec_receiver_transceiver::<_>(
+            codings,
+            PAYLOAD_TYPE,
+        )];
+        let mut stats = RTCStatsAccumulator::new();
+        let mut ctx = EndpointHandlerContext::default();
+
+        transceivers[0]
+            .receiver_mut()
+            .as_mut()
+            .unwrap()
+            .interceptor_remote_streams_op(&media_engine, &mut interceptor, true);
+        assert!(interceptor.remote_bindings.is_empty());
+
+        deliver_declared_rtp(
+            &mut ctx,
+            &mut transceivers,
+            &media_engine,
+            &mut interceptor,
+            &mut stats,
+            PRIMARY_1,
+            1,
+            PAYLOAD_TYPE,
+        );
+        assert_eq!(
+            interceptor
+                .remote_bindings
+                .iter()
+                .map(|info| info.ssrc)
+                .collect::<Vec<_>>(),
+            vec![PRIMARY_1, RTX_1, FEC_1]
+        );
+
+        // Later packets on the same stream must not duplicate its binding.
+        deliver_declared_rtp(
+            &mut ctx,
+            &mut transceivers,
+            &media_engine,
+            &mut interceptor,
+            &mut stats,
+            PRIMARY_1,
+            2,
+            PAYLOAD_TYPE,
+        );
+        assert_eq!(interceptor.remote_bindings.len(), 3);
+
+        // Resolving another simulcast stream binds only that stream and its
+        // repair SSRCs; rebinding PRIMARY_1 would reset interceptor state.
+        deliver_declared_rtp(
+            &mut ctx,
+            &mut transceivers,
+            &media_engine,
+            &mut interceptor,
+            &mut stats,
+            PRIMARY_2,
+            1,
+            PAYLOAD_TYPE,
+        );
+        assert_eq!(
+            interceptor
+                .remote_bindings
+                .iter()
+                .map(|info| info.ssrc)
+                .collect::<Vec<_>>(),
+            vec![PRIMARY_1, RTX_1, FEC_1, PRIMARY_2, RTX_2, FEC_2]
         );
     }
 }

--- a/src/rtp_transceiver/rtp_receiver/internal.rs
+++ b/src/rtp_transceiver/rtp_receiver/internal.rs
@@ -14,7 +14,9 @@ use crate::rtp_transceiver::rtp_sender::rtp_codec_parameters::RTCRtpCodecParamet
 use crate::rtp_transceiver::rtp_sender::rtp_coding_parameters::RTCRtpCodingParameters;
 use crate::rtp_transceiver::rtp_sender::rtp_header_extension_capability::RTCRtpHeaderExtensionCapability;
 use crate::rtp_transceiver::rtp_sender::rtp_receiver_parameters::RTCRtpReceiveParameters;
-use crate::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpHeaderExtensionParameters};
+use crate::rtp_transceiver::rtp_sender::{
+    RTCRtpCodec, RTCRtpEncodingParameters, RTCRtpHeaderExtensionParameters,
+};
 use crate::rtp_transceiver::{PayloadType, SSRC};
 use interceptor::Interceptor;
 use shared::error::Result;
@@ -238,46 +240,75 @@ where
         let parameters = self.get_parameters(media_engine).clone();
 
         for coding in self.track().codings() {
-            let (codec, match_type) =
-                codec_parameters_fuzzy_search(&coding.codec, &parameters.rtp_parameters.codecs);
-            if let Some(&ssrc) = coding.rtp_coding_parameters.ssrc.as_ref()
-                && match_type != CodecMatch::None
-            {
+            Self::interceptor_remote_coding_op(interceptor, is_binding, coding, &parameters);
+        }
+    }
+
+    /// Bind or unbind one exact primary SSRC and its repair streams.
+    ///
+    /// SDP-declared tracks initially have no codec. Once the first RTP packet
+    /// resolves that codec, binding only its coding avoids rebinding other
+    /// simulcast streams whose codecs were resolved by earlier packets.
+    pub(crate) fn interceptor_remote_stream_by_ssrc_op(
+        &mut self,
+        media_engine: &MediaEngine,
+        interceptor: &mut I,
+        is_binding: bool,
+        ssrc: SSRC,
+    ) {
+        let parameters = self.get_parameters(media_engine).clone();
+
+        if let Some(coding) = self
+            .track()
+            .codings()
+            .iter()
+            .find(|coding| coding.rtp_coding_parameters.ssrc == Some(ssrc))
+        {
+            Self::interceptor_remote_coding_op(interceptor, is_binding, coding, &parameters);
+        }
+    }
+
+    fn interceptor_remote_coding_op(
+        interceptor: &mut I,
+        is_binding: bool,
+        coding: &RTCRtpEncodingParameters,
+        parameters: &RTCRtpReceiveParameters,
+    ) {
+        let (codec, match_type) =
+            codec_parameters_fuzzy_search(&coding.codec, &parameters.rtp_parameters.codecs);
+        if let Some(&ssrc) = coding.rtp_coding_parameters.ssrc.as_ref()
+            && match_type != CodecMatch::None
+        {
+            RTCRtpReceiverInternal::interceptor_remote_stream_op(
+                interceptor,
+                is_binding,
+                ssrc,
+                codec.payload_type,
+                &codec.rtp_codec,
+                &parameters.rtp_parameters.header_extensions,
+            );
+
+            if let Some(rtx) = coding.rtp_coding_parameters.rtx.as_ref() {
                 RTCRtpReceiverInternal::interceptor_remote_stream_op(
                     interceptor,
                     is_binding,
-                    ssrc,
-                    codec.payload_type,
+                    rtx.ssrc,
+                    find_rtx_payload_type(codec.payload_type, &parameters.rtp_parameters.codecs)
+                        .unwrap_or_default(),
                     &codec.rtp_codec,
                     &parameters.rtp_parameters.header_extensions,
                 );
+            }
 
-                if let Some(rtx) = coding.rtp_coding_parameters.rtx.as_ref() {
-                    RTCRtpReceiverInternal::interceptor_remote_stream_op(
-                        interceptor,
-                        is_binding,
-                        rtx.ssrc,
-                        find_rtx_payload_type(
-                            codec.payload_type,
-                            &parameters.rtp_parameters.codecs,
-                        )
-                        .unwrap_or_default(),
-                        &codec.rtp_codec,
-                        &parameters.rtp_parameters.header_extensions,
-                    );
-                }
-
-                if let Some(fec) = coding.rtp_coding_parameters.fec.as_ref() {
-                    RTCRtpReceiverInternal::interceptor_remote_stream_op(
-                        interceptor,
-                        is_binding,
-                        fec.ssrc,
-                        find_fec_payload_type(&parameters.rtp_parameters.codecs)
-                            .unwrap_or_default(),
-                        &codec.rtp_codec,
-                        &parameters.rtp_parameters.header_extensions,
-                    );
-                }
+            if let Some(fec) = coding.rtp_coding_parameters.fec.as_ref() {
+                RTCRtpReceiverInternal::interceptor_remote_stream_op(
+                    interceptor,
+                    is_binding,
+                    fec.ssrc,
+                    find_fec_payload_type(&parameters.rtp_parameters.codecs).unwrap_or_default(),
+                    &codec.rtp_codec,
+                    &parameters.rtp_parameters.header_extensions,
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

- retry remote interceptor binding when the first RTP packet resolves an SDP-declared SSRC's deferred codec
- bind only that exact coding and its RTX/FEC repair streams, avoiding state resets on already-active simulcast streams
- add regressions proving rtc-generated TWCC resumes and each declared simulcast/repair SSRC binds exactly once

## Root cause

`start_rtp` creates SDP-declared tracks with an empty codec and immediately attempts interceptor binding. The codec fuzzy match correctly skips that incomplete coding. The endpoint later resolves and stores the codec from the first RTP payload type, but previously never retried the remote-stream bind, leaving receiver-report, NACK, and TWCC interceptors unaware of the stream.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib declared_ -- --nocapture`
- `cargo clippy -p rtc --lib --tests --no-deps`
- `cargo test -p rtc --tests -- --skip test_ice_restart_interop`
- `cargo test --workspace --exclude rtc --exclude rtc-mdns --exclude rtc-ice`
- `cargo test -p rtc-mdns -p rtc-ice`

The unskipped `ice_restart_by_webrtc_interop` test is unrelated to this change and fails on this macOS host while the legacy `webrtc` peer enumerates unavailable link-local IPv6 interfaces (`Can't assign requested address`).
