### PR TITLE
Add SettingEngineBuilder::with_sctp_mtu for non-default path MTUs

### DIFF
--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -560,7 +560,7 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
 // datagram loss.
 
 use crate::EndpointConfig;
-use crate::config::INITIAL_MTU;
+use crate::config::{INITIAL_MTU, max_payload_size_for_mtu};
 
 fn create_association_with_mtu(mtu: u32) -> Association {
     Association::new(
@@ -629,16 +629,15 @@ fn single_maximum_size_chunk_marshals_within_initial_mtu() {
 
 #[test]
 fn single_maximum_size_chunk_marshals_within_a_custom_mtu() {
-    // `EndpointConfig::mtu(N)` promises that a single maximum-size DATA
-    // chunk marshals to at most N bytes, mirroring the default derivation's
-    // guarantee for INITIAL_MTU. Prove it on emitted bytes at the 32-byte
-    // floor (exactly the smallest representable padded DATA packet), across
+    // `max_payload_size_for_mtu(N)` derives a payload budget for which a
+    // single maximum-size DATA chunk marshals to at most N bytes, mirroring
+    // the default derivation's guarantee for INITIAL_MTU. Prove it on
+    // emitted bytes at the 32-byte floor (exactly the smallest
+    // representable padded DATA packet), across
     // a 4-byte padding boundary (1201 emits 1200), and at a typical larger
     // path MTU (1500, fully used).
     for (mtu, expected) in [(32u32, 32usize), (1201, 1200), (1500, 1500)] {
-        let mut config = EndpointConfig::new();
-        config.mtu(mtu);
-        let max_payload = config.get_max_payload_size();
+        let max_payload = max_payload_size_for_mtu(mtu);
         let a =
             create_association_with_mtu(max_payload + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE);
         let chunks = vec![payload_chunk(1, max_payload as usize)];
@@ -658,9 +657,9 @@ fn initial_cwnd_is_computed_safely_for_non_default_mtus() {
     // Regression: the initial congestion window was computed as
     // `(2 * mtu).clamp(4380, 4 * mtu)`, which panicked for effective MTUs
     // below ~1095 (`Ord::clamp` with min > max) and overflowed near
-    // `u32::MAX` — both reachable via `EndpointConfig::max_payload_size`/
-    // `mtu`. RFC 4960 §7.2.1: cwnd = min(4*MTU, max(2*MTU, 4380)); for a
-    // small MTU that is 4*MTU.
+    // `u32::MAX` — reachable through `EndpointConfig::max_payload_size`
+    // and MTU-derived payload budgets. RFC 4960 §7.2.1:
+    // cwnd = min(4*MTU, max(2*MTU, 4380)); for a small MTU that is 4*MTU.
     let a = create_association_with_mtu(100);
     assert_eq!(a.cwnd, 4 * a.mtu);
 

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -628,6 +628,62 @@ fn single_maximum_size_chunk_marshals_within_initial_mtu() {
 }
 
 #[test]
+fn single_maximum_size_chunk_marshals_within_a_custom_mtu() {
+    // `EndpointConfig::mtu(N)` promises that a single maximum-size DATA
+    // chunk marshals to at most N bytes, mirroring the default derivation's
+    // guarantee for INITIAL_MTU. Prove it on emitted bytes at the 32-byte
+    // floor (exactly the smallest representable padded DATA packet), across
+    // a 4-byte padding boundary (1201 emits 1200), and at a typical larger
+    // path MTU (1500, fully used).
+    for (mtu, expected) in [(32u32, 32usize), (1201, 1200), (1500, 1500)] {
+        let mut config = EndpointConfig::new();
+        config.mtu(mtu);
+        let max_payload = config.get_max_payload_size();
+        let a =
+            create_association_with_mtu(max_payload + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE);
+        let chunks = vec![payload_chunk(1, max_payload as usize)];
+        let mut raw_packets = vec![];
+        a.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
+        assert_eq!(raw_packets.len(), 1);
+        assert_eq!(
+            raw_packets[0].len(),
+            expected,
+            "a single maximum-size chunk under mtu({mtu})"
+        );
+    }
+}
+
+#[test]
+fn initial_cwnd_is_computed_safely_for_non_default_mtus() {
+    // Regression: the initial congestion window was computed as
+    // `(2 * mtu).clamp(4380, 4 * mtu)`, which panicked for effective MTUs
+    // below ~1095 (`Ord::clamp` with min > max) and overflowed near
+    // `u32::MAX` — both reachable via `EndpointConfig::max_payload_size`/
+    // `mtu`. RFC 4960 §7.2.1: cwnd = min(4*MTU, max(2*MTU, 4380)); for a
+    // small MTU that is 4*MTU.
+    let a = create_association_with_mtu(100);
+    assert_eq!(a.cwnd, 4 * a.mtu);
+
+    // Directly via the low-level `max_payload_size` setter path: the
+    // effective-MTU reconstruction (`max_payload_size + 28`) must saturate
+    // rather than overflow when the payload budget itself is near
+    // `u32::MAX` (the helper above subtracts the headers first, so it
+    // never exercises this addition's edge).
+    let a = Association::new(
+        None,
+        Arc::new(TransportConfig::default()),
+        u32::MAX,
+        0,
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        TransportProtocol::UDP,
+        Instant::now(),
+    );
+    assert_eq!(a.mtu, u32::MAX);
+    assert_eq!(a.cwnd, u32::MAX);
+}
+
+#[test]
 fn many_small_chunks_bundle_within_mtu() {
     // Per-chunk padding (17-byte payloads: 33 raw, 36 padded) compounds; a
     // payload-only accounting packed bundles that marshalled well past the

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -345,12 +345,16 @@ impl Association {
 
         // It's a bit strange, but we're going backwards from the calculation in
         // config.rs to get max_payload_size from INITIAL_MTU.
-        let mtu = max_payload_size + COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE;
+        let mtu = max_payload_size.saturating_add(COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE);
 
-        // RFC 4690 Sec 7.2.1
+        // RFC 4960 Sec 7.2.1
         // The initial cwnd before DATA transmission or after a sufficiently
         // long idle period MUST be set to min(4*MTU, max (2*MTU, 4380bytes)).
-        let cwnd = (2 * mtu).clamp(4380, 4 * mtu);
+        // Written in total form: the previous `(2 * mtu).clamp(4380, 4 * mtu)`
+        // panicked for effective MTUs below ~1095 (`Ord::clamp` with
+        // min > max) and overflowed near `u32::MAX`, both reachable via
+        // `EndpointConfig::max_payload_size`/`mtu`.
+        let cwnd = mtu.saturating_mul(2).max(4380).min(mtu.saturating_mul(4));
         // RFC 4960 requires an unpredictable initial TSN. SCTP remains usable without an RTC
         // crypto provider, so this deliberately uses `rand`'s thread-local CSPRNG.
         let mut tsn = random::<u32>();

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -352,8 +352,8 @@ impl Association {
         // long idle period MUST be set to min(4*MTU, max (2*MTU, 4380bytes)).
         // Written in total form: the previous `(2 * mtu).clamp(4380, 4 * mtu)`
         // panicked for effective MTUs below ~1095 (`Ord::clamp` with
-        // min > max) and overflowed near `u32::MAX`, both reachable via
-        // `EndpointConfig::max_payload_size`/`mtu`.
+        // min > max) and overflowed near `u32::MAX`, both reachable through
+        // `EndpointConfig::max_payload_size` and MTU-derived payload budgets.
         let cwnd = mtu.saturating_mul(2).max(4380).min(mtu.saturating_mul(4));
         // RFC 4960 requires an unpredictable initial TSN. SCTP remains usable without an RTC
         // crypto provider, so this deliberately uses `rand`'s thread-local CSPRNG.

--- a/rtc-sctp/src/config.rs
+++ b/rtc-sctp/src/config.rs
@@ -21,6 +21,10 @@ pub(crate) const INITIAL_MTU: u32 = 1191;
 pub(crate) const INITIAL_RECV_BUF_SIZE: u32 = 1024 * 1024;
 pub(crate) const COMMON_HEADER_SIZE: u32 = 12;
 pub(crate) const DATA_CHUNK_HEADER_SIZE: u32 = 16;
+/// Floor for [`EndpointConfig::mtu`]: the smallest representable padded DATA
+/// packet — the 12-byte common header, the 16-byte DATA chunk header, and a
+/// 1..=4-byte payload padded to the 4-byte chunk boundary.
+pub(crate) const MIN_DATA_PACKET_MTU: u32 = COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE + 4;
 pub(crate) const DEFAULT_MAX_MESSAGE_SIZE: u32 = 262144;
 
 /// Config collects the arguments to create_association construction into
@@ -181,6 +185,35 @@ impl EndpointConfig {
         self
     }
 
+    /// Sets [`max_payload_size`](Self::max_payload_size) from an outbound DATA-packet
+    /// budget: the largest DATA packet (common header plus bundled DATA chunks)
+    /// associations built from this configuration may emit, in bytes. Control packets
+    /// (INIT, INIT ACK, SACK, RECONFIG, FORWARD TSN, shutdown) marshal without consulting
+    /// this value.
+    ///
+    /// This is the inverse of the default derivation: the per-chunk payload budget is `value`
+    /// minus the 12-byte common header and the 16-byte DATA chunk header, rounded down to the
+    /// SCTP 4-byte chunk-padding boundary —
+    /// `(value - COMMON_HEADER_SIZE - DATA_CHUNK_HEADER_SIZE) & !3` — so a single maximum-size
+    /// DATA chunk (common header plus the padded chunk) always marshals to at most `value`
+    /// bytes, exactly as the default budget does for `INITIAL_MTU` (1191, the TURN-relayed
+    /// IPv6 minimum-MTU budget).
+    ///
+    /// Values below 32 — the smallest representable padded DATA packet: the two headers
+    /// plus a 1..=4-byte payload padded to the 4-byte boundary — cannot satisfy that
+    /// promise and are raised to 32 with a warning.
+    pub fn mtu(&mut self, value: u32) -> &mut Self {
+        if value < MIN_DATA_PACKET_MTU {
+            log::warn!(
+                "sctp mtu {value} is below the smallest representable DATA packet; raising to \
+                 {MIN_DATA_PACKET_MTU} bytes"
+            );
+        }
+        let value = value.max(MIN_DATA_PACKET_MTU);
+        self.max_payload_size = (value - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3;
+        self
+    }
+
     /// Get the current value of `max_payload_size`
     ///
     /// While most parameters don't need to be readable, this must be exposed to allow higher-level
@@ -281,5 +314,38 @@ mod tests {
         let padded_chunk =
             (DATA_CHUNK_HEADER_SIZE + config.get_max_payload_size()).next_multiple_of(4);
         assert!(COMMON_HEADER_SIZE + padded_chunk <= INITIAL_MTU);
+    }
+
+    #[test]
+    fn mtu_setter_derives_the_payload_budget() {
+        // `mtu(INITIAL_MTU)` must reproduce the default payload budget exactly.
+        let mut config = EndpointConfig::new();
+        config.mtu(INITIAL_MTU);
+        assert_eq!(
+            config.get_max_payload_size(),
+            EndpointConfig::default().get_max_payload_size()
+        );
+
+        // Rounded down to the 4-byte padding boundary: the last MTU of one
+        // padding window and the first of the next straddle a 4-byte step.
+        config.mtu(1203);
+        assert_eq!(config.get_max_payload_size(), 1172);
+        config.mtu(1204);
+        assert_eq!(config.get_max_payload_size(), 1176);
+
+        // Values below MIN_DATA_PACKET_MTU behave exactly as the 32-byte
+        // floor: the smallest representable padded DATA packet, a 4-byte
+        // payload budget.
+        for mtu in [0, 31, 32] {
+            config.mtu(mtu);
+            assert_eq!(config.get_max_payload_size(), 4, "mtu {mtu}");
+        }
+
+        // Upper edge: the derivation must not overflow.
+        config.mtu(u32::MAX);
+        assert_eq!(
+            config.get_max_payload_size(),
+            (u32::MAX - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3
+        );
     }
 }

--- a/rtc-sctp/src/config.rs
+++ b/rtc-sctp/src/config.rs
@@ -21,10 +21,34 @@ pub(crate) const INITIAL_MTU: u32 = 1191;
 pub(crate) const INITIAL_RECV_BUF_SIZE: u32 = 1024 * 1024;
 pub(crate) const COMMON_HEADER_SIZE: u32 = 12;
 pub(crate) const DATA_CHUNK_HEADER_SIZE: u32 = 16;
-/// Floor for [`EndpointConfig::mtu`]: the smallest representable padded DATA
-/// packet — the 12-byte common header, the 16-byte DATA chunk header, and a
-/// 1..=4-byte payload padded to the 4-byte chunk boundary.
-pub(crate) const MIN_DATA_PACKET_MTU: u32 = COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE + 4;
+/// Floor for [`max_payload_size_for_mtu`]: the smallest representable padded
+/// DATA packet — the 12-byte common header, the 16-byte DATA chunk header, and
+/// a 1..=4-byte payload padded to the 4-byte chunk boundary.
+pub const MIN_DATA_PACKET_MTU: u32 = COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE + 4;
+
+/// Derive an [`EndpointConfig::max_payload_size`] value from an outbound
+/// DATA-packet budget: the largest DATA packet (common header plus bundled
+/// DATA chunks) associations may emit, in bytes. Control packets (INIT,
+/// INIT ACK, SACK, RECONFIG, FORWARD TSN, shutdown) marshal without
+/// consulting this value.
+///
+/// This is the inverse of the default derivation: `mtu` minus the two fixed
+/// headers, rounded down to the SCTP 4-byte chunk-padding boundary, so a
+/// single maximum-size DATA chunk always marshals to at most `mtu` bytes —
+/// exactly as the default budget does for `INITIAL_MTU` (1191, the
+/// TURN-relayed IPv6 minimum-MTU budget). Budgets below
+/// [`MIN_DATA_PACKET_MTU`] cannot satisfy that promise and are raised to it
+/// with a warning.
+pub fn max_payload_size_for_mtu(mtu: u32) -> u32 {
+    if mtu < MIN_DATA_PACKET_MTU {
+        log::warn!(
+            "sctp mtu {mtu} is below the smallest representable DATA packet; raising to \
+             {MIN_DATA_PACKET_MTU} bytes"
+        );
+    }
+    let mtu = mtu.max(MIN_DATA_PACKET_MTU);
+    (mtu - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3
+}
 pub(crate) const DEFAULT_MAX_MESSAGE_SIZE: u32 = 262144;
 
 /// Config collects the arguments to create_association construction into
@@ -147,11 +171,7 @@ impl EndpointConfig {
         let aid_factory: fn() -> Box<dyn AssociationIdGenerator + Send> =
             || Box::<RandomAssociationIdGenerator>::default();
         Self {
-            // Rounded down to the SCTP 4-byte chunk-padding boundary (as
-            // pion/sctp does) so a single maximum-size DATA chunk — common
-            // header plus the padded chunk — marshals to at most INITIAL_MTU
-            // bytes.
-            max_payload_size: (INITIAL_MTU - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3,
+            max_payload_size: max_payload_size_for_mtu(INITIAL_MTU),
             aid_generator_factory: Arc::new(aid_factory),
         }
     }
@@ -182,35 +202,6 @@ impl EndpointConfig {
     /// on networks supporting Ethernet jumbo frames or similar should set this appropriately.
     pub fn max_payload_size(&mut self, value: u32) -> &mut Self {
         self.max_payload_size = value;
-        self
-    }
-
-    /// Sets [`max_payload_size`](Self::max_payload_size) from an outbound DATA-packet
-    /// budget: the largest DATA packet (common header plus bundled DATA chunks)
-    /// associations built from this configuration may emit, in bytes. Control packets
-    /// (INIT, INIT ACK, SACK, RECONFIG, FORWARD TSN, shutdown) marshal without consulting
-    /// this value.
-    ///
-    /// This is the inverse of the default derivation: the per-chunk payload budget is `value`
-    /// minus the 12-byte common header and the 16-byte DATA chunk header, rounded down to the
-    /// SCTP 4-byte chunk-padding boundary —
-    /// `(value - COMMON_HEADER_SIZE - DATA_CHUNK_HEADER_SIZE) & !3` — so a single maximum-size
-    /// DATA chunk (common header plus the padded chunk) always marshals to at most `value`
-    /// bytes, exactly as the default budget does for `INITIAL_MTU` (1191, the TURN-relayed
-    /// IPv6 minimum-MTU budget).
-    ///
-    /// Values below 32 — the smallest representable padded DATA packet: the two headers
-    /// plus a 1..=4-byte payload padded to the 4-byte boundary — cannot satisfy that
-    /// promise and are raised to 32 with a warning.
-    pub fn mtu(&mut self, value: u32) -> &mut Self {
-        if value < MIN_DATA_PACKET_MTU {
-            log::warn!(
-                "sctp mtu {value} is below the smallest representable DATA packet; raising to \
-                 {MIN_DATA_PACKET_MTU} bytes"
-            );
-        }
-        let value = value.max(MIN_DATA_PACKET_MTU);
-        self.max_payload_size = (value - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3;
         self
     }
 
@@ -317,34 +308,29 @@ mod tests {
     }
 
     #[test]
-    fn mtu_setter_derives_the_payload_budget() {
-        // `mtu(INITIAL_MTU)` must reproduce the default payload budget exactly.
-        let mut config = EndpointConfig::new();
-        config.mtu(INITIAL_MTU);
+    fn max_payload_size_for_mtu_derives_the_payload_budget() {
+        // `max_payload_size_for_mtu(INITIAL_MTU)` must reproduce the default
+        // payload budget exactly.
         assert_eq!(
-            config.get_max_payload_size(),
+            max_payload_size_for_mtu(INITIAL_MTU),
             EndpointConfig::default().get_max_payload_size()
         );
 
         // Rounded down to the 4-byte padding boundary: the last MTU of one
         // padding window and the first of the next straddle a 4-byte step.
-        config.mtu(1203);
-        assert_eq!(config.get_max_payload_size(), 1172);
-        config.mtu(1204);
-        assert_eq!(config.get_max_payload_size(), 1176);
+        assert_eq!(max_payload_size_for_mtu(1203), 1172);
+        assert_eq!(max_payload_size_for_mtu(1204), 1176);
 
         // Values below MIN_DATA_PACKET_MTU behave exactly as the 32-byte
         // floor: the smallest representable padded DATA packet, a 4-byte
         // payload budget.
         for mtu in [0, 31, 32] {
-            config.mtu(mtu);
-            assert_eq!(config.get_max_payload_size(), 4, "mtu {mtu}");
+            assert_eq!(max_payload_size_for_mtu(mtu), 4, "mtu {mtu}");
         }
 
         // Upper edge: the derivation must not overflow.
-        config.mtu(u32::MAX);
         assert_eq!(
-            config.get_max_payload_size(),
+            max_payload_size_for_mtu(u32::MAX),
             (u32::MAX - (COMMON_HEADER_SIZE + DATA_CHUNK_HEADER_SIZE)) & !3
         );
     }

--- a/rtc-sctp/src/lib.rs
+++ b/rtc-sctp/src/lib.rs
@@ -70,7 +70,10 @@ pub use crate::chunk::{
 };
 
 mod config;
-pub use crate::config::{ClientConfig, EndpointConfig, ServerConfig, TransportConfig};
+pub use crate::config::{
+    ClientConfig, EndpointConfig, MIN_DATA_PACKET_MTU, ServerConfig, TransportConfig,
+    max_payload_size_for_mtu,
+};
 
 mod endpoint;
 pub use crate::endpoint::{AssociationHandle, ConnectError, DatagramEvent, Endpoint};

--- a/src/peer_connection/configuration/setting_engine.rs
+++ b/src/peer_connection/configuration/setting_engine.rs
@@ -353,6 +353,10 @@ pub struct SettingEngine {
     /// Overrides the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes.
     /// `None` uses the rtc-sctp default (`INITIAL_RECV_BUF_SIZE`, 1 MiB).
     pub(crate) sctp_max_receive_buffer_size: Option<u32>,
+    /// Overrides the outbound SCTP DATA-packet budget handed to rtc-sctp's
+    /// `EndpointConfig::mtu`. `None` uses the rtc-sctp default (`INITIAL_MTU`, 1191 — the
+    /// TURN-relayed IPv6 minimum-MTU budget).
+    pub(crate) sctp_mtu: Option<u32>,
     pub(crate) ignore_rid_pause_for_recv: bool,
     pub(crate) write_ssrc_attributes_for_simulcast: bool,
 }
@@ -1344,6 +1348,30 @@ impl SettingEngineBuilder {
         }
 
         self.0.sctp_max_receive_buffer_size = Some(size.max(MIN_SCTP_RECEIVE_BUFFER_SIZE));
+        self
+    }
+
+    /// Overrides the SCTP MTU: the size budget, in bytes, for each outbound DATA packet
+    /// (common header plus bundled DATA chunks) this endpoint emits. Control packets
+    /// (INIT, INIT ACK, SACK, RECONFIG, FORWARD TSN, shutdown) marshal without consulting
+    /// this value.
+    ///
+    /// Each SCTP packet becomes one DTLS record carried in one UDP datagram, so the wire
+    /// size is roughly this value + ~37 bytes of DTLS record overhead + IP/UDP headers
+    /// (+ 4 bytes of TURN ChannelData framing when relayed). The default (1191) is the
+    /// TURN-relayed IPv6 minimum-MTU budget of `1280 - 40 IPv6 - 8 UDP - 4 TURN
+    /// ChannelData - 37 DTLS` (webrtc-rs/rtc#178). Set this only for paths with a known
+    /// different budget: raise it where the path genuinely carries more (fewer, larger
+    /// packets cut per-packet overhead), lower it for tunnels with an even smaller MTU.
+    ///
+    /// The per-chunk payload budget is derived from this value by the inverse of the
+    /// default derivation (minus the 12-byte common header and 16-byte DATA chunk header,
+    /// rounded down to the SCTP 4-byte chunk-padding boundary), so a single maximum-size
+    /// DATA chunk always marshals within this budget. Values below 32 — the smallest
+    /// representable padded DATA packet — are raised to 32 with a warning. To keep the
+    /// default, leave this unset.
+    pub fn with_sctp_mtu(mut self, mtu: u32) -> Self {
+        self.0.sctp_mtu = Some(mtu);
         self
     }
 

--- a/src/peer_connection/configuration/setting_engine.rs
+++ b/src/peer_connection/configuration/setting_engine.rs
@@ -353,9 +353,9 @@ pub struct SettingEngine {
     /// Overrides the SCTP receive-buffer size (the a_rwnd flow-control window), in bytes.
     /// `None` uses the rtc-sctp default (`INITIAL_RECV_BUF_SIZE`, 1 MiB).
     pub(crate) sctp_max_receive_buffer_size: Option<u32>,
-    /// Overrides the outbound SCTP DATA-packet budget handed to rtc-sctp's
-    /// `EndpointConfig::mtu`. `None` uses the rtc-sctp default (`INITIAL_MTU`, 1191 — the
-    /// TURN-relayed IPv6 minimum-MTU budget).
+    /// Overrides the outbound SCTP DATA-packet budget, converted to a payload
+    /// budget via rtc-sctp's `max_payload_size_for_mtu`. `None` uses the rtc-sctp
+    /// default (`INITIAL_MTU`, 1191 — the TURN-relayed IPv6 minimum-MTU budget).
     pub(crate) sctp_mtu: Option<u32>,
     pub(crate) ignore_rid_pause_for_recv: bool,
     pub(crate) write_ssrc_attributes_for_simulcast: bool,

--- a/src/peer_connection/handler/sctp.rs
+++ b/src/peer_connection/handler/sctp.rs
@@ -1100,6 +1100,7 @@ mod tests {
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
             None,
+            None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
         );
@@ -1534,6 +1535,7 @@ mod tests {
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
             None,
+            None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
         );
@@ -1597,6 +1599,7 @@ mod tests {
 
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
+            None,
             None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),

--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -145,6 +145,7 @@ where
         let sctp_transport = SctpTransport::new(
             setting_engine.sctp_max_message_size,
             setting_engine.sctp_max_receive_buffer_size,
+            setting_engine.sctp_mtu,
             sctp_transport_id,
             dtls_transport_id,
         );

--- a/src/peer_connection/transport/sctp/mod.rs
+++ b/src/peer_connection/transport/sctp/mod.rs
@@ -47,6 +47,10 @@ pub(crate) struct SctpTransport {
     // in bytes. None uses the sctp crate default (INITIAL_RECV_BUF_SIZE, 1 MiB).
     pub(crate) max_receive_buffer_size: Option<u32>,
 
+    // Optional override for the outbound SCTP DATA-packet budget, applied to the endpoint's
+    // `EndpointConfig` in `start()`. None uses the sctp crate default (INITIAL_MTU, 1191).
+    pub(crate) mtu: Option<u32>,
+
     pub(crate) internal_buffer: Vec<u8>,
 }
 
@@ -54,6 +58,7 @@ impl SctpTransport {
     pub(crate) fn new(
         max_message_size: SctpMaxMessageSize,
         max_receive_buffer_size: Option<u32>,
+        mtu: Option<u32>,
         id: RTCTransportId,
         dtls_transport_id: RTCTransportId,
     ) -> Self {
@@ -68,6 +73,7 @@ impl SctpTransport {
             max_message_size,
             negotiated_max_message_size: None,
             max_receive_buffer_size,
+            mtu,
             internal_buffer: vec![],
         }
     }
@@ -169,7 +175,10 @@ impl SctpTransport {
         self.negotiated_max_message_size = Some(max_message_size);
         self.internal_buffer.resize(max_message_size as usize, 0u8);
 
-        let sctp_endpoint_config = ::sctp::EndpointConfig::default();
+        let mut sctp_endpoint_config = ::sctp::EndpointConfig::default();
+        if let Some(mtu) = self.mtu {
+            sctp_endpoint_config.mtu(mtu);
+        }
         let mut sctp_transport_config = ::sctp::TransportConfig::default()
             .with_max_message_size(max_message_size)
             .with_sctp_port(local_port);
@@ -216,6 +225,7 @@ mod tests {
     ) -> SctpTransport {
         let mut transport = SctpTransport::new(
             configured,
+            None,
             None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
@@ -272,6 +282,7 @@ mod tests {
         let transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
             None,
+            None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
         );
@@ -283,6 +294,7 @@ mod tests {
     fn state_and_max_channels_before_any_association() {
         let transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
+            None,
             None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
@@ -298,6 +310,7 @@ mod tests {
     fn state_follows_a_closed_association() {
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
+            None,
             None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
@@ -320,6 +333,7 @@ mod tests {
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
             Some(200_000),
+            None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
         );
@@ -347,6 +361,7 @@ mod tests {
         let mut transport = SctpTransport::new(
             SctpMaxMessageSize::default(),
             None,
+            None,
             test_transport_id(TransportKind::Sctp),
             test_transport_id(TransportKind::Dtls),
         );
@@ -367,6 +382,38 @@ mod tests {
                 .expect("client transport config")
                 .max_receive_buffer_size(),
             1024 * 1024
+        );
+    }
+
+    // Starting a Client transport builds the endpoint from an `EndpointConfig`, so we can
+    // assert the configured MTU flowed through `start()` as the derived payload budget:
+    // mtu minus the common and DATA chunk headers, rounded down to the 4-byte boundary.
+    #[test]
+    fn start_applies_configured_mtu() {
+        let mut transport = SctpTransport::new(
+            SctpMaxMessageSize::default(),
+            None,
+            Some(1500),
+            test_transport_id(TransportKind::Sctp),
+            test_transport_id(TransportKind::Dtls),
+        );
+        transport
+            .start(
+                RTCDtlsRole::Client,
+                SCTPTransportCapabilities {
+                    max_message_size: 0,
+                },
+                5000,
+                5000,
+            )
+            .expect("start");
+        assert_eq!(
+            transport
+                .sctp_endpoint
+                .expect("client endpoint")
+                .endpoint_config()
+                .get_max_payload_size(),
+            (1500 - (12 + 16)) & !3
         );
     }
 }

--- a/src/peer_connection/transport/sctp/mod.rs
+++ b/src/peer_connection/transport/sctp/mod.rs
@@ -177,7 +177,7 @@ impl SctpTransport {
 
         let mut sctp_endpoint_config = ::sctp::EndpointConfig::default();
         if let Some(mtu) = self.mtu {
-            sctp_endpoint_config.mtu(mtu);
+            sctp_endpoint_config.max_payload_size(::sctp::max_payload_size_for_mtu(mtu));
         }
         let mut sctp_transport_config = ::sctp::TransportConfig::default()
             .with_max_message_size(max_message_size)


### PR DESCRIPTION
Follow-up promised in #180: a send-MTU knob for paths whose budget differs from the default (1191, the TURN-relayed IPv6 budget — #178).

`SettingEngineBuilder::with_sctp_mtu(mtu)` converts the requested DATA-packet budget with rtc-sctp's new `max_payload_size_for_mtu` helper, then applies it through the existing `EndpointConfig::max_payload_size` setter:

- Derives `max_payload_size` as the exact inverse of the default derivation — subtract the 12-byte common and 16-byte DATA chunk headers, round down to the 4-byte padding boundary — so a single maximum-size DATA chunk marshals within the budget, and #180's padded-wire bundling keeps multi-chunk DATA packets inside it.
- Scope: an outbound **DATA-packet** budget. Control packets (INIT/INIT ACK, SACK, RECONFIG, FORWARD TSN, shutdown) marshal without consulting it.
- Inputs below 32 — the smallest representable padded DATA packet — are raised to 32 with a warning.

Also fixed here: `Association::new` initialized the congestion window as `(2 * mtu).clamp(4380, 4 * mtu)`, which panics for effective MTUs below ~1095 (`Ord::clamp` with min > max) and overflows near `u32::MAX`. Latent behind the low-level `max_payload_size` setter, but this knob advertises exactly such MTUs — rewritten in RFC 4960 §7.2.1's total form with saturating arithmetic.

Tests: the derivation (default-equivalence, a rounding boundary, the 32 floor, `u32::MAX`); emitted single-chunk packet sizes at the floor, across a padding boundary, and at 1500 (reusing #180's helpers); start-time plumbing; and a cwnd construction regression (small and `u32::MAX`).

Assisted-by: claude:claude-fable-5
