### PR TITLE
Add support for RTP-carried application media

### DIFF
--- a/rtc-rtp/src/codec/mod.rs
+++ b/rtc-rtp/src/codec/mod.rs
@@ -8,6 +8,8 @@ pub mod h264;
 pub mod h265;
 /// Opus payload format ([RFC 7587]), one packet per frame.
 pub mod opus;
+/// SMPTE ST 336 (KLV) payload ([RFC 6597]).
+pub mod smpte336m;
 /// VP8 payload format ([RFC 7741]).
 pub mod vp8;
 /// VP9 payload format (draft-ietf-payload-vp9).

--- a/rtc-rtp/src/codec/smpte336m/mod.rs
+++ b/rtc-rtp/src/codec/smpte336m/mod.rs
@@ -1,0 +1,60 @@
+//! SMPTE ST 336 (KLV) RTP payload format ([RFC 6597]).
+//!
+//! The format defines no header of its own: a KLV unit that fits the MTU is sent as-is,
+//! and a larger one is simply split into consecutive chunks. The marker bit (set by the
+//! payloader on the last chunk) is the only signal that a unit is complete.
+//!
+//! [RFC 6597]: https://datatracker.ietf.org/doc/html/rfc6597
+#[cfg(test)]
+mod smpte336m_test;
+
+use crate::packetizer::{Depacketizer, Payloader};
+use shared::error::Result;
+
+use bytes::Bytes;
+
+/// Smpte336mPayloader payloads SMPTE ST 336 (KLV) metadata units
+#[derive(Default, Debug, Copy, Clone)]
+pub struct Smpte336mPayloader;
+
+impl Payloader for Smpte336mPayloader {
+    fn payload(&mut self, mtu: usize, payload: &Bytes) -> Result<Vec<Bytes>> {
+        if payload.is_empty() || mtu == 0 {
+            return Ok(vec![]);
+        }
+
+        let mut remaining = payload.len();
+        let mut index = 0;
+        let mut payloads = Vec::with_capacity(remaining.div_ceil(mtu));
+        while remaining > 0 {
+            let chunk_size = std::cmp::min(mtu, remaining);
+            payloads.push(payload.slice(index..index + chunk_size));
+            remaining -= chunk_size;
+            index += chunk_size;
+        }
+
+        Ok(payloads)
+    }
+
+    fn clone_to(&self) -> Box<dyn Payloader> {
+        Box::new(*self)
+    }
+}
+
+/// Smpte336mDepacketizer depacketizes SMPTE ST 336 (KLV) metadata units
+#[derive(Default, Debug, Copy, Clone)]
+pub struct Smpte336mDepacketizer;
+
+impl Depacketizer for Smpte336mDepacketizer {
+    fn depacketize(&mut self, packet: &Bytes) -> Result<Bytes> {
+        Ok(packet.clone())
+    }
+
+    fn is_partition_head(&self, _payload: &Bytes) -> bool {
+        true
+    }
+
+    fn is_partition_tail(&self, marker: bool, _payload: &Bytes) -> bool {
+        marker
+    }
+}

--- a/rtc-rtp/src/codec/smpte336m/smpte336m_test.rs
+++ b/rtc-rtp/src/codec/smpte336m/smpte336m_test.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+#[test]
+fn test_smpte336m_payload_fragments_and_reassembles() -> Result<()> {
+    let mut pck = Smpte336mPayloader::default();
+
+    const TEST_LEN: usize = 10000;
+    const TEST_MTU: usize = 1400;
+
+    let unit: Vec<u8> = (0..TEST_LEN).map(|i| (i % 256) as u8).collect();
+    let unit = Bytes::copy_from_slice(&unit);
+
+    let payloads = pck.payload(TEST_MTU, &unit)?;
+    let expected_count = TEST_LEN.div_ceil(TEST_MTU);
+    assert_eq!(expected_count, payloads.len());
+    for payload in &payloads[..payloads.len() - 1] {
+        assert_eq!(payload.len(), TEST_MTU);
+    }
+
+    let mut depkt = Smpte336mDepacketizer::default();
+    let mut reassembled = Vec::new();
+    for payload in &payloads {
+        reassembled.extend_from_slice(&depkt.depacketize(payload)?);
+    }
+    assert_eq!(Bytes::from(reassembled), unit);
+
+    Ok(())
+}
+
+#[test]
+fn test_smpte336m_payload_empty_or_zero_mtu() -> Result<()> {
+    let mut pck = Smpte336mPayloader::default();
+
+    let empty = Bytes::from_static(&[]);
+    assert!(pck.payload(1400, &empty)?.is_empty());
+
+    let unit = Bytes::from_static(&[0x06, 0x0e, 0x2b, 0x34]);
+    assert!(pck.payload(0, &unit)?.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_smpte336m_partition_boundaries_follow_marker_bit() {
+    let depkt = Smpte336mDepacketizer::default();
+    let payload = Bytes::from_static(&[0xab]);
+
+    // No structural head marker exists in this payload format, so every packet is
+    // accepted as a possible partition head.
+    assert!(depkt.is_partition_head(&payload));
+
+    // The marker bit is the only signal that an SMPTE ST 336 (KLV) unit is complete.
+    assert!(!depkt.is_partition_tail(false, &payload));
+    assert!(depkt.is_partition_tail(true, &payload));
+}

--- a/src/peer_connection/configuration/media_engine.rs
+++ b/src/peer_connection/configuration/media_engine.rs
@@ -186,6 +186,12 @@ pub const MIME_TYPE_ULP_FEC: &str = "video/ulpfec";
 /// Note: MIME type matching is case-insensitive.
 pub const MIME_TYPE_TELEPHONE_EVENT: &str = "audio/telephone-event";
 
+/// SMPTE ST 336 (KLV) metadata MIME type
+///
+/// Used for transmitting KLV (key-length-value) metadata.
+/// Note: MIME type matching is case-insensitive.
+pub const MIME_TYPE_SMPTE336M: &str = "application/smpte336m";
+
 const VALID_EXT_IDS: Range<u16> = 1..15;
 
 #[derive(Default, Clone)]

--- a/src/peer_connection/configuration/media_engine.rs
+++ b/src/peer_connection/configuration/media_engine.rs
@@ -81,7 +81,7 @@
 //mod media_engine_test;
 
 use crate::peer_connection::sdp::{
-    codecs_from_media_description, rtp_extensions_from_media_description,
+    MediaDescriptionExt, codecs_from_media_description, rtp_extensions_from_media_description,
 };
 use crate::rtp_transceiver::direction::RTCRtpTransceiverDirection;
 use crate::rtp_transceiver::fmtp;
@@ -294,12 +294,15 @@ pub struct MediaEngine {
     // If we have attempted to negotiate a codec type yet.
     pub(crate) negotiated_video: bool,
     pub(crate) negotiated_audio: bool,
+    pub(crate) negotiated_application: bool,
     pub(crate) negotiate_multi_codecs: bool,
 
     pub(crate) video_codecs: Vec<RTCRtpCodecParameters>,
     pub(crate) audio_codecs: Vec<RTCRtpCodecParameters>,
+    pub(crate) application_codecs: Vec<RTCRtpCodecParameters>,
     pub(crate) negotiated_video_codecs: Vec<RTCRtpCodecParameters>,
     pub(crate) negotiated_audio_codecs: Vec<RTCRtpCodecParameters>,
+    pub(crate) negotiated_application_codecs: Vec<RTCRtpCodecParameters>,
 
     pub(crate) header_extensions: Vec<MediaEngineHeaderExtension>,
     pub(crate) negotiated_header_extensions: HashMap<u16, MediaEngineHeaderExtension>,
@@ -629,6 +632,10 @@ impl MediaEngine {
                 MediaEngine::add_codec(&mut self.video_codecs, codec);
                 Ok(())
             }
+            RtpCodecKind::Application => {
+                MediaEngine::add_codec(&mut self.application_codecs, codec);
+                Ok(())
+            }
             _ => Err(Error::ErrUnknownType),
         }
     }
@@ -727,6 +734,7 @@ impl MediaEngine {
         MediaEngine {
             video_codecs: self.video_codecs.clone(),
             audio_codecs: self.audio_codecs.clone(),
+            application_codecs: self.application_codecs.clone(),
             header_extensions: self.header_extensions.clone(),
             ..Default::default()
         }
@@ -760,6 +768,13 @@ impl MediaEngine {
                 }
             }
         }
+        if self.negotiated_application {
+            for codec in &self.negotiated_application_codecs {
+                if codec.payload_type == payload_type {
+                    return Ok((codec.clone(), RtpCodecKind::Application));
+                }
+            }
+        }
         if !self.negotiated_video {
             for codec in &self.video_codecs {
                 if codec.payload_type == payload_type {
@@ -771,6 +786,13 @@ impl MediaEngine {
             for codec in &self.audio_codecs {
                 if codec.payload_type == payload_type {
                     return Ok((codec.clone(), RtpCodecKind::Audio));
+                }
+            }
+        }
+        if !self.negotiated_application {
+            for codec in &self.application_codecs {
+                if codec.payload_type == payload_type {
+                    return Ok((codec.clone(), RtpCodecKind::Application));
                 }
             }
         }
@@ -786,10 +808,11 @@ impl MediaEngine {
         exact_matches: &[RTCRtpCodecParameters],
         partial_matches: &[RTCRtpCodecParameters],
     ) -> Result<(RTCRtpCodecParameters, CodecMatch)> {
-        let codecs = if typ == RtpCodecKind::Audio {
-            &self.audio_codecs
-        } else {
-            &self.video_codecs
+        let codecs = match typ {
+            RtpCodecKind::Audio => &self.audio_codecs,
+            RtpCodecKind::Video => &self.video_codecs,
+            RtpCodecKind::Application => &self.application_codecs,
+            RtpCodecKind::Unspecified => unreachable!(),
         };
 
         let remote_fmtp = fmtp::parse(
@@ -912,6 +935,8 @@ impl MediaEngine {
                 MediaEngine::add_codec(&mut self.negotiated_audio_codecs, codec);
             } else if typ == RtpCodecKind::Video {
                 MediaEngine::add_codec(&mut self.negotiated_video_codecs, codec);
+            } else if typ == RtpCodecKind::Application {
+                MediaEngine::add_codec(&mut self.negotiated_application_codecs, codec);
             }
         }
     }
@@ -922,10 +947,16 @@ impl MediaEngine {
         desc: &SessionDescription,
     ) -> Result<()> {
         for media in &desc.media_descriptions {
+            if media.is_webrtc_datachannel() {
+                continue;
+            }
+
             let typ = if media.media_name.media.to_lowercase() == "audio" {
                 RtpCodecKind::Audio
             } else if media.media_name.media.to_lowercase() == "video" {
                 RtpCodecKind::Video
+            } else if media.media_name.media.to_lowercase() == "application" {
+                RtpCodecKind::Application
             } else {
                 RtpCodecKind::Unspecified
             };
@@ -934,6 +965,8 @@ impl MediaEngine {
                 self.negotiated_audio = true;
             } else if !self.negotiated_video && typ == RtpCodecKind::Video {
                 self.negotiated_video = true;
+            } else if !self.negotiated_application && typ == RtpCodecKind::Application {
+                self.negotiated_application = true;
             } else {
                 // update header extesions from remote sdp if codec is negotiated, Firefox
                 // would send updated header extension in renegotiation.
@@ -941,9 +974,7 @@ impl MediaEngine {
                 // then the two media secontions have different rtp header extensions in offer
                 self.update_header_extension_from_media_section(media)?;
 
-                if !self.negotiate_multi_codecs
-                    || (typ != RtpCodecKind::Audio && typ != RtpCodecKind::Video)
-                {
+                if !self.negotiate_multi_codecs || typ == RtpCodecKind::Unspecified {
                     continue;
                 }
             }
@@ -1028,6 +1059,12 @@ impl MediaEngine {
                 self.negotiated_audio_codecs.clone()
             } else {
                 self.audio_codecs.clone()
+            }
+        } else if typ == RtpCodecKind::Application {
+            if self.negotiated_application {
+                self.negotiated_application_codecs.clone()
+            } else {
+                self.application_codecs.clone()
             }
         } else {
             vec![]

--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -293,7 +293,7 @@ impl RTCPeerConnection {
                         return Err(Error::ErrPeerConnRemoteDescriptionWithoutMidValue);
                     }
 
-                    if media.media_name.media == MEDIA_SECTION_APPLICATION {
+                    if media.is_webrtc_datachannel() {
                         media_sections.push(MediaSection {
                             mid: mid_value.to_owned(),
                             transceiver_index: usize::MAX,

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -267,6 +267,7 @@ use crate::peer_connection::handler::PipelineContext;
 use crate::peer_connection::handler::dtls::DtlsHandlerContext;
 use crate::peer_connection::handler::ice::IceHandlerContext;
 use crate::peer_connection::handler::sctp::SctpHandlerContext;
+use crate::peer_connection::sdp::MediaDescriptionExt;
 use crate::peer_connection::sdp::session_description::RTCSessionDescription;
 use crate::peer_connection::sdp::{
     extract_fingerprint, extract_ice_details, get_application_media,
@@ -1142,7 +1143,7 @@ impl RTCPeerConnection {
                     _ => return Err(Error::ErrPeerConnLocalDescriptionWithoutMidValue),
                 };
 
-                if media.media_name.media == MEDIA_SECTION_APPLICATION {
+                if media.is_webrtc_datachannel() {
                     continue;
                 }
 
@@ -1361,7 +1362,7 @@ impl RTCPeerConnection {
                             _ => return Err(Error::ErrPeerConnRemoteDescriptionWithoutMidValue),
                         };
 
-                        if media.media_name.media == MEDIA_SECTION_APPLICATION {
+                        if media.is_webrtc_datachannel() {
                             continue;
                         }
 
@@ -1466,7 +1467,7 @@ impl RTCPeerConnection {
                             _ => return Err(Error::ErrPeerConnRemoteDescriptionWithoutMidValue),
                         };
 
-                        if media.media_name.media == MEDIA_SECTION_APPLICATION {
+                        if media.is_webrtc_datachannel() {
                             continue;
                         }
 

--- a/src/peer_connection/sdp/mod.rs
+++ b/src/peer_connection/sdp/mod.rs
@@ -244,6 +244,10 @@ pub(crate) fn track_details_from_sdp(s: &SessionDescription) -> Vec<TrackDetails
             _ => continue,
         };
 
+        if media.is_webrtc_datachannel() {
+            continue;
+        }
+
         let codec_type = RtpCodecKind::from(media.media_name.media.as_str());
         if codec_type == RtpCodecKind::Unspecified {
             continue;
@@ -676,6 +680,7 @@ impl RTCPeerConnection {
                 .mime_type
                 .trim_start_matches("audio/")
                 .trim_start_matches("video/")
+                .trim_start_matches("application/")
                 .to_owned();
             media = media.with_codec(
                 codec.payload_type,

--- a/src/peer_connection/sdp/mod.rs
+++ b/src/peer_connection/sdp/mod.rs
@@ -1297,10 +1297,23 @@ pub(crate) fn is_lite_set(desc: &SessionDescription) -> bool {
     false
 }
 
+pub(crate) trait MediaDescriptionExt {
+    /// Reports whether `self` is the WebRTC SCTP data channel m-line, as opposed to some
+    /// other RTP-carried media that also uses the SDP media name `"application"`.
+    fn is_webrtc_datachannel(&self) -> bool;
+}
+
+impl MediaDescriptionExt for MediaDescription {
+    fn is_webrtc_datachannel(&self) -> bool {
+        self.media_name.media == MEDIA_SECTION_APPLICATION
+            && self.media_name.formats == ["webrtc-datachannel"]
+    }
+}
+
 pub(crate) fn get_application_media_section_sctp_port(
     media_desc: &MediaDescription,
 ) -> Option<u16> {
-    if media_desc.media_name.media == MEDIA_SECTION_APPLICATION {
+    if media_desc.is_webrtc_datachannel() {
         return if let Some(sctp_port_attr) = media_desc
             .attributes
             .iter()
@@ -1333,7 +1346,7 @@ pub(crate) fn get_application_media_section_sctp_port(
 pub(crate) fn get_application_media_section_max_message_size(
     media_desc: &MediaDescription,
 ) -> Option<u32> {
-    if media_desc.media_name.media == MEDIA_SECTION_APPLICATION {
+    if media_desc.is_webrtc_datachannel() {
         media_desc
             .attribute(ATTR_KEY_MAX_MESSAGE_SIZE)??
             .parse()
@@ -1362,7 +1375,7 @@ pub(crate) fn get_by_mid<'a>(
 pub(crate) fn get_application_media(desc: &SessionDescription) -> Option<&MediaDescription> {
     desc.media_descriptions
         .iter()
-        .find(|media_description| media_description.media_name.media == MEDIA_SECTION_APPLICATION)
+        .find(|media_description| media_description.is_webrtc_datachannel())
 }
 
 /// have_data_channel return MediaDescription with MediaName equal application

--- a/src/rtp_transceiver/rtp_sender/internal.rs
+++ b/src/rtp_transceiver/rtp_sender/internal.rs
@@ -187,12 +187,7 @@ impl RTCRtpSenderInternal {
                 }
             }
 
-            if self.kind() == RtpCodecKind::Audio {
-                parameters.encodings.retain(|encoding| {
-                    encoding.scale_resolution_down_by.is_none() && encoding.max_framerate.is_none()
-                });
-            } else {
-                // Video
+            if self.kind() == RtpCodecKind::Video {
                 parameters.encodings.iter_mut().for_each(|encoding| {
                     encoding.scale_resolution_down_by.get_or_insert(1.0);
                 });
@@ -206,6 +201,11 @@ impl RTCRtpSenderInternal {
                         "scaleResolutionDownBy must be >= 1.0".to_string(),
                     ));
                 }
+            } else {
+                // Audio and Application have no resolution/framerate to scale.
+                parameters.encodings.retain(|encoding| {
+                    encoding.scale_resolution_down_by.is_none() && encoding.max_framerate.is_none()
+                });
             }
         }
 

--- a/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -23,6 +23,10 @@ pub enum RtpCodecKind {
     /// Video codec
     #[serde(rename = "video")]
     Video = 2,
+
+    /// Non-audio/video RTP-carried application data
+    #[serde(rename = "application")]
+    Application = 3,
 }
 
 impl From<&str> for RtpCodecKind {
@@ -30,6 +34,7 @@ impl From<&str> for RtpCodecKind {
         match raw {
             "audio" => RtpCodecKind::Audio,
             "video" => RtpCodecKind::Video,
+            "application" => RtpCodecKind::Application,
             _ => RtpCodecKind::Unspecified,
         }
     }
@@ -40,6 +45,7 @@ impl From<u8> for RtpCodecKind {
         match v {
             1 => RtpCodecKind::Audio,
             2 => RtpCodecKind::Video,
+            3 => RtpCodecKind::Application,
             _ => RtpCodecKind::Unspecified,
         }
     }
@@ -50,6 +56,7 @@ impl fmt::Display for RtpCodecKind {
         let s = match *self {
             RtpCodecKind::Audio => "audio",
             RtpCodecKind::Video => "video",
+            RtpCodecKind::Application => "application",
             RtpCodecKind::Unspecified => UNSPECIFIED_STR,
         };
         write!(f, "{s}")

--- a/src/rtp_transceiver/rtp_sender/rtp_codec.rs
+++ b/src/rtp_transceiver/rtp_sender/rtp_codec.rs
@@ -106,6 +106,8 @@ impl RTCRtpCodec {
             Ok(Box::<rtp::codec::g7xx::G7xxPayloader>::default())
         } else if mime_type == MIME_TYPE_AV1.to_lowercase() {
             Ok(Box::<rtp::codec::av1::Av1Payloader>::default())
+        } else if mime_type == MIME_TYPE_SMPTE336M.to_lowercase() {
+            Ok(Box::<rtp::codec::smpte336m::Smpte336mPayloader>::default())
         } else {
             Err(Error::ErrNoPayloaderForCodec)
         }

--- a/tests/smpte336m_negotiation.rs
+++ b/tests/smpte336m_negotiation.rs
@@ -1,0 +1,201 @@
+//! Regression test for `RtpCodecKind::Application` (SMPTE ST 336 / KLV metadata).
+//!
+//! The SDP media name `"application"` is shared by two unrelated things: the WebRTC
+//! SCTP data channel m-line and any other RTP-carried "application" media, such as an
+//! SMPTE336M metadata track. This test builds a peer that negotiates a video track, a
+//! real data channel, *and* an SMPTE336M metadata transceiver in the same offer/answer,
+//! and checks that all three come out as distinct m-lines rather than the SMPTE336M
+//! section being misread as (or clobbering) the data channel.
+
+use rtc::peer_connection::RTCPeerConnectionBuilder;
+use rtc::peer_connection::configuration::RTCConfigurationBuilder;
+use rtc::peer_connection::configuration::media_engine::{
+    MIME_TYPE_SMPTE336M, MIME_TYPE_VP8, MediaEngine,
+};
+use rtc::rtp_transceiver::rtp_sender::{
+    RTCRtpCodec, RTCRtpCodecParameters, RTCRtpEncodingParameters, RtpCodecKind,
+};
+use rtc::rtp_transceiver::{RTCRtpSenderId, RTCRtpTransceiverDirection, RTCRtpTransceiverInit};
+use std::time::Instant;
+
+fn application_codec() -> RTCRtpCodecParameters {
+    RTCRtpCodecParameters {
+        rtp_codec: RTCRtpCodec {
+            mime_type: MIME_TYPE_SMPTE336M.to_owned(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: String::new(),
+            rtcp_feedback: vec![],
+        },
+        payload_type: 96,
+        ..Default::default()
+    }
+}
+
+fn video_codec() -> RTCRtpCodecParameters {
+    RTCRtpCodecParameters {
+        rtp_codec: RTCRtpCodec {
+            mime_type: MIME_TYPE_VP8.to_owned(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: String::new(),
+            rtcp_feedback: vec![],
+        },
+        payload_type: 98,
+        ..Default::default()
+    }
+}
+
+fn media_engine_with_video_and_smpte336m() -> MediaEngine {
+    let mut media_engine = MediaEngine::default();
+    media_engine
+        .register_codec(video_codec(), RtpCodecKind::Video)
+        .expect("register video codec");
+    media_engine
+        .register_codec(application_codec(), RtpCodecKind::Application)
+        .expect("register application codec");
+    media_engine
+}
+
+/// Splits an SDP into its m= sections (including the leading session-level block).
+fn media_sections(sdp: &str) -> Vec<&str> {
+    let mut sections = vec![];
+    let mut rest = sdp;
+    while let Some(idx) = rest[1..].find("\r\nm=") {
+        sections.push(&rest[..idx + 1]);
+        rest = &rest[idx + 3..];
+    }
+    sections.push(rest);
+    sections
+}
+
+fn find_section<'a>(sections: &[&'a str], predicate: impl Fn(&str) -> bool) -> &'a str {
+    sections
+        .iter()
+        .copied()
+        .find(|s| predicate(s))
+        .unwrap_or_else(|| panic!("no matching m= section in {sections:?}"))
+}
+
+#[test]
+fn test_smpte336m_transceiver_negotiates_alongside_video_and_data_channel() {
+    let config = RTCConfigurationBuilder::new().build();
+
+    let mut offerer = RTCPeerConnectionBuilder::new()
+        .with_configuration(config.clone())
+        .with_media_engine(media_engine_with_video_and_smpte336m())
+        .build(Instant::now())
+        .expect("build offerer");
+
+    offerer
+        .add_transceiver_from_kind(
+            RtpCodecKind::Video,
+            Some(RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Sendonly,
+                streams: vec![],
+                send_encodings: vec![RTCRtpEncodingParameters {
+                    codec: video_codec().rtp_codec,
+                    ..Default::default()
+                }],
+            }),
+        )
+        .expect("add video transceiver");
+
+    let smpte336m_transceiver_id = offerer
+        .add_transceiver_from_kind(
+            RtpCodecKind::Application,
+            Some(RTCRtpTransceiverInit {
+                direction: RTCRtpTransceiverDirection::Sendonly,
+                streams: vec![],
+                send_encodings: vec![RTCRtpEncodingParameters {
+                    codec: application_codec().rtp_codec,
+                    ..Default::default()
+                }],
+            }),
+        )
+        .expect("add smpte336m transceiver");
+
+    offerer
+        .create_data_channel("chat", None)
+        .expect("create data channel");
+
+    let offer = offerer.create_offer(None).expect("create offer");
+    offerer
+        .set_local_description(Instant::now(), offer.clone())
+        .expect("set local offer");
+
+    let sections = media_sections(&offer.sdp);
+    assert_eq!(
+        sections.len(),
+        4,
+        "expected session block + video + smpte336m + data channel, got: {}",
+        offer.sdp
+    );
+
+    let video_section = find_section(&sections, |s| s.starts_with("m=video"));
+    assert!(video_section.contains("VP8/90000"), "{video_section}");
+
+    let datachannel_section = find_section(&sections, |s| {
+        s.starts_with("m=application") && s.contains("webrtc-datachannel")
+    });
+    assert!(
+        datachannel_section.contains("UDP/DTLS/SCTP"),
+        "{datachannel_section}"
+    );
+    assert!(
+        !datachannel_section.contains("smpte336m"),
+        "the data channel section must not absorb the SMPTE336M codec: {datachannel_section}"
+    );
+
+    let smpte336m_section = find_section(&sections, |s| {
+        s.starts_with("m=application") && s.contains("smpte336m")
+    });
+    assert!(
+        !smpte336m_section.contains("webrtc-datachannel"),
+        "the SMPTE336M section must not be mistaken for the data channel: {smpte336m_section}"
+    );
+    assert!(
+        smpte336m_section.contains("UDP/TLS/RTP"),
+        "{smpte336m_section}"
+    );
+
+    let mut answerer = RTCPeerConnectionBuilder::new()
+        .with_configuration(config)
+        .with_media_engine(media_engine_with_video_and_smpte336m())
+        .build(Instant::now())
+        .expect("build answerer");
+
+    answerer
+        .set_remote_description(Instant::now(), offer)
+        .expect("set remote offer");
+    let answer = answerer.create_answer(None).expect("create answer");
+
+    let answer_sections = media_sections(&answer.sdp);
+    assert_eq!(answer_sections.len(), 4, "{}", answer.sdp);
+    let answer_smpte336m_section = find_section(&answer_sections, |s| {
+        s.starts_with("m=application") && s.contains("smpte336m")
+    });
+    assert!(
+        !answer_smpte336m_section.contains("webrtc-datachannel"),
+        "{answer_smpte336m_section}"
+    );
+
+    answerer
+        .set_local_description(Instant::now(), answer.clone())
+        .expect("set local answer");
+    offerer
+        .set_remote_description(Instant::now(), answer)
+        .expect("set remote answer");
+
+    let smpte336m_sender_id = RTCRtpSenderId::from(smpte336m_transceiver_id);
+    let parameters = offerer
+        .rtp_sender(smpte336m_sender_id)
+        .expect("offerer smpte336m sender")
+        .get_parameters()
+        .clone();
+    assert_eq!(parameters.rtp_parameters.codecs.len(), 1);
+    assert_eq!(
+        parameters.rtp_parameters.codecs[0].rtp_codec.mime_type,
+        MIME_TYPE_SMPTE336M
+    );
+}


### PR DESCRIPTION
Allow transport of non-audio/video data via RTP, compared to the webrtc-datachannel that uses SCTP for the transport.

This is useful if you want to reuse the connection establishment mechanism of WebRTC (STUN, TURN, ICE) to transport non-audio/video RTP data with timestamp information.

Example: A drone offers a video stream and a metadata stream with GPS coordinates (e.g. [MISB ST 0601](https://upload.wikimedia.org/wikipedia/commons/1/19/MISB_Standard_0601.pdf)).