### PR TITLE
Bind declared SSRC remote streams to interceptors

### DIFF
--- a/src/peer_connection/handler/endpoint.rs
+++ b/src/peer_connection/handler/endpoint.rs
@@ -397,12 +397,22 @@ where
                 // handle_rtp_message before reaching here, so payload_type is the
                 // primary codec's. FEC de-encapsulation is still TODO (see #12).
                 {
-                    Some(codec.rtp_codec.clone())
+                    Some((codec.rtp_codec.clone(), rtp_header.payload_type))
                 } else {
                     None
                 };
 
-                if let Some(codec) = track_codec {
+                if let Some((codec, payload_type)) = track_codec {
+                    let parameters = receiver.get_parameters(self.media_engine);
+                    RTCRtpReceiverInternal::interceptor_remote_stream_op(
+                        self.interceptor,
+                        true,
+                        ssrc,
+                        payload_type,
+                        &codec,
+                        &parameters.rtp_parameters.header_extensions,
+                    );
+
                     // Set valid Codec for track when received the first RTP packet for such ssrc stream
                     // assert not inserting new entry
                     let new_entry = receiver.track_mut().set_codec_by_ssrc(codec, ssrc);


### PR DESCRIPTION
## Context

This was found while testing the [webrtc-rs/sfu](https://github.com/webrtc-rs/sfu) as a publisher/subscriber scenario. A browser publisher sends media tracks with declared SSRCs to the SFU and relies on RTCP feedback from the SFU receiver side. Since the declared SSRC path did not bind the remote stream to the interceptor chain after codec resolution, RTCP feedback such as receiver reports, TWCC, NACK, and PLI was not generated.

In the Shig/SFU this showed up as missing `remote-inbound-rtp` stats on the browser publisher side and the browser reducing outbound bitrate/resolution.

Related Shigde/SFU branch used for testing: https://github.com/shigde/shig/tree/core/webrtcrs20/src/sfu/rtc/media