### PR TITLE
defer data-channel stream-id assignment until DTLS role resolves

### DIFF
--- a/examples/data-channels-close/data-channels-close.rs
+++ b/examples/data-channels-close/data-channels-close.rs
@@ -251,12 +251,12 @@ async fn run(
                                 .data_channel(channel_id)
                                 .ok_or(Error::ErrDataChannelClosed)?;
                             println!(
-                                "Data channel '{}'-'{}' open. Random messages will now be sent every {} seconds",
+                                "Data channel '{}'-'{:?}' open. Random messages will now be sent every {} seconds",
                                 dc.label(),
                                 dc.id(),
                                 send_interval.as_secs()
                             );
-                            data_channel_opened = Some(dc.id());
+                            data_channel_opened = Some(channel_id);
                             data_channel_last_sent = Instant::now();
                         }
                         RTCDataChannelEvent::OnClose(channel_id) => {
@@ -347,7 +347,7 @@ async fn run(
 
                         close_after -= 1;
                         if close_after <=  0 {
-                            println!("Sent times out. Closing data channel '{}'-'{}'.", dc.label(), dc.id());
+                            println!("Sent times out. Closing data channel '{}'-'{:?}'.", dc.label(), dc.id());
                             let _ = dc.close();
                         }
                     }

--- a/examples/data-channels-create/data-channels-create.rs
+++ b/examples/data-channels-create/data-channels-create.rs
@@ -247,8 +247,8 @@ async fn run(
                             let dc = peer_connection
                                 .data_channel(channel_id)
                                 .ok_or(Error::ErrDataChannelClosed)?;
-                            println!("Data channel '{}'-'{}' open", dc.label(), dc.id());
-                            data_channel_opened = Some(dc.id());
+                            println!("Data channel '{}'-'{:?}' open", dc.label(), dc.id());
+                            data_channel_opened = Some(channel_id);
                         }
                         RTCDataChannelEvent::OnClose(channel_id) => {
                             println!("Data channel '{}' closed.", channel_id);

--- a/examples/data-channels-offer-answer/data-channels-answer.rs
+++ b/examples/data-channels-offer-answer/data-channels-answer.rs
@@ -236,7 +236,7 @@ async fn main() -> Result<()> {
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     if let Some(dc) = peer_connection.data_channel(channel_id) {
                         println!(
-                            "Data channel '{}'-'{}' open. Random messages will now be sent every 5 seconds",
+                            "Data channel '{}'-'{:?}' open. Random messages will now be sent every 5 seconds",
                             dc.label(),
                             dc.id()
                         );

--- a/examples/data-channels-offer-answer/data-channels-offer.rs
+++ b/examples/data-channels-offer-answer/data-channels-offer.rs
@@ -260,7 +260,7 @@ async fn main() -> Result<()> {
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     if let Some(dc) = peer_connection.data_channel(channel_id) {
                         println!(
-                            "Data channel '{}'-'{}' open. Random messages will now be sent every 5 seconds",
+                            "Data channel '{}'-'{:?}' open. Random messages will now be sent every 5 seconds",
                             dc.label(),
                             dc.id()
                         );

--- a/examples/data-channels/data-channels.rs
+++ b/examples/data-channels/data-channels.rs
@@ -239,7 +239,7 @@ async fn run(
                             let dc = peer_connection
                                 .data_channel(channel_id)
                                 .ok_or(Error::ErrDataChannelClosed)?;
-                            println!("Data channel '{}'-'{}' open", dc.label(), dc.id());
+                            println!("Data channel '{}'-'{:?}' open", dc.label(), dc.id());
                         }
                         _ => {}
                     }

--- a/examples/ice-restart/ice-restart.rs
+++ b/examples/ice-restart/ice-restart.rs
@@ -253,7 +253,7 @@ async fn main() -> Result<()> {
                         channel_id,
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
-                            println!("Data channel '{}'-'{}' open", dc.label(), dc.id());
+                            println!("Data channel '{}'-'{:?}' open", dc.label(), dc.id());
                             data_channel_opened = Some(channel_id);
                             last_send = Instant::now();
                         }

--- a/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
@@ -322,7 +322,7 @@ async fn main() -> Result<()> {
                 }
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     if let Some(dc) = peer_connection.data_channel(channel_id) {
-                        println!("[Offer] Data channel '{}'-'{}' open", dc.label(), dc.id());
+                        println!("[Offer] Data channel '{}'-'{:?}' open", dc.label(), dc.id());
                         data_channel_id = Some(channel_id);
                         last_send = Instant::now();
                     }

--- a/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
@@ -242,7 +242,11 @@ async fn main() -> Result<()> {
                         channel_id,
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
-                            println!("[Answer] Data channel '{}'-'{}' open", dc.label(), dc.id());
+                            println!(
+                                "[Answer] Data channel '{}'-'{:?}' open",
+                                dc.label(),
+                                dc.id()
+                            );
                             data_channel_id = Some(channel_id);
                             last_send = Instant::now();
                         }

--- a/examples/ice-tcp/ice-tcp.rs
+++ b/examples/ice-tcp/ice-tcp.rs
@@ -236,7 +236,7 @@ async fn run_main_loop(
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
                             println!(
-                                "{} - Data channel '{}'-'{}' open",
+                                "{} - Data channel '{}'-'{:?}' open",
                                 chrono::Local::now().format("%H:%M:%S"),
                                 dc.label(),
                                 dc.id()

--- a/examples/mdns-query-and-gather/mdns-query-and-gather.rs
+++ b/examples/mdns-query-and-gather/mdns-query-and-gather.rs
@@ -288,7 +288,7 @@ async fn run(
                             let dc = peer_connection
                                 .data_channel(channel_id)
                                 .ok_or(Error::ErrDataChannelClosed)?;
-                            println!("Data channel '{}'-'{}' open", dc.label(), dc.id());
+                            println!("Data channel '{}'-'{:?}' open", dc.label(), dc.id());
                         }
                         _ => {}
                     }

--- a/examples/perfect-negotiation/perfect-negotiation.rs
+++ b/examples/perfect-negotiation/perfect-negotiation.rs
@@ -525,7 +525,7 @@ async fn run_peer(
                                 RTCDataChannelEvent::OnOpen(channel_id) => {
                                     data_channel_id = Some(channel_id);
                                     if let Some(dc) = negotiation.peer_connection().data_channel(channel_id) {
-                                        info!("[{}] Data channel '{}-{}' opened", role, dc.label(), dc.id());
+                                        info!("[{}] Data channel '{}'-'{:?}' opened", role, dc.label(), dc.id());
                                     }
                                 }
                                 _ => {}

--- a/examples/play-from-disk-playlist-control/play-from-disk-playlist-control.rs
+++ b/examples/play-from-disk-playlist-control/play-from-disk-playlist-control.rs
@@ -22,7 +22,7 @@ use env_logger::Target;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use log::{debug, error, trace};
-use rtc::data_channel::RTCDataChannelId;
+use rtc::data_channel::{RTCDataChannelHandle, RTCDataChannelId};
 use rtc::interceptor::Registry;
 use rtc::media::io::ogg_reader::{
     OggHeader, OggHeaderType, OggReader, OpusTags, parse_opus_head, parse_opus_tags,
@@ -560,8 +560,11 @@ async fn handle_whep_connection(
 
     let audio_sender_id = peer_connection.add_track(output_track)?;
 
-    // Create data channel for playlist control
-    let playlist_channel_id = peer_connection.create_data_channel("playlist", None)?.id();
+    // Create data channel for playlist control. The stream id is only assigned once the SCTP
+    // transport connects (W3C section 6.1 step 18), so the channel is tracked by its stable handle.
+    let playlist_channel_handle = peer_connection
+        .create_data_channel("playlist", None)?
+        .handle();
 
     // Set remote description
     let offer = RTCSessionDescription::offer(offer_sdp)?;
@@ -607,7 +610,7 @@ async fn handle_whep_connection(
         peer_connection,
         tracks,
         audio_sender_id,
-        playlist_channel_id,
+        playlist_channel_handle,
         ssrc,
         opus_codec,
     )
@@ -621,7 +624,7 @@ async fn run_peer_connection(
     mut peer_connection: RTCPeerConnection,
     tracks: Arc<Vec<OggTrack>>,
     audio_sender_id: RTCRtpSenderId,
-    playlist_channel_id: RTCDataChannelId,
+    playlist_channel_handle: RTCDataChannelHandle,
     ssrc: SSRC,
     codec: RTCRtpCodecParameters,
 ) -> Result<()> {
@@ -629,6 +632,9 @@ async fn run_peer_connection(
     let current_page = Arc::new(AtomicUsize::new(0));
     let switch_track = Arc::new(AtomicI32::new(-1)); // -1 means no switch requested
     let mut connected = false;
+    // The playlist channel's stream id, assigned once the SCTP transport connects; used to
+    // filter inbound messages and to look the channel up for sends.
+    let mut playlist_stream_id: Option<RTCDataChannelId> = None;
 
     // Create packetizer
     let mut packetizer = rtp::packetizer::new_packetizer(
@@ -672,7 +678,9 @@ async fn run_peer_connection(
                         connected = true;
 
                         // Send initial playlist
-                        if let Some(mut dc) = peer_connection.data_channel(playlist_channel_id) {
+                        if let Some(mut dc) =
+                            peer_connection.data_channel_handle(playlist_channel_handle)
+                        {
                             let playlist_msg = build_playlist_message(
                                 &tracks,
                                 current_track.load(Ordering::SeqCst),
@@ -688,7 +696,7 @@ async fn run_peer_connection(
                     }
                 }
                 RTCPeerConnectionEvent::OnDataChannel(dc_event) => match dc_event {
-                    RTCDataChannelEvent::OnOpen(_) => {}
+                    RTCDataChannelEvent::OnOpen(stream_id) => playlist_stream_id = Some(stream_id),
                     RTCDataChannelEvent::OnClose(_) => {}
                     _ => {}
                 },
@@ -699,7 +707,7 @@ async fn run_peer_connection(
         // Process data channel messages
         while let Some(TaggedRTCMessage { message, .. }) = peer_connection.poll_read() {
             if let RTCMessage::DataChannelMessage(dc_id, dc_message) = message {
-                if dc_id == playlist_channel_id {
+                if Some(dc_id) == playlist_stream_id {
                     let command = String::from_utf8_lossy(&dc_message.data)
                         .trim()
                         .to_lowercase();
@@ -709,7 +717,7 @@ async fn run_peer_connection(
                         &current_track,
                         &switch_track,
                         &mut peer_connection,
-                        playlist_channel_id,
+                        playlist_channel_handle,
                     );
                 }
             }
@@ -769,7 +777,9 @@ async fn run_peer_connection(
                         current_page.store(0, Ordering::SeqCst);
 
                         // Send now playing
-                        if let Some(mut dc) = peer_connection.data_channel(playlist_channel_id) {
+                        if let Some(mut dc) =
+                            peer_connection.data_channel_handle(playlist_channel_handle)
+                        {
                             let now_msg = build_now_playing_message(&tracks, switch as usize);
                             let _ = dc.send_text(Instant::now(), now_msg);
                         }
@@ -783,7 +793,9 @@ async fn run_peer_connection(
                     current_page.store(0, Ordering::SeqCst);
 
                     // Send now playing
-                    if let Some(mut dc) = peer_connection.data_channel(playlist_channel_id) {
+                    if let Some(mut dc) =
+                        peer_connection.data_channel_handle(playlist_channel_handle)
+                    {
                         let now_msg = build_now_playing_message(&tracks, next as usize);
                         let _ = dc.send_text(Instant::now(), now_msg);
                     }
@@ -849,7 +861,7 @@ fn handle_playlist_command(
     current_track: &AtomicI32,
     switch_track: &AtomicI32,
     peer_connection: &mut RTCPeerConnection,
-    playlist_channel_id: RTCDataChannelId,
+    playlist_channel_handle: RTCDataChannelHandle,
 ) {
     let limit = tracks.len() as i32;
     let current = current_track.load(Ordering::SeqCst);
@@ -863,7 +875,7 @@ fn handle_playlist_command(
             next = wrap_prev(current, limit);
         }
         "list" => {
-            if let Some(mut dc) = peer_connection.data_channel(playlist_channel_id) {
+            if let Some(mut dc) = peer_connection.data_channel_handle(playlist_channel_handle) {
                 let msg = build_playlist_message(tracks, current);
                 let _ = dc.send_text(Instant::now(), msg);
             }
@@ -883,7 +895,7 @@ fn handle_playlist_command(
 
     switch_track.store(next, Ordering::SeqCst);
 
-    if let Some(mut dc) = peer_connection.data_channel(playlist_channel_id) {
+    if let Some(mut dc) = peer_connection.data_channel_handle(playlist_channel_handle) {
         let msg = build_playlist_message(tracks, next);
         let _ = dc.send_text(Instant::now(), msg);
     }

--- a/examples/trickle-ice-host/trickle-ice-host.rs
+++ b/examples/trickle-ice-host/trickle-ice-host.rs
@@ -191,7 +191,7 @@ async fn run_main_loop() -> Result<()> {
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
                             println!(
-                                "{} - Data channel '{}'-'{}' open",
+                                "{} - Data channel '{}'-'{:?}' open",
                                 chrono::Local::now().format("%H:%M:%S"),
                                 dc.label(),
                                 dc.id()

--- a/examples/trickle-ice-relay/trickle-ice-relay.rs
+++ b/examples/trickle-ice-relay/trickle-ice-relay.rs
@@ -357,7 +357,7 @@ async fn run_main_loop(
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
                             println!(
-                                "{} - Data channel '{}'-'{}' open",
+                                "{} - Data channel '{}'-'{:?}' open",
                                 chrono::Local::now().format("%H:%M:%S"),
                                 dc.label(),
                                 dc.id()

--- a/examples/trickle-ice-srflx/trickle-ice-srflx.rs
+++ b/examples/trickle-ice-srflx/trickle-ice-srflx.rs
@@ -198,7 +198,7 @@ async fn run_main_loop() -> Result<()> {
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
                             println!(
-                                "{} - Data channel '{}'-'{}' open",
+                                "{} - Data channel '{}'-'{:?}' open",
                                 chrono::Local::now().format("%H:%M:%S"),
                                 dc.label(),
                                 dc.id()

--- a/examples/trickle-ice/trickle-ice.rs
+++ b/examples/trickle-ice/trickle-ice.rs
@@ -507,7 +507,7 @@ async fn run_main_loop(cli: Cli) -> Result<()> {
                     )) => {
                         if let Some(dc) = pc.data_channel(channel_id) {
                             println!(
-                                "{} - Data channel '{}'-'{}' open",
+                                "{} - Data channel '{}'-'{:?}' open",
                                 chrono::Local::now().format("%H:%M:%S"),
                                 dc.label(),
                                 dc.id()

--- a/rtc-shared/src/error.rs
+++ b/rtc-shared/src/error.rs
@@ -1813,6 +1813,12 @@ pub enum Error {
     #[error("both max_packet_life_time and max_retransmits was set")]
     ErrRetransmitsOrPacketLifeTime,
 
+    /// ErrOperationError indicates an operation was rejected because it conflicts
+    /// with existing state (e.g. creating a negotiated data channel whose stream
+    /// id is already in use, W3C section 6.1 createDataChannel step 18).
+    #[error("operation error")]
+    ErrOperationError,
+
     /// ErrCodecNotFound is returned when a codec search to the Media Engine fails
     #[error("codec not found")]
     ErrCodecNotFound,

--- a/src/data_channel/internal.rs
+++ b/src/data_channel/internal.rs
@@ -1,15 +1,22 @@
+use crate::data_channel::RTCDataChannelHandle;
 use crate::data_channel::RTCDataChannelId;
 use crate::data_channel::parameters::DataChannelParameters;
 use crate::data_channel::state::RTCDataChannelState;
 use datachannel::data_channel::DataChannelConfig;
 use sansio::Protocol;
 use sctp::PayloadProtocolIdentifier;
-use shared::error::Result;
+use shared::error::{Error, Result};
 use std::time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct RTCDataChannelInternal {
-    pub(crate) id: RTCDataChannelId,
+    pub(crate) handle: RTCDataChannelHandle,
+    /// The SCTP stream identifier for this channel.
+    ///
+    /// `None` until the DTLS role has been negotiated and the SCTP transport has connected
+    /// (W3C section 6.1 step 18 / section 6.1.1.3). Negotiated channels with an explicit id and channels
+    /// created after the transport is connected are assigned one immediately.
+    pub(crate) stream_id: Option<RTCDataChannelId>,
     pub(crate) label: String,
     pub(crate) ordered: bool,
     pub(crate) max_packet_life_time: Option<u16>,
@@ -41,7 +48,8 @@ pub(crate) struct RTCDataChannelInternal {
 impl Default for RTCDataChannelInternal {
     fn default() -> Self {
         Self {
-            id: 0,
+            handle: RTCDataChannelHandle::new(0),
+            stream_id: None,
             label: "".to_string(),
             ordered: false,
             max_packet_life_time: None,
@@ -61,9 +69,11 @@ impl Default for RTCDataChannelInternal {
 
 impl RTCDataChannelInternal {
     /// create the DataChannel object before the networking is set up.
-    pub(crate) fn new(id: RTCDataChannelId, params: DataChannelParameters) -> Self {
+    pub(crate) fn new(handle: RTCDataChannelHandle, params: DataChannelParameters) -> Self {
+        let stream_id = params.negotiated;
         Self {
-            id,
+            handle,
+            stream_id,
             label: params.label,
             protocol: params.protocol,
             negotiated: params.negotiated.is_some(),
@@ -97,8 +107,9 @@ impl RTCDataChannelInternal {
             negotiated: self.negotiated,
         };
 
+        let stream_id = self.stream_id.ok_or(Error::ErrDataChannelNotOpen)?;
         let mut data_channel =
-            ::datachannel::data_channel::DataChannel::dial(config, association_handle, self.id)?;
+            ::datachannel::data_channel::DataChannel::dial(config, association_handle, stream_id)?;
         data_channel.set_buffered_amount_low_threshold(self.buffered_amount_low_threshold)?;
         data_channel.set_buffered_amount_high_threshold(self.buffered_amount_high_threshold)?;
 
@@ -117,6 +128,7 @@ impl RTCDataChannelInternal {
     }
 
     pub(crate) fn accept(
+        handle: RTCDataChannelHandle,
         association_handle: usize,
         stream_id: u16,
         ppi: PayloadProtocolIdentifier,
@@ -138,7 +150,7 @@ impl RTCDataChannelInternal {
             );
 
         let mut data_channel_internal = RTCDataChannelInternal::new(
-            stream_id,
+            handle,
             DataChannelParameters {
                 label: data_channel_config.label.clone(),
                 protocol: data_channel_config.protocol.clone(),
@@ -148,6 +160,7 @@ impl RTCDataChannelInternal {
                 negotiated: None,
             },
         );
+        data_channel_internal.stream_id = Some(stream_id);
         data_channel_internal.data_channel = Some(data_channel);
         data_channel_internal.ready_state = RTCDataChannelState::Open;
 

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -53,6 +53,32 @@ pub(crate) mod state;
 /// Each data channel has a unique 16-bit identifier within its peer connection.
 pub type RTCDataChannelId = u16;
 
+/// Stable handle for a data channel within a particular peer connection.
+///
+/// The connection keeps channels in a map keyed by this handle. It is assigned at
+/// `create_data_channel` time and never changes, unlike the stream identifier
+/// (`RTCDataChannelId`), which is only assigned once the DTLS role has been
+/// negotiated and the SCTP transport is connected (W3C section 6.1 step 18 and section 6.1.1.3).
+///
+/// This type addresses a channel before its stream id is known.
+/// [`RTCDataChannel::id`] exposes the stream id once assigned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct RTCDataChannelHandle(pub(crate) usize);
+
+impl RTCDataChannelHandle {
+    /// Constructs a handle. Intended for tests and bindings that read handles from
+    /// the core; handles otherwise come from [`RTCPeerConnection::create_data_channel`].
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for RTCDataChannelHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 pub use init::RTCDataChannelInit;
 
 pub use message::RTCDataChannelMessage;
@@ -71,11 +97,19 @@ pub use state::RTCDataChannelState;
 /// * [W3C WebRTC - RTCDataChannel](https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel)
 /// * [MDN - RTCDataChannel](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel)
 pub struct RTCDataChannel<'a> {
-    pub(crate) id: RTCDataChannelId,
+    pub(crate) handle: RTCDataChannelHandle,
     pub(crate) peer_connection: &'a mut RTCPeerConnection,
 }
 
 impl RTCDataChannel<'_> {
+    /// The stable handle for this data channel, assigned at creation and never changed.
+    ///
+    /// [`RTCDataChannel::id`] returns the stream id once assigned; this handle is the stable
+    /// identity used internally to address the channel before then.
+    pub fn handle(&self) -> RTCDataChannelHandle {
+        self.handle
+    }
+
     /// label represents a label that can be used to distinguish this
     /// DataChannel object from other DataChannel objects. Scripts are
     /// allowed to create multiple DataChannel objects with the same label.
@@ -84,7 +118,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .label
             .as_str()
@@ -97,7 +131,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .ordered
     }
@@ -109,7 +143,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .max_packet_life_time
     }
@@ -121,7 +155,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .max_retransmits
     }
@@ -133,7 +167,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .protocol
             .as_str()
@@ -146,7 +180,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .negotiated
     }
@@ -157,8 +191,13 @@ impl RTCDataChannel<'_> {
     /// yet been negotiated. Otherwise, it will return the ID that was either
     /// selected by the script or generated. After the ID is set to a non-null
     /// value, it will not change.
-    pub fn id(&self) -> RTCDataChannelId {
-        self.id
+    pub fn id(&self) -> Option<RTCDataChannelId> {
+        // Per W3C section 6.1 step 18 the identifier is null until the DTLS role has been negotiated
+        // and the SCTP transport connected; this returns `None` until then.
+        self.peer_connection
+            .data_channels
+            .get(&self.handle)?
+            .stream_id
     }
 
     /// ready_state represents the state of the DataChannel object.
@@ -167,7 +206,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .ready_state
     }
@@ -183,7 +222,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .buffered_amount_high_threshold
     }
@@ -196,7 +235,7 @@ impl RTCDataChannel<'_> {
         let dc = self
             .peer_connection
             .data_channels
-            .get_mut(&self.id)
+            .get_mut(&self.handle)
             .unwrap();
         dc.buffered_amount_high_threshold = threshold;
         if let Some(data_channel) = dc.data_channel.as_mut() {
@@ -215,7 +254,7 @@ impl RTCDataChannel<'_> {
         // so, unwrap() here is safe.
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .unwrap()
             .buffered_amount_low_threshold
     }
@@ -228,7 +267,7 @@ impl RTCDataChannel<'_> {
         let dc = self
             .peer_connection
             .data_channels
-            .get_mut(&self.id)
+            .get_mut(&self.handle)
             .unwrap();
         dc.buffered_amount_low_threshold = threshold;
         if let Some(data_channel) = dc.data_channel.as_mut() {
@@ -246,7 +285,7 @@ impl RTCDataChannel<'_> {
         let dc = self
             .peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .ok_or(Error::ErrDataChannelClosed)?;
 
         if dc.data_channel.is_none() {
@@ -268,10 +307,16 @@ impl RTCDataChannel<'_> {
     pub fn send(&mut self, now: Instant, data: BytesMut) -> Result<()> {
         self.ensure_sendable()?;
         let data_len = data.len();
+        let stream_id = self
+            .peer_connection
+            .data_channels
+            .get(&self.handle)
+            .and_then(|dc| dc.stream_id)
+            .ok_or(Error::ErrDataChannelNotOpen)?;
         self.peer_connection.handle_write(TaggedRTCMessage {
             now,
             message: RTCMessage::DataChannelMessage(
-                self.id,
+                stream_id,
                 RTCDataChannelMessage {
                     is_string: false,
                     data,
@@ -281,7 +326,7 @@ impl RTCDataChannel<'_> {
         // Count only after a successful enqueue, so a failed send never leaks the
         // counter upward (those bytes never entered the SCTP send pipeline). This
         // is the synchronous send-boundary accounting used for back-pressure.
-        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.id) {
+        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.handle) {
             dc.outstanding_bytes += data_len;
         }
         Ok(())
@@ -294,17 +339,23 @@ impl RTCDataChannel<'_> {
         self.ensure_sendable()?;
         let data = BytesMut::from(s.into().as_str());
         let data_len = data.len();
+        let stream_id = self
+            .peer_connection
+            .data_channels
+            .get(&self.handle)
+            .and_then(|dc| dc.stream_id)
+            .ok_or(Error::ErrDataChannelNotOpen)?;
         self.peer_connection.handle_write(TaggedRTCMessage {
             now,
             message: RTCMessage::DataChannelMessage(
-                self.id,
+                stream_id,
                 RTCDataChannelMessage {
                     is_string: true,
                     data,
                 },
             ),
         })?;
-        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.id) {
+        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.handle) {
             dc.outstanding_bytes += data_len;
         }
         Ok(())
@@ -318,14 +369,14 @@ impl RTCDataChannel<'_> {
     pub fn outstanding_bytes(&self) -> usize {
         self.peer_connection
             .data_channels
-            .get(&self.id)
+            .get(&self.handle)
             .map(|dc| dc.outstanding_bytes)
             .unwrap_or(0)
     }
 
     /// Closes the data channel.
     pub fn close(&mut self) -> Result<()> {
-        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.id) {
+        if let Some(dc) = self.peer_connection.data_channels.get_mut(&self.handle) {
             if dc.ready_state == RTCDataChannelState::Closed {
                 return Ok(());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,7 @@
 //! };
 //!
 //! let mut dc = pc.create_data_channel("my-channel", Some(init))?;
-//! let channel_id = dc.id();
+//! let channel_id = dc.id().expect("data channel id is assigned once negotiated");
 //!
 //! // Send text message
 //! dc.send_text(Instant::now(), "Hello, WebRTC!")?;

--- a/src/peer_connection/event/data_channel_event.rs
+++ b/src/peer_connection/event/data_channel_event.rs
@@ -2,7 +2,7 @@
 //!
 //! Events related to RTCDataChannel lifecycle and buffering state changes.
 
-use crate::data_channel::RTCDataChannelId;
+use crate::data_channel::{RTCDataChannelHandle, RTCDataChannelId};
 
 /// Events that can be emitted by an RTCDataChannel.
 ///
@@ -106,6 +106,15 @@ pub enum RTCDataChannelEvent {
     /// This event is fired when the channel is fully closed and no longer usable.
     /// No more data can be sent or received.
     OnClose(RTCDataChannelId),
+
+    /// Data channel failed before a stream id could be assigned (e.g. SCTP stream
+    /// exhaustion). Keyed by the stable `RTCDataChannelHandle` instead of a stream
+    /// id, and addressed directly by handle, because the channel never received one.
+    OnErrorByHandle(RTCDataChannelHandle),
+
+    /// Data channel closed before a stream id could be assigned (see
+    /// `OnErrorByHandle`). Keyed by the stable `RTCDataChannelHandle`.
+    OnCloseByHandle(RTCDataChannelHandle),
 
     /// Buffered amount dropped below the low-water mark.
     ///

--- a/src/peer_connection/handler/datachannel.rs
+++ b/src/peer_connection/handler/datachannel.rs
@@ -1,3 +1,4 @@
+use crate::data_channel::RTCDataChannelHandle;
 use crate::data_channel::RTCDataChannelId;
 use crate::data_channel::internal::RTCDataChannelInternal;
 use crate::data_channel::message::RTCDataChannelMessage;
@@ -9,12 +10,14 @@ use crate::peer_connection::event::{
 use crate::peer_connection::message::internal::{
     ApplicationMessage, DTLSMessage, DataChannelEvent, RTCMessageInternal, TaggedRTCMessageInternal,
 };
+use crate::peer_connection::transport::RTCDtlsRole;
+use crate::peer_connection::transport::sctp::SCTP_MAX_CHANNELS;
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use log::{debug, warn};
 use sctp::PayloadProtocolIdentifier;
 use shared::TransportContext;
 use shared::error::{Error, Result};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 pub(crate) struct DataChannelHandlerContext {
@@ -51,24 +54,47 @@ impl DataChannelHandlerContext {
 /// DataChannelHandler implements DataChannel Protocol handling
 pub(crate) struct DataChannelHandler<'a> {
     ctx: &'a mut DataChannelHandlerContext,
-    data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+    data_channels: &'a mut HashMap<RTCDataChannelHandle, RTCDataChannelInternal>,
+    /// Handles of locally-created channels whose stream id is still unassigned (DTLS role not yet
+    /// resolved / SCTP not connected), in creation order.
+    pending_handles: &'a mut Vec<RTCDataChannelHandle>,
+    /// Reverse lookup stream id -> handle, for channels that have been assigned a stream id.
+    data_channel_ids: &'a mut HashMap<RTCDataChannelId, RTCDataChannelHandle>,
+    /// Handle allocator, shared with `RTCPeerConnection`, so accepted (remote) channels get a
+    /// distinct handle.
+    handle_allocator: &'a mut usize,
     stats: &'a mut RTCStatsAccumulator,
     /// Configured DCEP handshake timeout for in-band channels. `None` disables it.
     dcep_handshake_timeout: Option<Duration>,
+    /// The local DTLS role, resolved once the remote description has been applied.
+    dtls_role: RTCDtlsRole,
+    /// The negotiated SCTP channel cap, known once the SCTP association is connected.
+    max_channels: Option<u16>,
 }
 
 impl<'a> DataChannelHandler<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         ctx: &'a mut DataChannelHandlerContext,
-        data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+        data_channels: &'a mut HashMap<RTCDataChannelHandle, RTCDataChannelInternal>,
+        pending_handles: &'a mut Vec<RTCDataChannelHandle>,
+        data_channel_ids: &'a mut HashMap<RTCDataChannelId, RTCDataChannelHandle>,
+        handle_allocator: &'a mut usize,
         stats: &'a mut RTCStatsAccumulator,
         dcep_handshake_timeout: Option<Duration>,
+        dtls_role: RTCDtlsRole,
+        max_channels: Option<u16>,
     ) -> Self {
         DataChannelHandler {
             ctx,
             data_channels,
+            pending_handles,
+            data_channel_ids,
+            handle_allocator,
             stats,
             dcep_handshake_timeout,
+            dtls_role,
+            max_channels,
         }
     }
 
@@ -84,27 +110,103 @@ impl<'a> DataChannelHandler<'a> {
         &mut self,
         now: Instant,
         transport: TransportContext,
-        id: RTCDataChannelId,
+        handle: RTCDataChannelHandle,
     ) -> Result<()> {
         let dc = self
             .data_channels
-            .get(&id)
+            .get(&handle)
             .ok_or(Error::ErrDataChannelNotExisted)?;
+        // A channel only opens once its stream id has been assigned (on the connected
+        // procedure), so the event always carries a stream id.
+        let stream_id = dc.stream_id.ok_or(Error::ErrDataChannelNotExisted)?;
 
         self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
             now,
             transport,
             message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(ApplicationMessage {
-                data_channel_id: id,
+                data_channel_id: stream_id,
                 data_channel_event: DataChannelEvent::Open,
             })),
         });
 
         self.stats.peer_connection.on_data_channel_opened();
         self.stats
-            .get_or_create_data_channel(id, &dc.label, &dc.protocol)
+            .get_or_create_data_channel(stream_id, &dc.label, &dc.protocol)
             .on_state_changed(RTCDataChannelState::Open);
         Ok(())
+    }
+
+    /// Assign stream ids to pending local channels once the DTLS role is resolved.
+    ///
+    /// Implements W3C WebRTC section 6.1.1.3 step 4.2 / RFC 8832 section 6.
+    /// Channels that cannot be assigned an id are closed and the application is notified.
+    fn assign_pending_ids(&mut self, now: Instant) {
+        let pending = std::mem::take(self.pending_handles);
+        // `max` is a count of streams, so valid ids span `0..max` and the top id (`max - 1`)
+        // is usable.
+        let max = self.max_channels.unwrap_or(SCTP_MAX_CHANNELS);
+        let mut used: HashSet<RTCDataChannelId> = self.data_channel_ids.keys().copied().collect();
+        let mut closed = Vec::new();
+        for handle in pending {
+            // Closed channels cannot be dialed, so they must not consume a stream id.
+            if let Some(dc) = self.data_channels.get(&handle)
+                && (dc.ready_state == RTCDataChannelState::Closed
+                    || dc.ready_state == RTCDataChannelState::Closing)
+            {
+                continue;
+            }
+            let mut id = 0u16;
+            if self.dtls_role == RTCDtlsRole::Server {
+                id += 1;
+            }
+            let mut found = None;
+            while id < max {
+                if !used.contains(&id) {
+                    found = Some(id);
+                    break;
+                }
+                id += 2;
+            }
+            match found {
+                Some(stream_id) => {
+                    if let Some(dc) = self.data_channels.get_mut(&handle) {
+                        dc.stream_id = Some(stream_id);
+                        self.data_channel_ids.insert(stream_id, handle);
+                        // Reserve the id for later handles in this batch, so two pending
+                        // channels cannot be assigned the same stream id.
+                        used.insert(stream_id);
+                    }
+                }
+                None => {
+                    closed.push(handle);
+                }
+            }
+        }
+        for handle in closed {
+            if let Some(mut dc) = self.data_channels.remove(&handle) {
+                let _ = dc.close();
+                // The channel never received a stream id, so it cannot be keyed by one.
+                // Notify the application with the stable handle so the event routes to the right
+                // channel rather than via the defaulted stream id 0. Error first, then close
+                // (W3C section 6.2.7).
+                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(
+                            RTCDataChannelEvent::OnErrorByHandle(handle),
+                        ),
+                    ),
+                });
+                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(
+                            RTCDataChannelEvent::OnCloseByHandle(handle),
+                        ),
+                    ),
+                });
+            }
+        }
     }
 }
 
@@ -128,11 +230,19 @@ impl<'a>
                 msg.transport.peer_addr
             );
 
+            // Defensive assignment in case DATA_CHANNEL_ACK arrives before SCTPHandshakeComplete.
+            self.assign_pending_ids(now);
+
             let stream_id = message.stream_id;
             let transport = msg.transport;
 
-            let opened = if let Some(data_channel_internal) = self.data_channels.get_mut(&stream_id)
-            {
+            let handle = self.data_channel_ids.get(&stream_id).copied();
+
+            let (handle, opened) = if let Some(handle) = handle {
+                let data_channel_internal = self
+                    .data_channels
+                    .get_mut(&handle)
+                    .ok_or(Error::ErrDataChannelNotExisted)?;
                 // A closed channel is terminal: ignore any late DCEP or user data.
                 if data_channel_internal.ready_state == RTCDataChannelState::Closed {
                     return Ok(());
@@ -154,29 +264,33 @@ impl<'a>
                     data_channel_internal.handshake_deadline = None;
                     opened = true;
                 }
-                opened
+                (handle, opened)
             } else {
+                // Incoming (remote) channel: assign a fresh handle and record its stream id.
+                let handle = RTCDataChannelHandle::new(*self.handle_allocator);
+                *self.handle_allocator += 1;
                 let data_channel_internal = RTCDataChannelInternal::accept(
+                    handle,
                     message.association_handle,
-                    message.stream_id,
+                    stream_id,
                     message.ppi,
                     &message.payload,
                 )?;
 
-                self.data_channels
-                    .insert(message.stream_id, data_channel_internal);
-                true
+                self.data_channels.insert(handle, data_channel_internal);
+                self.data_channel_ids.insert(stream_id, handle);
+                (handle, true)
             };
 
             if opened {
-                self.emit_data_channel_opened(now, transport, stream_id)?;
+                self.emit_data_channel_opened(now, transport, handle)?;
             }
 
             // Get label/protocol before taking mutable borrow for the loop
             let (label, protocol) = {
                 let dc = self
                     .data_channels
-                    .get(&stream_id)
+                    .get(&handle)
                     .ok_or(Error::ErrDataChannelNotExisted)?;
                 (dc.label.clone(), dc.protocol.clone())
             };
@@ -187,12 +301,12 @@ impl<'a>
             // discarded on close/timeout.
             let is_open = self
                 .data_channels
-                .get(&stream_id)
+                .get(&handle)
                 .is_some_and(|dc| dc.ready_state == RTCDataChannelState::Open);
 
             let data_channel = self
                 .data_channels
-                .get_mut(&stream_id)
+                .get_mut(&handle)
                 .ok_or(Error::ErrDataChannelNotExisted)?
                 .data_channel
                 .as_mut()
@@ -276,18 +390,23 @@ impl<'a>
             {
                 let data_len = data.len();
                 let channel_id = message.data_channel_id;
+                let handle = self
+                    .data_channel_ids
+                    .get(&channel_id)
+                    .copied()
+                    .ok_or(Error::ErrDataChannelNotExisted)?;
 
                 // Get label/protocol before taking mutable borrow
                 let dc_internal = self
                     .data_channels
-                    .get(&channel_id)
+                    .get(&handle)
                     .ok_or(Error::ErrDataChannelNotExisted)?;
                 let label = dc_internal.label.clone();
                 let protocol = dc_internal.protocol.clone();
 
                 let data_channel = self
                     .data_channels
-                    .get_mut(&channel_id)
+                    .get_mut(&handle)
                     .ok_or(Error::ErrDataChannelNotExisted)?
                     .data_channel
                     .as_mut()
@@ -347,6 +466,9 @@ impl<'a>
         let now = evt.now;
         match evt.event {
             RTCEventInternal::SCTPHandshakeComplete(association_handle) => {
+                // Assign stream ids before dialing (W3C section 6.1.1.3).
+                self.assign_pending_ids(now);
+
                 // Out-of-band negotiated channels have no DCEP handshake, so they are
                 // open immediately and fire the open event here. In-band channels stay
                 // connecting until their `DATA_CHANNEL_ACK` arrives in `handle_read`.
@@ -358,10 +480,14 @@ impl<'a>
                     if data_channel_internal.ready_state == RTCDataChannelState::Connecting
                         && data_channel_internal.data_channel.is_none()
                     {
+                        // A channel can only be dialed once its stream id is assigned.
+                        let _stream_id = data_channel_internal
+                            .stream_id
+                            .ok_or(Error::ErrDataChannelNotExisted)?;
                         data_channel_internal.dial(association_handle)?;
 
                         if data_channel_internal.negotiated {
-                            opened.push(data_channel_internal.id);
+                            opened.push(data_channel_internal.handle);
                         } else {
                             // In-band channels have a DCEP handshake to complete; arm a
                             // deadline so a lost ACK cannot leave them Connecting forever.
@@ -387,13 +513,15 @@ impl<'a>
                     }
                 }
 
-                for id in opened {
-                    self.emit_data_channel_opened(now, TransportContext::default(), id)?;
+                for handle in opened {
+                    self.emit_data_channel_opened(now, TransportContext::default(), handle)?;
                 }
             }
 
             RTCEventInternal::SCTPStreamClosed(_association_handle, stream_id) => {
-                if let Some(dc) = self.data_channels.remove(&stream_id) {
+                if let Some(handle) = self.data_channel_ids.remove(&stream_id)
+                    && let Some(dc) = self.data_channels.remove(&handle)
+                {
                     // A channel already closed by handshake timeout has already fired OnClose
                     // and been counted; do not emit or count it twice.
                     if !dc.close_emitted {
@@ -419,7 +547,9 @@ impl<'a>
                 // Pure accounting: SCTP released (acked or abandoned) `n_bytes` of
                 // this channel's outgoing buffer. Decrement the synchronous send
                 // back-pressure counter; do NOT forward the event further.
-                if let Some(dc) = self.data_channels.get_mut(&stream_id) {
+                if let Some(handle) = self.data_channel_ids.get(&stream_id).copied()
+                    && let Some(dc) = self.data_channels.get_mut(&handle)
+                {
                     dc.outstanding_bytes = dc.outstanding_bytes.saturating_sub(n_bytes);
                 }
             }
@@ -448,12 +578,13 @@ impl<'a>
                 && dc.ready_state == RTCDataChannelState::Connecting
                 && deadline <= now
             {
-                timed_out.push(dc.id);
+                timed_out.push(dc.handle);
             }
         }
 
-        for id in timed_out {
-            if let Some(dc) = self.data_channels.get_mut(&id) {
+        for handle in timed_out {
+            if let Some(dc) = self.data_channels.get_mut(&handle) {
+                let stream_id = dc.stream_id;
                 dc.handshake_deadline = None;
                 dc.ready_state = RTCDataChannelState::Closed;
                 if let Some(data_channel) = dc.data_channel.as_mut() {
@@ -461,15 +592,19 @@ impl<'a>
                 }
 
                 self.stats.peer_connection.on_data_channel_closed();
-                self.stats
-                    .get_or_create_data_channel(id, &dc.label, &dc.protocol)
-                    .on_state_changed(RTCDataChannelState::Closed);
+                if let Some(stream_id) = stream_id {
+                    self.stats
+                        .get_or_create_data_channel(stream_id, &dc.label, &dc.protocol)
+                        .on_state_changed(RTCDataChannelState::Closed);
+                }
 
                 dc.close_emitted = true;
                 self.ctx.event_outs.push_back(TaggedRTCEventInternal {
                     now,
                     event: RTCEventInternal::RTCPeerConnectionEvent(
-                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(id)),
+                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(
+                            stream_id.unwrap_or(0),
+                        )),
                     ),
                 });
             }
@@ -498,7 +633,8 @@ impl<'a>
 
 #[cfg(test)]
 mod tests {
-    //! Timing contract for the DCEP handshake-complete signal.
+    //! Timing contract for the DCEP handshake-complete signal and for the connected-procedure
+    //! id assignment.
     //!
     //! These drive `DataChannelHandler` directly and pin
     //! *when* the open event fires and `ready_state` flips, which the integration
@@ -515,9 +651,65 @@ mod tests {
     use sansio::Protocol;
     use shared::marshal::Marshal;
 
-    fn in_band_channel(id: u16) -> RTCDataChannelInternal {
-        RTCDataChannelInternal::new(
-            id,
+    /// Test harness, mimicking the `RTCPeerConnection`-owned fields that `DataChannelHandler`
+    /// borrows. `handler()` returns a short-lived `DataChannelHandler` borrowing the harness.
+    struct Harness {
+        ctx: DataChannelHandlerContext,
+        data_channels: HashMap<RTCDataChannelHandle, RTCDataChannelInternal>,
+        pending: Vec<RTCDataChannelHandle>,
+        ids: HashMap<RTCDataChannelId, RTCDataChannelHandle>,
+        allocator: usize,
+        stats: RTCStatsAccumulator,
+        dtls_role: RTCDtlsRole,
+        max_channels: Option<u16>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let now = Instant::now();
+            Self {
+                ctx: DataChannelHandlerContext::new(now),
+                data_channels: HashMap::new(),
+                pending: Vec::new(),
+                ids: HashMap::new(),
+                allocator: 100,
+                stats: RTCStatsAccumulator::new(),
+                dtls_role: RTCDtlsRole::Client,
+                max_channels: None,
+            }
+        }
+
+        fn add(&mut self, handle: usize, stream_id: u16) {
+            assert!(
+                self.data_channels
+                    .insert(
+                        RTCDataChannelHandle::new(handle),
+                        in_band_channel(handle, stream_id),
+                    )
+                    .is_none()
+            );
+            self.ids
+                .insert(stream_id, RTCDataChannelHandle::new(handle));
+        }
+
+        fn handler(&mut self, timeout: Option<Duration>) -> DataChannelHandler<'_> {
+            DataChannelHandler::new(
+                &mut self.ctx,
+                &mut self.data_channels,
+                &mut self.pending,
+                &mut self.ids,
+                &mut self.allocator,
+                &mut self.stats,
+                timeout,
+                self.dtls_role,
+                self.max_channels,
+            )
+        }
+    }
+
+    fn in_band_channel(handle: usize, stream_id: u16) -> RTCDataChannelInternal {
+        let mut dc = RTCDataChannelInternal::new(
+            RTCDataChannelHandle::new(handle),
             DataChannelParameters {
                 label: "timing-test".to_string(),
                 protocol: String::new(),
@@ -526,21 +718,25 @@ mod tests {
                 max_retransmits: None,
                 negotiated: None,
             },
-        )
+        );
+        dc.stream_id = Some(stream_id);
+        dc
     }
 
-    fn negotiated_channel(id: u16) -> RTCDataChannelInternal {
-        RTCDataChannelInternal::new(
-            id,
+    fn negotiated_channel(handle: usize, stream_id: u16) -> RTCDataChannelInternal {
+        let mut dc = RTCDataChannelInternal::new(
+            RTCDataChannelHandle::new(handle),
             DataChannelParameters {
                 label: "timing-test".to_string(),
                 protocol: String::new(),
                 ordered: true,
                 max_packet_life_time: None,
                 max_retransmits: None,
-                negotiated: Some(id),
+                negotiated: Some(stream_id),
             },
-        )
+        );
+        dc.stream_id = Some(stream_id);
+        dc
     }
 
     fn ack(association_handle: usize, stream_id: u16) -> DataChannelMessage {
@@ -578,21 +774,33 @@ mod tests {
             .collect()
     }
 
+    /// The open events emitted so far, as stream ids (the public-facing identity).
+    fn open_ids(ctx: &DataChannelHandlerContext) -> Vec<RTCDataChannelId> {
+        ctx.read_outs
+            .iter()
+            .filter_map(|m| match &m.message {
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
+                    if matches!(app.data_channel_event, DataChannelEvent::Open) =>
+                {
+                    Some(app.data_channel_id)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     /// An in-band channel is dialed at `SCTPHandshakeComplete` but stays
     /// `Connecting` with no open event; the open event fires exactly once, and
     /// `ready_state` flips to `Open`, only when the peer's `DATA_CHANNEL_ACK`
     /// is processed.
     #[test]
     fn in_band_channel_fires_open_only_when_ack_is_processed() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.add(1, 1);
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -601,7 +809,7 @@ mod tests {
                 .unwrap();
         }
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = h.data_channels.get(&RTCDataChannelHandle::new(1)).unwrap();
         assert!(
             dc.data_channel.is_some(),
             "SCTPHandshakeComplete must dial the in-band channel"
@@ -612,7 +820,7 @@ mod tests {
             "an in-band channel must stay Connecting after the SCTP handshake"
         );
         assert!(
-            ctx.read_outs.iter().all(|m| !matches!(
+            h.ctx.read_outs.iter().all(|m| !matches!(
                 &m.message,
                 RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
                     if matches!(app.data_channel_event, DataChannelEvent::Open)
@@ -621,8 +829,7 @@ mod tests {
         );
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -633,30 +840,21 @@ mod tests {
         }
 
         assert_eq!(
-            data_channels.get(&1).unwrap().ready_state,
+            h.data_channels
+                .get(&RTCDataChannelHandle::new(1))
+                .unwrap()
+                .ready_state,
             RTCDataChannelState::Open,
             "ready_state flips to Open exactly when the ACK is processed"
         );
 
-        let open_events: Vec<u16> = ctx
-            .read_outs
-            .iter()
-            .filter_map(|m| match &m.message {
-                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
-                    if matches!(app.data_channel_event, DataChannelEvent::Open) =>
-                {
-                    Some(app.data_channel_id)
-                }
-                _ => None,
-            })
-            .collect();
         assert_eq!(
-            open_events,
+            open_ids(&h.ctx),
             vec![1],
             "exactly one open event, fired on the ACK"
         );
         assert_eq!(
-            stats.peer_connection.data_channels_opened, 1,
+            h.stats.peer_connection.data_channels_opened, 1,
             "open stats recorded exactly once"
         );
     }
@@ -665,13 +863,13 @@ mod tests {
     /// immediately and fires the open event at `SCTPHandshakeComplete`.
     #[test]
     fn negotiated_channel_fires_open_at_handshake_complete() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, negotiated_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.data_channels
+            .insert(RTCDataChannelHandle::new(1), negotiated_channel(1, 1));
+        h.ids.insert(1, RTCDataChannelHandle::new(1));
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = h.handler(None);
         handler
             .handle_event(TaggedRTCEventInternal {
                 now,
@@ -679,7 +877,7 @@ mod tests {
             })
             .unwrap();
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = h.data_channels.get(&RTCDataChannelHandle::new(1)).unwrap();
         assert_eq!(
             dc.ready_state,
             RTCDataChannelState::Open,
@@ -690,25 +888,13 @@ mod tests {
             "a negotiated channel has no DCEP handshake deadline"
         );
 
-        let open_events: Vec<u16> = ctx
-            .read_outs
-            .iter()
-            .filter_map(|m| match &m.message {
-                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app))
-                    if matches!(app.data_channel_event, DataChannelEvent::Open) =>
-                {
-                    Some(app.data_channel_id)
-                }
-                _ => None,
-            })
-            .collect();
         assert_eq!(
-            open_events,
+            open_ids(&h.ctx),
             vec![1],
             "exactly one open event at SCTPHandshakeComplete for a negotiated channel"
         );
         assert_eq!(
-            stats.peer_connection.data_channels_opened, 1,
+            h.stats.peer_connection.data_channels_opened, 1,
             "open stats recorded for the negotiated channel"
         );
     }
@@ -716,14 +902,16 @@ mod tests {
     /// `emit_data_channel_opened` returns an error when the channel does not exist.
     #[test]
     fn emit_data_channel_opened_missing_channel_returns_error() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        let mut stats = RTCStatsAccumulator::new();
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = h.handler(None);
         let err = handler
-            .emit_data_channel_opened(now, TransportContext::default(), 99)
+            .emit_data_channel_opened(
+                now,
+                TransportContext::default(),
+                RTCDataChannelHandle::new(99),
+            )
             .unwrap_err();
         assert_eq!(err, Error::ErrDataChannelNotExisted);
     }
@@ -733,16 +921,13 @@ mod tests {
     /// `data_channel.is_none()` guard is what excludes it.
     #[test]
     fn sctp_handshake_complete_does_not_redial() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.add(1, 1);
 
         // Fire SCTPHandshakeComplete once; this dials the channel and queues its OPEN.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -750,17 +935,16 @@ mod tests {
                 })
                 .unwrap();
         }
-        let first_writes = ctx.write_outs.len();
+        let first_writes = h.ctx.write_outs.len();
         assert!(
             first_writes >= 1,
             "dialing must queue the DATA_CHANNEL_OPEN"
         );
-        ctx.write_outs.clear();
+        h.ctx.write_outs.clear();
 
         // Fire it again: no new dial, so nothing new is queued.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -769,7 +953,7 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(
-            ctx.write_outs.len(),
+            h.ctx.write_outs.len(),
             0,
             "a second SCTPHandshakeComplete must not re-dial the channel"
         );
@@ -779,15 +963,14 @@ mod tests {
     /// must be ignored: it must not flip state or emit an open event.
     #[test]
     fn ack_on_closed_channel_is_ignored() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        let mut dc = in_band_channel(1);
+        let mut dc = in_band_channel(1, 1);
         dc.ready_state = RTCDataChannelState::Closed;
-        data_channels.insert(1, dc);
-        let mut stats = RTCStatsAccumulator::new();
+        h.data_channels.insert(RTCDataChannelHandle::new(1), dc);
+        h.ids.insert(1, RTCDataChannelHandle::new(1));
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = h.handler(None);
         handler
             .handle_read(TaggedRTCMessageInternal {
                 now,
@@ -797,12 +980,15 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            data_channels.get(&1).unwrap().ready_state,
+            h.data_channels
+                .get(&RTCDataChannelHandle::new(1))
+                .unwrap()
+                .ready_state,
             RTCDataChannelState::Closed,
             "a closed channel must ignore a late ACK"
         );
         assert!(
-            !message_events(&ctx)
+            !message_events(&h.ctx)
                 .iter()
                 .any(|e| matches!(e, DataChannelEvent::Open)),
             "no open event may fire for a closed channel"
@@ -813,17 +999,14 @@ mod tests {
     /// to Closed, fires OnClose and is counted exactly once (closed without opened).
     #[test]
     fn in_band_channel_times_out_without_ack() {
+        let mut h = Harness::new();
         let now = Instant::now();
         let timeout = Duration::from_millis(100);
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.add(1, 1);
 
         // Dial the in-band channel and arm a deadline.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -834,8 +1017,7 @@ mod tests {
 
         // A deadline must be reported.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             let deadline = handler
                 .poll_timeout()
                 .expect("a dialed in-band channel must have a deadline");
@@ -845,12 +1027,11 @@ mod tests {
         // Advance past the deadline and let handle_timeout fire.
         let later = now + timeout + Duration::from_secs(1);
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             handler.handle_timeout(later).unwrap();
         }
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = h.data_channels.get(&RTCDataChannelHandle::new(1)).unwrap();
         assert_eq!(
             dc.ready_state,
             RTCDataChannelState::Closed,
@@ -861,13 +1042,14 @@ mod tests {
             "timeout must clear the deadline"
         );
         assert!(
-            !message_events(&ctx)
+            !message_events(&h.ctx)
                 .iter()
                 .any(|e| matches!(e, DataChannelEvent::Open)),
             "no open event for a timed-out channel"
         );
 
-        let closes = ctx
+        let closes = h
+            .ctx
             .event_outs
             .iter()
             .filter(|e| {
@@ -881,13 +1063,12 @@ mod tests {
             .count();
         assert_eq!(closes, 1, "exactly one OnClose for the timed-out channel");
 
-        assert_eq!(stats.peer_connection.data_channels_opened, 0);
-        assert_eq!(stats.peer_connection.data_channels_closed, 1);
+        assert_eq!(h.stats.peer_connection.data_channels_opened, 0);
+        assert_eq!(h.stats.peer_connection.data_channels_closed, 1);
 
         // No further deadlines remain.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             assert!(
                 handler.poll_timeout().is_none(),
                 "no deadline after the timeout fired"
@@ -899,16 +1080,13 @@ mod tests {
     /// after the channel opens, with the open event first.
     #[test]
     fn pre_open_data_is_buffered_until_open() {
+        let mut h = Harness::new();
         let now = Instant::now();
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.add(1, 1);
 
         // Dial first.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -919,8 +1097,7 @@ mod tests {
 
         // A user data message arrives while the channel is still Connecting.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -934,7 +1111,7 @@ mod tests {
 
         // No message event yet.
         assert!(
-            !message_events(&ctx)
+            !message_events(&h.ctx)
                 .iter()
                 .any(|e| matches!(e, DataChannelEvent::Message(_))),
             "no message may be delivered before the channel is open"
@@ -943,8 +1120,7 @@ mod tests {
         // The ACK arrives: the channel opens and the buffered message is delivered,
         // with the open event first.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = h.handler(None);
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -954,7 +1130,7 @@ mod tests {
                 .unwrap();
         }
 
-        let events = message_events(&ctx);
+        let events = message_events(&h.ctx);
         assert!(
             matches!(events.first(), Some(DataChannelEvent::Open)),
             "open event must fire first"
@@ -969,16 +1145,13 @@ mod tests {
     /// out: it must never be delivered to the application.
     #[test]
     fn pre_open_data_is_dropped_on_timeout() {
+        let mut h = Harness::new();
         let now = Instant::now();
         let timeout = Duration::from_millis(100);
-        let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
-        let mut stats = RTCStatsAccumulator::new();
+        h.add(1, 1);
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -989,8 +1162,7 @@ mod tests {
 
         // Buffer a user message while Connecting.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -1005,16 +1177,287 @@ mod tests {
         // Time out; the channel closes and the buffered message must not be delivered.
         let later = now + timeout + Duration::from_secs(1);
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = h.handler(Some(timeout));
             handler.handle_timeout(later).unwrap();
         }
 
         assert!(
-            !message_events(&ctx)
+            !message_events(&h.ctx)
                 .iter()
                 .any(|e| matches!(e, DataChannelEvent::Message(_))),
             "a buffered message must never be delivered after the timeout"
+        );
+    }
+
+    /// Pending (pre-connection) local channels are assigned ids in creation order at the
+    /// connected procedure, using the resolved DTLS role's parity, and channels that cannot be
+    /// assigned an id (the negotiated max channel count is exhausted) are closed.
+    ///
+    /// The stream cap is a count of streams, so `max = 4` admits ids `0..3`; server parity (odd)
+    /// admits `1` and `3`, exercising the top usable id (`max - 1 = 3`).
+    #[test]
+    fn assign_pending_ids_respects_max_channels_and_closes_overflow() {
+        let mut h = Harness::new();
+        h.dtls_role = RTCDtlsRole::Server;
+        h.max_channels = Some(4);
+
+        // Three in-band channels created while the DTLS role was still Auto: no stream id yet.
+        let first = RTCDataChannelHandle::new(1);
+        let second = RTCDataChannelHandle::new(2);
+        let third = RTCDataChannelHandle::new(3);
+        for handle in [first, second, third] {
+            h.data_channels.insert(
+                handle,
+                RTCDataChannelInternal::new(
+                    handle,
+                    DataChannelParameters {
+                        label: "deferred".to_string(),
+                        protocol: String::new(),
+                        ordered: true,
+                        max_packet_life_time: None,
+                        max_retransmits: None,
+                        negotiated: None,
+                    },
+                ),
+            );
+        }
+        h.pending = vec![first, second, third];
+
+        let now = Instant::now();
+        {
+            let mut handler = h.handler(None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        // Server parity (odd) with a cap of 4 streams admits two ids: 1 and 3. The first two
+        // pending channels get them; the third has no id left and is closed and removed.
+        assert_eq!(
+            h.data_channels.get(&first).unwrap().stream_id,
+            Some(1),
+            "the first pending channel gets the server-parity id 1"
+        );
+        assert_eq!(
+            h.data_channels.get(&second).unwrap().stream_id,
+            Some(3),
+            "the second pending channel gets the top server-parity id 3 (max - 1)"
+        );
+        assert!(
+            h.data_channels.get(&third).is_none(),
+            "the third pending channel is closed when the id space is exhausted"
+        );
+        assert!(h.pending.is_empty(), "pending handles are consumed");
+        assert_eq!(
+            h.ids.get(&1),
+            Some(&first),
+            "the first assigned id is registered in the reverse map"
+        );
+        assert_eq!(
+            h.ids.get(&3),
+            Some(&second),
+            "the top assigned id is registered in the reverse map"
+        );
+    }
+
+    /// Two pending channels must never be handed the same stream id, even when both share the
+    /// role's parity: the first reserves its id and the second takes the next free one.
+    #[test]
+    fn assign_pending_ids_assigns_distinct_ids_across_a_batch() {
+        let mut h = Harness::new();
+        h.dtls_role = RTCDtlsRole::Client;
+        h.max_channels = Some(8);
+
+        let first = RTCDataChannelHandle::new(1);
+        let second = RTCDataChannelHandle::new(2);
+        for handle in [first, second] {
+            h.data_channels.insert(
+                handle,
+                RTCDataChannelInternal::new(
+                    handle,
+                    DataChannelParameters {
+                        label: "deferred".to_string(),
+                        protocol: String::new(),
+                        ordered: true,
+                        max_packet_life_time: None,
+                        max_retransmits: None,
+                        negotiated: None,
+                    },
+                ),
+            );
+        }
+        h.pending = vec![first, second];
+
+        let now = Instant::now();
+        {
+            let mut handler = h.handler(None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        let first_id = h.data_channels.get(&first).unwrap().stream_id;
+        let second_id = h.data_channels.get(&second).unwrap().stream_id;
+        assert_eq!(first_id, Some(0), "client parity starts at even id 0");
+        assert_eq!(
+            second_id,
+            Some(2),
+            "the second pending channel gets the next even id"
+        );
+        assert_ne!(
+            first_id, second_id,
+            "two pending channels must not share a stream id"
+        );
+    }
+
+    /// Closed pending channels do not consume a stream id.
+    #[test]
+    fn closed_pending_channel_skipped_by_assign_pending_ids() {
+        let mut h = Harness::new();
+        h.dtls_role = RTCDtlsRole::Client;
+        let closed = RTCDataChannelHandle::new(1);
+        let live = RTCDataChannelHandle::new(2);
+        for handle in [closed, live] {
+            h.data_channels.insert(
+                handle,
+                RTCDataChannelInternal::new(
+                    handle,
+                    DataChannelParameters {
+                        label: "deferred".to_string(),
+                        protocol: String::new(),
+                        ordered: true,
+                        max_packet_life_time: None,
+                        max_retransmits: None,
+                        negotiated: None,
+                    },
+                ),
+            );
+        }
+        // Close the first channel before SCTPHandshakeComplete.
+        h.data_channels.get_mut(&closed).unwrap().close().unwrap();
+        assert_eq!(
+            h.data_channels.get(&closed).unwrap().ready_state,
+            RTCDataChannelState::Closed
+        );
+        h.pending = vec![closed, live];
+
+        let now = Instant::now();
+        {
+            let mut handler = h.handler(None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        assert!(h.pending.is_empty());
+        assert_eq!(h.data_channels.get(&closed).unwrap().stream_id, None);
+        assert_eq!(h.data_channels.get(&live).unwrap().stream_id, Some(0));
+        assert!(!h.ids.values().any(|handle| *handle == closed));
+        assert_eq!(h.ids.get(&0), Some(&live));
+    }
+
+    /// An id-exhausted pending channel is closed and the application receives OnError then OnClose.
+    #[test]
+    fn assign_pending_ids_overflow_fires_error_and_close() {
+        let mut h = Harness::new();
+        h.dtls_role = RTCDtlsRole::Client;
+        // A cap of 2 streams admits one client-parity id (0); the second channel overflows.
+        h.max_channels = Some(2);
+
+        let first = RTCDataChannelHandle::new(1);
+        let second = RTCDataChannelHandle::new(2);
+        for handle in [first, second] {
+            h.data_channels.insert(
+                handle,
+                RTCDataChannelInternal::new(
+                    handle,
+                    DataChannelParameters {
+                        label: "overflow".to_string(),
+                        protocol: String::new(),
+                        ordered: true,
+                        max_packet_life_time: None,
+                        max_retransmits: None,
+                        negotiated: None,
+                    },
+                ),
+            );
+        }
+        h.pending = vec![first, second];
+
+        let now = Instant::now();
+        {
+            let mut handler = h.handler(None);
+            handler
+                .handle_event(TaggedRTCEventInternal {
+                    now,
+                    event: RTCEventInternal::SCTPHandshakeComplete(0),
+                })
+                .unwrap();
+        }
+
+        assert_eq!(h.data_channels.get(&first).unwrap().stream_id, Some(0));
+        assert!(h.data_channels.get(&second).is_none());
+
+        let errors = h
+            .ctx
+            .event_outs
+            .iter()
+            .filter(|e| {
+                matches!(
+                    &e.event,
+                    RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(
+                            RTCDataChannelEvent::OnErrorByHandle(_)
+                        )
+                    )
+                )
+            })
+            .count();
+        let closes = h
+            .ctx
+            .event_outs
+            .iter()
+            .filter(|e| {
+                matches!(
+                    &e.event,
+                    RTCEventInternal::RTCPeerConnectionEvent(
+                        RTCPeerConnectionEvent::OnDataChannel(
+                            RTCDataChannelEvent::OnCloseByHandle(_)
+                        )
+                    )
+                )
+            })
+            .count();
+        assert_eq!(errors, 1);
+        assert_eq!(closes, 1);
+
+        // OnErrorByHandle must precede OnCloseByHandle (section 6.2.7).
+        let events: Vec<_> = h
+            .ctx
+            .event_outs
+            .iter()
+            .filter_map(|e| match &e.event {
+                RTCEventInternal::RTCPeerConnectionEvent(
+                    RTCPeerConnectionEvent::OnDataChannel(dc_event),
+                ) => Some(dc_event.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            matches!(
+                events.first(),
+                Some(RTCDataChannelEvent::OnErrorByHandle(_))
+            ),
+            "OnErrorByHandle must precede OnCloseByHandle"
         );
     }
 }

--- a/src/peer_connection/handler/mod.rs
+++ b/src/peer_connection/handler/mod.rs
@@ -196,11 +196,18 @@ impl RTCPeerConnection {
     }
 
     pub(crate) fn get_datachannel_handler(&mut self) -> DataChannelHandler<'_> {
+        let dtls_role = self.dtls_transport().role();
+        let max_channels = self.sctp_transport().max_channels();
         DataChannelHandler::new(
             &mut self.pipeline_context.datachannel_handler_context,
             &mut self.data_channels,
+            &mut self.pending_data_channel_handles,
+            &mut self.data_channel_ids,
+            &mut self.data_channel_handle_allocator,
             &mut self.pipeline_context.stats,
             self.setting_engine.data_channel.dcep_handshake_timeout,
+            dtls_role,
+            max_channels,
         )
     }
 

--- a/src/peer_connection/handler/mod.rs
+++ b/src/peer_connection/handler/mod.rs
@@ -235,6 +235,7 @@ impl sansio::Protocol<TaggedBytesMut, TaggedRTCMessage, TaggedRTCEvent> for RTCP
     type Time = Instant;
 
     fn handle_read(&mut self, msg: TaggedBytesMut) -> Result<(), Self::Error> {
+        self.observe(msg.now);
         let mut intermediate_routs = VecDeque::new();
         intermediate_routs.push_back(TaggedRTCMessageInternal {
             now: msg.now,
@@ -321,6 +322,7 @@ impl sansio::Protocol<TaggedBytesMut, TaggedRTCMessage, TaggedRTCEvent> for RTCP
     }
 
     fn handle_write(&mut self, msg: TaggedRTCMessage) -> Result<(), Self::Error> {
+        self.observe(msg.now);
         let now = msg.now;
         let rtc_message_internal = match msg.message {
             RTCMessage::DataChannelMessage(data_channel_id, data_channel_message) => {
@@ -418,6 +420,7 @@ impl sansio::Protocol<TaggedBytesMut, TaggedRTCMessage, TaggedRTCEvent> for RTCP
     }
 
     fn handle_timeout(&mut self, now: Instant) -> Result<(), Self::Error> {
+        self.observe(now);
         for_each_handler!(forward: process_handler!(self, handler, {
             handler.handle_timeout(now)?;
         }));

--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -188,6 +188,7 @@ impl RTCPeerConnection {
             pipeline_context,
             data_channels: HashMap::new(),
             rtp_transceivers: Vec::new(),
+            now,
             greater_mid: -1,
             sdp_origin: Origin::default(),
             last_offer: String::new(),

--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -187,6 +187,9 @@ impl RTCPeerConnection {
             can_trickle_ice_candidates: None,
             pipeline_context,
             data_channels: HashMap::new(),
+            data_channel_handle_allocator: 0,
+            pending_data_channel_handles: Vec::new(),
+            data_channel_ids: HashMap::new(),
             rtp_transceivers: Vec::new(),
             now,
             greater_mid: -1,
@@ -992,23 +995,29 @@ impl RTCPeerConnection {
         );
     }
 
-    pub(crate) fn generate_data_channel_id(&self) -> Result<RTCDataChannelId> {
+    pub(crate) fn generate_data_channel_id(&self, role: RTCDtlsRole) -> Result<RTCDataChannelId> {
         let mut id = 0u16;
-        if self.dtls_transport().role() != RTCDtlsRole::Client {
+        if role == RTCDtlsRole::Server {
             id += 1;
         }
 
-        // Create map of ids so we can compare without double-looping each time.
-        let ids: HashSet<RTCDataChannelId> = self.data_channels.keys().cloned().collect();
+        // Create map of ids so we can compare without double-looping each time. The reverse map
+        // (`data_channel_ids`) holds every assigned stream id (negotiated channels, accepted
+        // remote channels, and locally-created channels assigned on the connected procedure),
+        // while pending local channels have no id yet and cannot collide.
+        let ids: HashSet<RTCDataChannelId> = self.data_channel_ids.keys().copied().collect();
         // The negotiated stream count bounds data channel ids, but only once it is known: a
         // channel may be created before the association exists, and until it connects there is
         // nothing to bound against. This matches W3C §6.1.1.3, which applies the limit at the
         // connected procedure rather than at creation.
+        // `max` is a count of SCTP streams (`RTCSctpTransport.maxChannels`), so valid stream ids
+        // span `0..max` and the highest usable id is `max - 1`. See `assign_pending_ids` for the
+        // connected-procedure counterpart.
         let max = self
             .sctp_transport()
             .max_channels()
             .unwrap_or(SCTP_MAX_CHANNELS);
-        while id < max.saturating_sub(1) {
+        while id < max {
             if ids.contains(&id) {
                 id += 2;
             } else {

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -690,6 +690,14 @@ pub struct RTCPeerConnection {
     pub(crate) data_channels: HashMap<RTCDataChannelId, RTCDataChannelInternal>,
     pub(super) rtp_transceivers: Vec<RTCRtpTransceiverInternal>,
 
+    /// The newest instant a caller has supplied, seeded at construction.
+    ///
+    /// Synchronous sans-I/O methods - `poll_*`, `close`, `create_data_channel` - have no
+    /// `now` parameter, so when one needs the time it uses the instant retained from the last
+    /// `handle_*`. Refreshed by `observe()` from every inbound instant; see the design's
+    /// section 9.3 for why there is no monotonicity assert alongside the `max`.
+    now: Instant,
+
     greater_mid: isize,
     sdp_origin: Origin,
     last_offer: String,
@@ -701,6 +709,12 @@ pub struct RTCPeerConnection {
 }
 
 impl RTCPeerConnection {
+    /// Records the newest instant a caller has supplied, for the synchronous methods that
+    /// have no `now` parameter. See the `now` field's comment and the design's section 9.3.
+    fn observe(&mut self, now: Instant) {
+        self.now = now.max(self.now);
+    }
+
     /// Creates an SDP offer to start a new WebRTC connection to a remote peer.
     ///
     /// The offer includes information about the attached media tracks, codecs and options supported
@@ -1892,6 +1906,19 @@ impl RTCPeerConnection {
             && data_channel.data_channel.is_none()
         {
             data_channel.dial(handle.0)?;
+            // Set the DCEP handshake deadline, exactly as the SCTPHandshakeComplete handler
+            // does for channels dialed during the initial connection: a lost
+            // DATA_CHANNEL_ACK must not leave a channel dialed here Connecting forever.
+            // Negotiated channels have no DCEP handshake and get no deadline.
+            // `create_data_channel` is a synchronous sans-I/O method with no `now` parameter,
+            // so the retained instant (the last one a `handle_*` supplied) anchors the timeout.
+            if !data_channel.negotiated {
+                data_channel.handshake_deadline = self
+                    .setting_engine
+                    .data_channel
+                    .dcep_handshake_timeout
+                    .map(|timeout| self.now + timeout);
+            }
         }
 
         self.data_channels.insert(id, data_channel);
@@ -2628,6 +2655,31 @@ mod tests {
             RTCDataChannelState::Connecting,
             "a dialed in-band channel stays Connecting until its DATA_CHANNEL_ACK arrives"
         );
+    }
+
+    /// In-band channels dialed after SCTP connects set the DCEP handshake deadline.
+    #[test]
+    fn post_sctp_in_band_channel_sets_handshake_deadline() {
+        let mut pc = RTCPeerConnectionBuilder::new()
+            .build(Instant::now())
+            .unwrap();
+
+        // Simulate an existing SCTP association (post-connection), so the channel is dialed
+        // immediately rather than at SCTPHandshakeComplete.
+        pc.sctp_transport_mut()
+            .sctp_associations
+            .insert(AssociationHandle(0), sctp::Association::default());
+
+        let _dc = pc.create_data_channel("test", None).unwrap();
+
+        let internal = pc
+            .data_channels
+            .values()
+            .next()
+            .expect("data channel must be stored internally");
+        assert!(internal.data_channel.is_some());
+        assert!(internal.handshake_deadline.is_some());
+        assert_eq!(internal.ready_state, RTCDataChannelState::Connecting);
     }
 
     // ---- Rollback (RFC 8829, Section 5.7) ----

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -1891,6 +1891,9 @@ impl RTCPeerConnection {
         params.negotiated = options.negotiated;
 
         if let Some(negotiated_id) = &params.negotiated {
+            if self.data_channels.contains_key(negotiated_id) {
+                return Err(Error::ErrOperationError);
+            }
             id = *negotiated_id;
         }
 
@@ -2741,6 +2744,36 @@ mod tests {
             vec![7],
             "post-SCTP negotiated channel must emit OnOpen(7)"
         );
+    }
+
+    /// A negotiated stream id already in use is rejected with ErrOperationError.
+    #[test]
+    fn negotiated_id_collision_returns_operation_error() {
+        let mut pc = RTCPeerConnectionBuilder::new()
+            .build(Instant::now())
+            .unwrap();
+
+        // An SCTP association is required so the in-band channel is dialed (and registered)
+        // at creation. While the DTLS role is still Auto, parity is server-side (odd), so the
+        // in-band channel gets id 1.
+        pc.sctp_transport_mut()
+            .sctp_associations
+            .insert(AssociationHandle(0), sctp::Association::default());
+
+        let in_band = pc.create_data_channel("in-band", None).unwrap();
+        assert_eq!(in_band.id(), 1);
+
+        let err = match pc.create_data_channel(
+            "negotiated",
+            Some(RTCDataChannelInit {
+                negotiated: Some(1),
+                ..Default::default()
+            }),
+        ) {
+            Ok(_) => panic!("a negotiated channel must not reuse a live stream id"),
+            Err(err) => err,
+        };
+        assert_eq!(err, Error::ErrOperationError);
     }
 
     // ---- Rollback (RFC 8829, Section 5.7) ----

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -262,7 +262,9 @@ use crate::peer_connection::configuration::{
     RTCConfiguration, RTCIceTransportPolicy,
     offer_answer_options::{RTCAnswerOptions, RTCOfferOptions},
 };
-use crate::peer_connection::event::RTCPeerConnectionEvent;
+use crate::peer_connection::event::{
+    RTCPeerConnectionEvent, data_channel_event::RTCDataChannelEvent,
+};
 use crate::peer_connection::handler::PipelineContext;
 use crate::peer_connection::handler::dtls::DtlsHandlerContext;
 use crate::peer_connection::handler::ice::IceHandlerContext;
@@ -1921,6 +1923,17 @@ impl RTCPeerConnection {
             }
         }
 
+        // A negotiated channel opens immediately; fire the open event here because the
+        // SCTPHandshakeComplete handler runs only at SCTP connect, so it never fires
+        // for a channel dialed after the connection is already up.
+        if data_channel.negotiated && data_channel.ready_state == RTCDataChannelState::Open {
+            self.pipeline_context
+                .event_outs
+                .push_back(RTCPeerConnectionEvent::OnDataChannel(
+                    RTCDataChannelEvent::OnOpen(id),
+                ));
+        }
+
         self.data_channels.insert(id, data_channel);
 
         self.trigger_negotiation_needed();
@@ -2680,6 +2693,54 @@ mod tests {
         assert!(internal.data_channel.is_some());
         assert!(internal.handshake_deadline.is_some());
         assert_eq!(internal.ready_state, RTCDataChannelState::Connecting);
+    }
+
+    /// A negotiated channel created after the SCTP association is up is dialed immediately and
+    /// opens straight away; it must emit `OnOpen`, which the `SCTPHandshakeComplete`
+    /// handler would otherwise supply for negotiated channels dialed during the initial
+    /// connection.
+    #[test]
+    fn negotiated_channel_created_after_sctp_emits_on_open() {
+        let mut pc = RTCPeerConnectionBuilder::new()
+            .build(Instant::now())
+            .unwrap();
+
+        // Simulate an existing SCTP association (post-connection), so the channel is dialed
+        // immediately rather than at SCTPHandshakeComplete.
+        pc.sctp_transport_mut()
+            .sctp_associations
+            .insert(AssociationHandle(0), sctp::Association::default());
+
+        let dc = pc
+            .create_data_channel(
+                "negotiated",
+                Some(RTCDataChannelInit {
+                    ordered: true,
+                    negotiated: Some(7),
+                    ..Default::default()
+                }),
+            )
+            .unwrap();
+
+        // Immediately open, carrying its negotiated id.
+        assert_eq!(dc.ready_state(), RTCDataChannelState::Open);
+        assert_eq!(dc.id(), 7);
+
+        // The OnOpen event must be queued for the application.
+        let opens: Vec<_> = pc
+            .pipeline_context
+            .event_outs
+            .iter()
+            .filter_map(|e| match e {
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            opens,
+            vec![7],
+            "post-SCTP negotiated channel must emit OnOpen(7)"
+        );
     }
 
     // ---- Rollback (RFC 8829, Section 5.7) ----

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -254,7 +254,9 @@ pub mod transport;
 use crate::data_channel::init::RTCDataChannelInit;
 use crate::data_channel::parameters::DataChannelParameters;
 use crate::data_channel::state::RTCDataChannelState;
-use crate::data_channel::{RTCDataChannel, RTCDataChannelId, internal::RTCDataChannelInternal};
+use crate::data_channel::{
+    RTCDataChannel, RTCDataChannelHandle, RTCDataChannelId, internal::RTCDataChannelInternal,
+};
 use crate::media_stream::track::MediaStreamTrack;
 use crate::peer_connection::configuration::media_engine::MediaEngine;
 use crate::peer_connection::configuration::setting_engine::{SctpMaxMessageSize, SettingEngine};
@@ -689,7 +691,15 @@ pub struct RTCPeerConnection {
     // PeerConnection Internal State Machine
     //////////////////////////////////////////////////
     pub(crate) pipeline_context: PipelineContext,
-    pub(crate) data_channels: HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+    pub(crate) data_channels: HashMap<RTCDataChannelHandle, RTCDataChannelInternal>,
+    /// Allocator for `RTCDataChannelHandle` values. Handles are never reused.
+    pub(crate) data_channel_handle_allocator: usize,
+    /// Handles of locally-created channels whose stream id has not yet been assigned (the DTLS
+    /// role has not been resolved / SCTP not connected). Kept in creation order so the connected
+    /// procedure assigns ids in W3C section 6.1.1.3 order.
+    pub(crate) pending_data_channel_handles: Vec<RTCDataChannelHandle>,
+    /// Reverse lookup from stream id to handle for channels that have a stream id.
+    pub(crate) data_channel_ids: HashMap<RTCDataChannelId, RTCDataChannelHandle>,
     pub(super) rtp_transceivers: Vec<RTCRtpTransceiverInternal>,
 
     /// The newest instant a caller has supplied, seeded at construction.
@@ -1856,7 +1866,8 @@ impl RTCPeerConnection {
             ..Default::default()
         };
 
-        let mut id = self.generate_data_channel_id()?;
+        let handle = RTCDataChannelHandle::new(self.data_channel_handle_allocator);
+        self.data_channel_handle_allocator += 1;
 
         // `None` means "the dictionary defaults", which is what `RTCDataChannelInit::default()`
         // spells out. Taking that route rather than leaving `params` on its derived default
@@ -1890,27 +1901,42 @@ impl RTCPeerConnection {
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #12)
         params.negotiated = options.negotiated;
 
-        if let Some(negotiated_id) = &params.negotiated {
-            if self.data_channels.contains_key(negotiated_id) {
-                return Err(Error::ErrOperationError);
-            }
-            id = *negotiated_id;
+        if let Some(stream_id) = params.negotiated
+            && self.data_channel_ids.contains_key(&stream_id)
+        {
+            return Err(Error::ErrOperationError);
         }
 
-        let mut data_channel = RTCDataChannelInternal::new(id, params);
-
-        // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #23)
-        // Open the channel's data transport immediately when an SCTP association already exists.
-        if let Some(handle) = self
+        // W3C section 6.1 createDataChannel, step 18.
+        // Negotiated channels use the provided id. If the SCTP association already exists, the
+        // role is resolved so generate the id now. Otherwise defer to the connected procedure.
+        let sctp_association = self
             .sctp_transport()
             .sctp_associations
             .keys()
             .next()
-            .copied()
+            .copied();
+        let stream_id = if params.negotiated.is_some() {
+            params.negotiated
+        } else if sctp_association.is_some() {
+            Some(self.generate_data_channel_id(self.dtls_transport().role())?)
+        } else {
+            None
+        };
+
+        let mut data_channel = RTCDataChannelInternal::new(handle, params);
+        data_channel.stream_id = stream_id;
+
+        // W3C section 6.1 createDataChannel, step 23.
+        // Open the data transport immediately when an SCTP association already exists.
+        // Negotiated channels open straight away, so emit OnOpen here too.
+        let mut opened_immediately = false;
+        if let Some(association) = sctp_association
+            && stream_id.is_some()
             && data_channel.ready_state == RTCDataChannelState::Connecting
             && data_channel.data_channel.is_none()
         {
-            data_channel.dial(handle.0)?;
+            data_channel.dial(association.0)?;
             // Set the DCEP handshake deadline, exactly as the SCTPHandshakeComplete handler
             // does for channels dialed during the initial connection: a lost
             // DATA_CHANNEL_ACK must not leave a channel dialed here Connecting forever.
@@ -1924,25 +1950,30 @@ impl RTCPeerConnection {
                     .dcep_handshake_timeout
                     .map(|timeout| self.now + timeout);
             }
+            opened_immediately =
+                data_channel.negotiated && data_channel.ready_state == RTCDataChannelState::Open;
         }
 
-        // A negotiated channel opens immediately; fire the open event here because the
-        // SCTPHandshakeComplete handler runs only at SCTP connect, so it never fires
-        // for a channel dialed after the connection is already up.
-        if data_channel.negotiated && data_channel.ready_state == RTCDataChannelState::Open {
+        let opened_id = data_channel.stream_id;
+        self.data_channels.insert(handle, data_channel);
+        if let Some(stream_id) = stream_id {
+            self.data_channel_ids.insert(stream_id, handle);
+        } else {
+            self.pending_data_channel_handles.push(handle);
+        }
+
+        if opened_immediately && let Some(opened_id) = opened_id {
             self.pipeline_context
                 .event_outs
                 .push_back(RTCPeerConnectionEvent::OnDataChannel(
-                    RTCDataChannelEvent::OnOpen(id),
+                    RTCDataChannelEvent::OnOpen(opened_id),
                 ));
         }
-
-        self.data_channels.insert(id, data_channel);
 
         self.trigger_negotiation_needed();
 
         Ok(RTCDataChannel {
-            id,
+            handle,
             peer_connection: self,
         })
     }
@@ -2223,11 +2254,29 @@ impl RTCPeerConnection {
         Ok(self.add_rtp_transceiver(transceiver))
     }
 
-    /// data_channel provides the access to RTCDataChannel object with the given id
+    /// data_channel provides the access to RTCDataChannel object with the given stream id
     pub fn data_channel(&mut self, id: RTCDataChannelId) -> Option<RTCDataChannel<'_>> {
-        if self.data_channels.contains_key(&id) {
+        let handle = self.data_channel_ids.get(&id).copied()?;
+        if self.data_channels.contains_key(&handle) {
             Some(RTCDataChannel {
-                id,
+                handle,
+                peer_connection: self,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Looks up a data channel by its stable handle.
+    ///
+    /// Addresses a channel by `RTCDataChannelHandle`; `data_channel(id)` addresses one by stream id.
+    pub fn data_channel_handle(
+        &mut self,
+        handle: RTCDataChannelHandle,
+    ) -> Option<RTCDataChannel<'_>> {
+        if self.data_channels.contains_key(&handle) {
+            Some(RTCDataChannel {
+                handle,
                 peer_connection: self,
             })
         } else {
@@ -2699,9 +2748,8 @@ mod tests {
     }
 
     /// A negotiated channel created after the SCTP association is up is dialed immediately and
-    /// opens straight away; it must emit `OnOpen`, which the `SCTPHandshakeComplete`
-    /// handler would otherwise supply for negotiated channels dialed during the initial
-    /// connection.
+    /// opens straight away; it must emit `OnOpen`, which the `SCTPHandshakeComplete` handler
+    /// would otherwise supply for negotiated channels dialed during the initial connection.
     #[test]
     fn negotiated_channel_created_after_sctp_emits_on_open() {
         let mut pc = RTCPeerConnectionBuilder::new()
@@ -2725,9 +2773,9 @@ mod tests {
             )
             .unwrap();
 
-        // Immediately open, carrying its negotiated id.
+        // Immediately open, with an id assigned at creation.
         assert_eq!(dc.ready_state(), RTCDataChannelState::Open);
-        assert_eq!(dc.id(), 7);
+        assert_eq!(dc.id(), Some(7));
 
         // The OnOpen event must be queued for the application.
         let opens: Vec<_> = pc
@@ -2753,20 +2801,19 @@ mod tests {
             .build(Instant::now())
             .unwrap();
 
-        // An SCTP association is required so the in-band channel is dialed (and registered)
-        // at creation. While the DTLS role is still Auto, parity is server-side (odd), so the
-        // in-band channel gets id 1.
+        // An SCTP association is required so the in-band channel's id is assigned at creation
+        // (client parity: 0) and registered in the reverse map.
         pc.sctp_transport_mut()
             .sctp_associations
             .insert(AssociationHandle(0), sctp::Association::default());
 
         let in_band = pc.create_data_channel("in-band", None).unwrap();
-        assert_eq!(in_band.id(), 1);
+        assert_eq!(in_band.id(), Some(0));
 
         let err = match pc.create_data_channel(
             "negotiated",
             Some(RTCDataChannelInit {
-                negotiated: Some(1),
+                negotiated: Some(0),
                 ..Default::default()
             }),
         ) {

--- a/tests/data_channel_send_before_open.rs
+++ b/tests/data_channel_send_before_open.rs
@@ -71,10 +71,12 @@ fn send_on_a_closed_channel_reports_closed() -> Result<()> {
     let mut pc = RTCPeerConnectionBuilder::new().build(Instant::now())?;
 
     let mut dc = pc.create_data_channel("probe", Some(RTCDataChannelInit::default()))?;
-    let id = dc.id();
+    let handle = dc.handle();
     dc.close()?;
 
-    let mut dc = pc.data_channel(id).expect("handle survives close");
+    let mut dc = pc
+        .data_channel_handle(handle)
+        .expect("handle survives close");
     assert_ne!(
         dc.send(Instant::now(), BytesMut::from(&b"dropped"[..])),
         Ok(()),

--- a/tests/data_channel_stream_id_deferral.rs
+++ b/tests/data_channel_stream_id_deferral.rs
@@ -1,0 +1,530 @@
+//! Data-channel stream-id deferral: ids are only assigned once the DTLS role is resolved.
+//!
+//! W3C WebRTC section 6.1 step 18 assigns the stream id after the DTLS role has been negotiated, and
+//! section 6.1.1.3 step 4.2 assigns it during the SCTP *connected* procedure. RFC 8832 section 6 then forces
+//! the DTLS client onto even ids and the DTLS server onto odd ones. Creating channels *before*
+//! the answer is applied must yield a null id that later resolves with the correct
+//! role parity, never a guess made while the role is still `Auto`.
+
+use anyhow::Result;
+use bytes::BytesMut;
+use rtc::data_channel::RTCDataChannelId;
+use rtc::data_channel::RTCDataChannelInit;
+use rtc::peer_connection::configuration::RTCConfigurationBuilder;
+use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
+use rtc::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent};
+use rtc::peer_connection::message::{RTCMessage, TaggedRTCMessage};
+use rtc::peer_connection::state::RTCPeerConnectionState;
+use rtc::peer_connection::transport::{
+    CandidateConfig, CandidateHostConfig, RTCDtlsRole, RTCIceCandidate,
+};
+use rtc::peer_connection::{RTCPeerConnection, RTCPeerConnectionBuilder};
+use rtc::sansio::Protocol;
+use rtc::shared::{TaggedBytesMut, TransportContext, TransportProtocol};
+use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
+
+struct Peers {
+    offer_pc: RTCPeerConnection,
+    answer_pc: RTCPeerConnection,
+    offer_socket: UdpSocket,
+    answer_socket: UdpSocket,
+    offer_addr: std::net::SocketAddr,
+    answer_addr: std::net::SocketAddr,
+}
+
+async fn build_peer(
+    role: RTCDtlsRole,
+) -> Result<(RTCPeerConnection, UdpSocket, std::net::SocketAddr)> {
+    let socket = UdpSocket::bind("127.0.0.1:0").await?;
+    let addr = socket.local_addr()?;
+
+    let setting_engine = SettingEngineBuilder::new()
+        .with_answering_dtls_role(role)
+        .build();
+
+    let mut pc = RTCPeerConnectionBuilder::new()
+        .with_configuration(RTCConfigurationBuilder::new().build())
+        .with_setting_engine(setting_engine)
+        .build(Instant::now())?;
+
+    let candidate = CandidateHostConfig {
+        base_config: CandidateConfig {
+            network: "udp".to_owned(),
+            address: addr.ip().to_string(),
+            port: addr.port(),
+            component: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+    .new_candidate_host()?;
+    pc.add_local_candidate(RTCIceCandidate::from(&candidate).to_json()?)?;
+
+    Ok((pc, socket, addr))
+}
+
+async fn connect() -> Result<Peers> {
+    let (offer_pc, offer_socket, offer_addr) = build_peer(RTCDtlsRole::Server).await?;
+    let (answer_pc, answer_socket, answer_addr) = build_peer(RTCDtlsRole::Client).await?;
+    Ok(Peers {
+        offer_pc,
+        answer_pc,
+        offer_socket,
+        answer_socket,
+        offer_addr,
+        answer_addr,
+    })
+}
+
+/// Both peers create an in-band channel while the DTLS role is still `Auto`. Neither may get a
+/// stream id at creation. Each peer also receives the other's DATA_CHANNEL_OPEN as an incoming
+/// channel once SCTP connects, so every side must resolve *both* stream ids (its own dialed
+/// channel and the peer's announcement) to distinct, role-parity-correct values, with the
+/// offerer (DTLS server) on an odd id and the answerer (DTLS client) on an even one. Before the
+/// fix the two peers could hand themselves the *same* id and collide on one SCTP stream.
+#[tokio::test]
+async fn test_deferred_ids_get_role_parity_without_collision() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let mut p = connect().await?;
+
+    // Created before any offer/answer is exchanged: the DTLS role is unresolved.
+    let offer_dc = p.offer_pc.create_data_channel("deferred", None)?;
+    let answer_dc = p.answer_pc.create_data_channel("deferred", None)?;
+    assert_eq!(
+        offer_dc.id(),
+        None,
+        "a channel created while the role is Auto must have a null stream id"
+    );
+    assert_eq!(
+        answer_dc.id(),
+        None,
+        "a channel created while the role is Auto must have a null stream id"
+    );
+    let offer_own_handle = offer_dc.handle();
+    let answer_own_handle = answer_dc.handle();
+    drop(offer_dc);
+    drop(answer_dc);
+
+    let offer = p.offer_pc.create_offer(None)?;
+    p.offer_pc
+        .set_local_description(Instant::now(), offer.clone())?;
+    p.answer_pc.set_remote_description(Instant::now(), offer)?;
+    let answer = p.answer_pc.create_answer(None)?;
+    p.answer_pc
+        .set_local_description(Instant::now(), answer.clone())?;
+    p.offer_pc.set_remote_description(Instant::now(), answer)?;
+
+    let mut offer_connected = false;
+    let mut answer_connected = false;
+    // The open event carries a stream id (the public-facing identity).
+    let mut offer_opens: Vec<RTCDataChannelId> = Vec::new();
+    let mut answer_opens: Vec<RTCDataChannelId> = Vec::new();
+
+    let mut offer_buf = vec![0u8; 2048];
+    let mut answer_buf = vec![0u8; 2048];
+
+    let start = Instant::now();
+    let deadline = Duration::from_secs(15);
+
+    while start.elapsed() < deadline {
+        while let Some(msg) = p.offer_pc.poll_write() {
+            p.offer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+        while let Some(msg) = p.answer_pc.poll_write() {
+            p.answer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+
+        while let Some(event) = p.offer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => offer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(stream_id)) => {
+                    offer_opens.push(stream_id);
+                }
+                _ => {}
+            }
+        }
+        while let Some(event) = p.answer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => answer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(stream_id)) => {
+                    answer_opens.push(stream_id);
+                }
+                _ => {}
+            }
+        }
+        while p.offer_pc.poll_read().is_some() {}
+        while p.answer_pc.poll_read().is_some() {}
+
+        // The open events fire with stream ids; resolve the own channel ids via lookup.
+        let offer_own_ok = p
+            .offer_pc
+            .data_channel_handle(offer_own_handle)
+            .and_then(|dc| dc.id())
+            .map(|id| offer_opens.contains(&id))
+            .unwrap_or(false);
+        let answer_own_ok = p
+            .answer_pc
+            .data_channel_handle(answer_own_handle)
+            .and_then(|dc| dc.id())
+            .map(|id| answer_opens.contains(&id))
+            .unwrap_or(false);
+
+        if offer_connected
+            && answer_connected
+            && offer_own_ok
+            && answer_own_ok
+            && offer_opens.len() >= 2
+            && answer_opens.len() >= 2
+        {
+            break;
+        }
+
+        let next = p
+            .offer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + Duration::from_secs(1))
+            .min(
+                p.answer_pc
+                    .poll_timeout()
+                    .unwrap_or(Instant::now() + Duration::from_secs(1)),
+            );
+        let delay = next
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+        if delay.is_zero() {
+            p.offer_pc.handle_timeout(Instant::now()).ok();
+            p.answer_pc.handle_timeout(Instant::now()).ok();
+            continue;
+        }
+        let sleep = tokio::time::sleep(delay);
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            _ = sleep => {
+                p.offer_pc.handle_timeout(Instant::now()).ok();
+                p.answer_pc.handle_timeout(Instant::now()).ok();
+            }
+            Ok((n, peer_addr)) = p.offer_socket.recv_from(&mut offer_buf) => {
+                p.offer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: p.offer_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&offer_buf[..n]),
+                }).ok();
+            }
+            Ok((n, peer_addr)) = p.answer_socket.recv_from(&mut answer_buf) => {
+                p.answer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: p.answer_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&answer_buf[..n]),
+                }).ok();
+            }
+        }
+    }
+
+    assert!(
+        offer_connected && answer_connected,
+        "peers should connect (offer={offer_connected}, answer={answer_connected})"
+    );
+
+    // The offerer dials its own channel on an odd stream id; the answerer's announcement arrives
+    // there as a distinct incoming channel carrying the answerer's even id.
+    let offer_own_id: RTCDataChannelId = p
+        .offer_pc
+        .data_channel_handle(offer_own_handle)
+        .expect("offerer's own channel must still exist")
+        .id()
+        .expect("offerer's own channel must be assigned an id once connected");
+    let answer_own_id: RTCDataChannelId = p
+        .answer_pc
+        .data_channel_handle(answer_own_handle)
+        .expect("answerer's own channel must still exist")
+        .id()
+        .expect("answerer's own channel must be assigned an id once connected");
+
+    assert_eq!(
+        offer_own_id % 2,
+        1,
+        "the DTLS server must use an odd stream id (got {offer_own_id})"
+    );
+    assert_eq!(
+        answer_own_id % 2,
+        0,
+        "the DTLS client must use an even stream id (got {answer_own_id})"
+    );
+    assert_ne!(
+        offer_own_id, answer_own_id,
+        "the two peers must not collide on a stream id"
+    );
+
+    // The remote announcement on each side must carry the peer's stream id: the offerer sees the
+    // answerer's even id, the answerer sees the offerer's odd id. Each side's dialed and
+    // announced ids must agree.
+    let offer_incoming = offer_opens
+        .iter()
+        .copied()
+        .find(|&id| id != offer_own_id)
+        .expect("the offerer must also open the peer's announcement");
+    let answer_incoming = answer_opens
+        .iter()
+        .copied()
+        .find(|&id| id != answer_own_id)
+        .expect("the answerer must also open the peer's announcement");
+
+    let offer_incoming_id = p
+        .offer_pc
+        .data_channel(offer_incoming)
+        .expect("offerer's incoming channel must still exist")
+        .id()
+        .expect("incoming channels are opened with an assigned id");
+    let answer_incoming_id = p
+        .answer_pc
+        .data_channel(answer_incoming)
+        .expect("answerer's incoming channel must still exist")
+        .id()
+        .expect("incoming channels are opened with an assigned id");
+
+    assert_eq!(
+        offer_incoming_id, answer_own_id,
+        "the offerer's incoming channel carries the answerer's stream id"
+    );
+    assert_eq!(
+        answer_incoming_id, offer_own_id,
+        "the answerer's incoming channel carries the offerer's stream id"
+    );
+
+    p.offer_pc.close()?;
+    p.answer_pc.close()?;
+
+    Ok(())
+}
+
+/// Application data must flow over a channel whose id was deferred and only assigned at the
+/// connected procedure: the offerer dials its (odd) stream, the answerer receives it on the
+/// incoming channel, echoes, and the offerer receives the echo back.
+#[tokio::test]
+async fn test_deferred_channel_actually_exchanges_data() -> Result<()> {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init()
+        .ok();
+
+    let mut p = connect().await?;
+
+    let offer_dc = p.offer_pc.create_data_channel(
+        "data",
+        Some(RTCDataChannelInit {
+            ordered: true,
+            ..Default::default()
+        }),
+    )?;
+    let offer_own_handle = offer_dc.handle();
+    drop(offer_dc);
+    let answer_dc = p.answer_pc.create_data_channel(
+        "data",
+        Some(RTCDataChannelInit {
+            ordered: true,
+            ..Default::default()
+        }),
+    )?;
+    let answer_own_handle = answer_dc.handle();
+    drop(answer_dc);
+
+    let offer = p.offer_pc.create_offer(None)?;
+    p.offer_pc
+        .set_local_description(Instant::now(), offer.clone())?;
+    p.answer_pc.set_remote_description(Instant::now(), offer)?;
+    let answer = p.answer_pc.create_answer(None)?;
+    p.answer_pc
+        .set_local_description(Instant::now(), answer.clone())?;
+    p.offer_pc.set_remote_description(Instant::now(), answer)?;
+
+    let mut offer_connected = false;
+    let mut answer_connected = false;
+    let mut offer_opens: Vec<RTCDataChannelId> = Vec::new();
+    let mut answer_opens: Vec<RTCDataChannelId> = Vec::new();
+    let mut answer_received_offer = false;
+    let mut offer_received_echo = false;
+    let mut ping_sent = false;
+
+    let mut offer_buf = vec![0u8; 2048];
+    let mut answer_buf = vec![0u8; 2048];
+
+    let start = Instant::now();
+    let deadline = Duration::from_secs(15);
+
+    while start.elapsed() < deadline {
+        while let Some(msg) = p.offer_pc.poll_write() {
+            p.offer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+        while let Some(msg) = p.answer_pc.poll_write() {
+            p.answer_socket
+                .send_to(&msg.message, msg.transport.peer_addr)
+                .await?;
+        }
+
+        while let Some(event) = p.offer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => offer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(stream_id)) => {
+                    offer_opens.push(stream_id);
+                }
+                _ => {}
+            }
+        }
+        while let Some(event) = p.answer_pc.poll_event() {
+            match event {
+                RTCPeerConnectionEvent::OnConnectionStateChangeEvent(
+                    RTCPeerConnectionState::Connected,
+                ) => answer_connected = true,
+                RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(stream_id)) => {
+                    answer_opens.push(stream_id);
+                }
+                _ => {}
+            }
+        }
+
+        while let Some(TaggedRTCMessage { message, .. }) = p.offer_pc.poll_read() {
+            if let RTCMessage::DataChannelMessage(stream_id, msg) = message {
+                if String::from_utf8_lossy(&msg.data) == "echo" {
+                    // The echo returns on the offerer's own dialed stream (the answerer echoed
+                    // on the same stream the ping came in on).
+                    let own = p
+                        .offer_pc
+                        .data_channel_handle(offer_own_handle)
+                        .and_then(|dc| dc.id())
+                        .unwrap();
+                    assert_eq!(stream_id, own);
+                    offer_received_echo = true;
+                }
+            }
+        }
+        while let Some(TaggedRTCMessage { message, .. }) = p.answer_pc.poll_read() {
+            if let RTCMessage::DataChannelMessage(stream_id, msg) = message {
+                if String::from_utf8_lossy(&msg.data) == "ping" {
+                    let own = p
+                        .answer_pc
+                        .data_channel_handle(answer_own_handle)
+                        .and_then(|dc| dc.id())
+                        .unwrap();
+                    assert_ne!(
+                        stream_id, own,
+                        "ping arrives on the incoming channel, not the answerer's own"
+                    );
+                    answer_received_offer = true;
+                    if let Some(mut dc) = p.answer_pc.data_channel(stream_id) {
+                        dc.send_text(Instant::now(), "echo".to_string())?;
+                    }
+                }
+            }
+        }
+
+        // Send once the offerer's own channel is open.
+        let offer_own_open = p
+            .offer_pc
+            .data_channel_handle(offer_own_handle)
+            .and_then(|dc| dc.id())
+            .map(|id| offer_opens.contains(&id))
+            .unwrap_or(false);
+        if offer_own_open && !ping_sent {
+            if let Some(mut dc) = p.offer_pc.data_channel_handle(offer_own_handle) {
+                dc.send_text(Instant::now(), "ping".to_string())?;
+                ping_sent = true;
+            }
+        }
+
+        if offer_received_echo && answer_received_offer {
+            break;
+        }
+
+        let next = p
+            .offer_pc
+            .poll_timeout()
+            .unwrap_or(Instant::now() + Duration::from_secs(1))
+            .min(
+                p.answer_pc
+                    .poll_timeout()
+                    .unwrap_or(Instant::now() + Duration::from_secs(1)),
+            );
+        let delay = next
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_millis(10));
+        if delay.is_zero() {
+            p.offer_pc.handle_timeout(Instant::now()).ok();
+            p.answer_pc.handle_timeout(Instant::now()).ok();
+            continue;
+        }
+        let sleep = tokio::time::sleep(delay);
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            _ = sleep => {
+                p.offer_pc.handle_timeout(Instant::now()).ok();
+                p.answer_pc.handle_timeout(Instant::now()).ok();
+            }
+            Ok((n, peer_addr)) = p.offer_socket.recv_from(&mut offer_buf) => {
+                p.offer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: p.offer_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&offer_buf[..n]),
+                }).ok();
+            }
+            Ok((n, peer_addr)) = p.answer_socket.recv_from(&mut answer_buf) => {
+                p.answer_pc.handle_read(TaggedBytesMut {
+                    now: Instant::now(),
+                    transport: TransportContext {
+                        local_addr: p.answer_addr,
+                        peer_addr,
+                        ecn: None,
+                        transport_protocol: TransportProtocol::UDP,
+                    },
+                    message: BytesMut::from(&answer_buf[..n]),
+                }).ok();
+            }
+        }
+    }
+
+    assert!(offer_connected && answer_connected, "peers should connect");
+    assert!(
+        answer_received_offer && offer_received_echo,
+        "application data must flow both ways over deferred channels"
+    );
+
+    p.offer_pc.close()?;
+    p.answer_pc.close()?;
+
+    Ok(())
+}

--- a/tests/ice_restart_by_webrtc_interop.rs
+++ b/tests/ice_restart_by_webrtc_interop.rs
@@ -246,7 +246,7 @@ async fn test_ice_restart_interop() -> Result<()> {
                 }
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(channel_id)) => {
                     if let Some(dc) = rtc_pc.data_channel(channel_id) {
-                        log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
+                        log::info!("RTC data channel '{}'-'{:?}' opened", dc.label(), dc.id());
                         rtc_dc_id = Some(channel_id);
                     }
                 }
@@ -333,7 +333,7 @@ async fn test_ice_restart_interop() -> Result<()> {
                 event
             {
                 if let Some(dc) = rtc_pc.data_channel(channel_id) {
-                    log::info!("RTC data channel '{}'-'{}' opened", dc.label(), dc.id());
+                    log::info!("RTC data channel '{}'-'{:?}' opened", dc.label(), dc.id());
                     rtc_dc_id = Some(channel_id);
                 }
             }


### PR DESCRIPTION
This PR implements [#199](https://github.com/webrtc-rs/rtc/issues/199). It contains four commits, each of which may be tested in isolation. The only breaking change is `RTCDataChannel::id()` returning `Option` (in commit 4), which is the direct fix for issue #199; the other three commits are supporting fixes. Each commit's full description is below.

## Commit descriptions

<details>
<summary><strong>1. fix(data_channel): set the DCEP handshake deadline for channels dialed at create time</strong></summary>

# set DCEP handshake deadline for channels dialed at create time

A create-time dial gets no DCEP handshake deadline, so a lost `DATA_CHANNEL_ACK` leaves the channel in `connecting` forever.

`create_data_channel` dials an in-band channel immediately when the SCTP association already exists (W3C section 6.1 `createDataChannel`, step 23). For channels dialed during the initial connection, [webrtc-rs/rtc#171](https://github.com/webrtc-rs/rtc/pull/171) sets a DCEP handshake deadline; apply the same to the create-time path. Negotiated channels get none.

## Changes

- `src/peer_connection/mod.rs` - `create_data_channel`: after the create-time `dial`, set `handshake_deadline` from `setting_engine.data_channel.dcep_handshake_timeout`, same as the `SCTPHandshakeComplete` handler. Negotiated channels get none.

## Tests

- New test `post_sctp_in_band_channel_sets_handshake_deadline`: with an existing SCTP association, a newly created in-band channel dials immediately, stays `connecting`, and has a deadline set.

## Spec references

- [W3C WebRTC section 6.1 createDataChannel, step 23](https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel): the underlying data transport is created during `createDataChannel`.

  > Step 23: Create `channel`'s associated underlying data transport and configure it according to the relevant properties of `channel`.

- [RFC 8832 section 5.2 DATA_CHANNEL_ACK Message](https://www.rfc-editor.org/rfc/rfc8832.html#section-5.2): opening an in-band channel requires the peer's `DATA_CHANNEL_ACK`.

  > Reception of this message tells the opener that the data channel setup handshake is complete.

## Verification

```bash
cargo test --lib -- --test-threads=4
cargo clippy --lib -- -D warnings
```

</details>

<details>
<summary><strong>2. fix(data_channel): emit OnOpen when negotiated channel dials post-SCTP</strong></summary>

# emit OnOpen for negotiated channels dialed after SCTP connects

This PR queues `OnOpen` at the create-time dial, so a negotiated channel dialed after SCTP connects fires the open event.

A negotiated channel has no in-band DCEP handshake (W3C section 6.2; it is negotiated out-of-band). Created after SCTP connects it opens immediately, but only the `SCTPHandshakeComplete` handler fires `OnOpen`, and it never runs for such a channel.

## Changes

- `src/peer_connection/mod.rs` - `create_data_channel`: when the create-time dial leaves a negotiated channel `Open`, queue `RTCDataChannelEvent::OnOpen(id)` on `pipeline_context.event_outs`, same as the handshake-complete handler ([webrtc-rs/rtc#171](https://github.com/webrtc-rs/rtc/pull/171)).

## Tests

- New test `negotiated_channel_created_after_sctp_emits_on_open`: a negotiated channel created with an existing SCTP association is immediately `Open` and queues exactly one `OnOpen`, carrying the channel's negotiated id.

## Spec references

- [W3C WebRTC section 6.2 RTCDataChannel](https://www.w3.org/TR/webrtc/#rtcdatachannel): a negotiated channel connects two separately created `RTCDataChannel` objects out-of-band; no in-band DCEP handshake.

  > The second way is to let the application negotiate the `RTCDataChannel`. To do this, create an `RTCDataChannel` object with the `negotiated` `RTCDataChannelInit` dictionary member set to true, and signal out-of-band (e.g. via a web server) to the other side that it *SHOULD* create a corresponding `RTCDataChannel` with the `negotiated` `RTCDataChannelInit` dictionary member set to true and the same `id`.

  > This will connect the two separately created `RTCDataChannel` objects.

- [W3C WebRTC section 6.2.2 Announcing a data channel as open](https://www.w3.org/TR/webrtc/#announce-datachannel-open): the `open` event fires when the channel enters the `open` state.

  > Step 4: Set `channel`.[`[[ReadyState]]`] to "`open`".

  > Step 5: Fire an event named `open` at `channel`.

## Verification

```bash
cargo test --lib -- --test-threads=4
cargo clippy --lib -- -D warnings
```

</details>

<details>
<summary><strong>3. fix(data_channel): reject a negotiated stream id that is already in use</strong></summary>

# reject a negotiated stream id in use

W3C section 6.1 `createDataChannel` step 18: throw an `OperationError` when the negotiated id is already taken. `create_data_channel` accepted it, so two channels could collide on one SCTP stream. It now returns `ErrOperationError`.

## Changes

- `rtc-shared/src/error.rs` - add `ErrOperationError`.
- `src/peer_connection/mod.rs` - `create_data_channel` returns `ErrOperationError` when the requested negotiated id is already a key of `data_channels` (local and remote channels, keyed by stream id).

## Tests

- New test `negotiated_id_collision_returns_operation_error`: an in-band channel followed by a negotiated channel requesting the same id fails with `ErrOperationError`.

## Spec references

- [W3C WebRTC section 6.1 createDataChannel, step 18](https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel): throw an `OperationError` when the negotiated id is taken.

  > Step 18: If no available ID could be generated, or if the value of the `[[DataChannelId]]` slot is being used by an existing `RTCDataChannel`, throw an `OperationError` exception.

## Verification

```bash
cargo test --lib -- --test-threads=4
cargo clippy --lib -- -D warnings
```

</details>

<details>
<summary><strong>4. fix(data_channel): defer SCTP stream-id assignment until DTLS role is resolved</strong></summary>

# defer data channel stream-id assignment until the DTLS role is resolved ([#199](https://github.com/webrtc-rs/rtc/issues/199))

A data channel's SCTP stream id follows RFC 8832 parity: the DTLS client uses even ids, the server odd ones. The id is unknowable while the DTLS role is still `Auto`, so assigning it inside `create_data_channel` guesses a role, breaks parity, and can collide across peers.

This PR defers assignment to the SCTP connected procedure (W3C section 6.1 step 18 / section 6.1.1.3), once the role is resolved. A channel has no id until then: `RTCDataChannel::id()` returns `Option`, the PR's only breaking change (implements [#199](https://github.com/webrtc-rs/rtc/issues/199)).

## Changes

### Breaking

- **The only one:** `RTCDataChannel::id()` now returns `Option<RTCDataChannelId>` (`None` while the id is still unassigned).

### Deferred id assignment

- Ids are assigned by `DataChannelHandler::assign_pending_ids()`, strict W3C section 6.1.1.3:
  - On `SCTPHandshakeComplete`, and defensively at the top of `handle_read` (in case a `DATA_CHANNEL_ACK` beats the handshake-complete event through the pipeline).
  - Server parity odd, client even, respecting the negotiated max channel count.
- `generate_data_channel_id(role)` now takes the resolved role directly; the `Auto` special-case is gone (the caller passes the resolved role).

### Handle-based identity (internal)

- `RTCDataChannelHandle` - a stable per-connection identity, allocated at `create_data_channel`, never reused:
  - It is **not** part of `RTCDataChannelEvent`, `RTCMessage::DataChannelMessage`, or the `data_channel(id)` lookup API.
  - The existing lookup API (`data_channel(id)`) stays stream-id based, so it is non-breaking for apps.
- `RTCPeerConnection` now keys its channels by handle and keeps the supporting maps:
  - `data_channels`, keyed by `RTCDataChannelHandle`.
  - A reverse map `data_channel_ids` (stream id -> handle).
  - A creation-ordered `pending_data_channel_handles` list.

### Additive wrapper API

- `RTCDataChannel::handle()` and `RTCPeerConnection::data_channel_handle(handle)` are new, additive methods for the async `webrtc` wrapper crate, which must address a channel before its stream id is assigned. Applications keep using the stream-id based API.

### Fixes

- **Max-stream-id bound.** `maxChannels` is a count, so the highest usable stream id is `max - 1`; the old `id < max.saturating_sub(1)` bound treated `max - 1` as unusable. Assignment now admits the full `0..max` range (see the `assign_pending_ids` tests).
- **Closed-pending skip:** A pending channel the application closed before SCTP connects no longer consumes a stream id.
- **Id-exhaustion notify:** When `assign_pending_ids` cannot assign an id (the negotiated stream count is exhausted):
  - The channel is removed and closed.
  - The application is notified with `OnErrorByHandle` then `OnCloseByHandle` (W3C section 6.1.1.3 step 4.3 / section 6.2.7).
  - Both events are keyed by the stable `RTCDataChannelHandle`, so the wrapper routes to the correct owning channel rather than misrouting via stream id 0.

## Spec references

- [W3C WebRTC section 6.1 createDataChannel, step 18](https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel): the stream id is assigned after the DTLS role is negotiated, not at creation.

  > Step 18: If the `[[DataChannelId]]` slot is null (due to no ID being passed into `createDataChannel`, or `[[Negotiated]]` being false), and the DTLS role of the SCTP transport has already been negotiated, then initialize `[[DataChannelId]]` to a value generated by the user agent, according to [RFC8832], and skip to the next step.

  > Note after step 18: If the `[[DataChannelId]]` slot is null after this step, it will be populated during the RTCSctpTransport connected procedure.

- [W3C WebRTC section 6.1.1.3 Connected procedure, step 4.2](https://www.w3.org/TR/webrtc/#sctp-transport-connected): assigns the stream id during the SCTP *connected* procedure.

  > Step 4.2: If `channel`.[`[[DataChannelId]]`] is null, initialize [`[[DataChannelId]]`] to the value generated by the underlying sctp data channel, according to [RFC8832].

  > Step 4.3: If `channel`.[`[[DataChannelId]]`] is greater or equal to `transport`.[`[[MaxChannels]]`], or the previous step failed to assign an id, close the `channel` due to a failure.

- [RFC 8832 section 6 Procedures](https://www.rfc-editor.org/rfc/rfc8832.html#section-6): the DTLS client uses even ids and the DTLS server odd ones, so the id cannot be known until the role is resolved.

  > If the side is acting as the DTLS client, it MUST choose an even stream identifier; if the side is acting as the DTLS server, it MUST choose an odd one.

## Tests

- New unit tests: `closed_pending_channel_skipped_by_assign_pending_ids`, and `assign_pending_ids_overflow_fires_error_and_close`. All unit tests introduced by commit 1 (the create-time DCEP deadline), commit 2 (post-SCTP OnOpen), and commit 3 (negotiated-id collision) are migrated to the handle-keyed API in this PR.
- Updated unit test `assign_pending_ids_respects_max_channels_and_closes_overflow` to pin the fixed top-id bound (`max - 1`), which is fixed in this PR.
- New integration test `data_channel_stream_id_deferral.rs` (2 async tests): deferred ids, role parity, no cross-peer collision, bidirectional application data.

## Verification

```bash
cargo test --lib -- --test-threads=4
cargo test --tests -- --test-threads=4
cargo clippy --lib -- -D warnings
```

</details>
