### PR TITLE
fix(interceptor): RTX retransmissions must be RTP version 2

### DIFF
--- a/rtc-interceptor/src/nack/responder.rs
+++ b/rtc-interceptor/src/nack/responder.rs
@@ -144,6 +144,12 @@ impl NackResponderInterceptor {
 
                 rtp::Packet {
                     header: rtp::header::Header {
+                        // Not left to `..Default::default()`: the default
+                        // header is version 0, and receivers discard
+                        // version != 2 before examining anything else, so a
+                        // defaulted RTX packet is dropped on arrival and the
+                        // NACKed gap never repairs.
+                        version: 2,
                         ssrc: ssrc_rtx,
                         payload_type: pt_rtx,
                         sequence_number: rtx_seq,

--- a/rtc-interceptor/tests/nack_integration.rs
+++ b/rtc-interceptor/tests/nack_integration.rs
@@ -398,6 +398,11 @@ fn test_nack_responder_rtx_retransmission() {
             && rtp.header.payload_type == rtx_pt
         {
             rtx_found = true;
+            // The first thing any receiver checks: a version != 2 packet is
+            // discarded before ssrc, payload type or payload are ever looked
+            // at, so an RTX packet built from a defaulted header (version 0)
+            // passes every assertion below while being useless on the wire.
+            assert_eq!(rtp.header.version, 2, "RTX packet must be RTP version 2");
             // RTX payload should contain original sequence number
             assert!(rtp.payload.len() >= 2);
             let original_seq = u16::from_be_bytes([rtp.payload[0], rtp.payload[1]]);


### PR DESCRIPTION
Fixes #210.

The RFC 4588 branch of `NackResponderInterceptor` built the RTX packet header with `..Default::default()`, whose derived default is **version 0**. Receivers discard `version != 2` before examining anything else, so every RTX retransmission was dropped on arrival — the NACKing receiver re-asked for the same sequence numbers indefinitely and the gap never repaired, despite a correct `a=ssrc-group:FID` association and correct ssrc/pt/OSN in the packets. Observed on the wire against Chrome under 5% induced downlink loss: first byte `0x00` on every RTX packet, `retransmittedPacketsReceived` never moving, NACK count snowballing.

Change: set `version: 2` explicitly in the RTX header construction, and extend `test_nack_responder_rtx_retransmission` to assert it — the test previously checked ssrc, payload type and OSN payload (everything except the field a receiver validates first) and passes against the broken construction. With the assertion added the test fails without the fix and passes with it (verified both ways against current `main`).

With this one line, our deployment recovers every NACKed packet under induced loss and decode is continuous.