### PR TITLE
fix RFC: Defer SCTP stream-id assignment until DTLS role is resolved …

### DIFF
--- a/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-active-offer.rs
@@ -20,6 +20,7 @@ use clap::Parser;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client, Method, Request, Response, Server, StatusCode};
 use log::{error, info};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
@@ -288,7 +289,7 @@ async fn main() -> Result<()> {
     // State
     let mut tcp_stream: Option<TcpStream> = None;
     let mut local_addr: Option<SocketAddr> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut buf = vec![0u8; 2000];
     let mut tcp_decoder = TcpFrameDecoder::new();

--- a/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
+++ b/examples/ice-tcp-active-passive/ice-tcp-passive-answer.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client, Method, Request, Response, Server, StatusCode};
 use log::{error, info};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -206,7 +207,7 @@ async fn main() -> Result<()> {
     let mut peer_connection: Option<RTCPeerConnection> = None;
     let mut tcp_stream: Option<TcpStream> = None;
     let mut local_addr: Option<SocketAddr> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut buf = vec![0u8; 2000];
     let mut tcp_decoder = TcpFrameDecoder::new();

--- a/examples/ice-tcp/ice-tcp.rs
+++ b/examples/ice-tcp/ice-tcp.rs
@@ -21,6 +21,7 @@ use clap::Parser;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use log::{error, info};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -197,7 +198,7 @@ async fn run_main_loop(
     let mut peer_connection: Option<RTCPeerConnection> = None;
     let mut tcp_stream: Option<TcpStream> = None;
     let mut local_addr: Option<SocketAddr> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut buf = vec![0u8; 2000];
     let mut tcp_decoder = TcpFrameDecoder::new();

--- a/examples/perfect-negotiation/perfect-negotiation.rs
+++ b/examples/perfect-negotiation/perfect-negotiation.rs
@@ -22,6 +22,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Response, Server, StatusCode};
 use log::{error, info, trace, warn};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngine;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -441,7 +442,7 @@ async fn run_peer(
     let mut buf = BytesMut::with_capacity(2048);
     buf.resize(2048, 0);
     let mut pending_negotiation = false;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut data_channel_created = false;
 
     loop {

--- a/examples/trickle-ice-host/trickle-ice-host.rs
+++ b/examples/trickle-ice-host/trickle-ice-host.rs
@@ -19,6 +19,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Response, Server, StatusCode};
 use log::{error, info, trace};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -152,7 +153,7 @@ async fn run_main_loop() -> Result<()> {
     let mut peer_connection: Option<RTCPeerConnection> = None;
     let mut udp_socket: Option<UdpSocket> = None;
     let mut local_addr: Option<SocketAddr> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut ws_stream: Option<WebSocketStream<TcpStream>> = None;
     let mut buf = vec![0; 2000];

--- a/examples/trickle-ice-relay/trickle-ice-relay.rs
+++ b/examples/trickle-ice-relay/trickle-ice-relay.rs
@@ -15,6 +15,7 @@ use hyper::{Body, Method, Response, Server, StatusCode};
 use ice::candidate::candidate_relay::CandidateRelayConfig;
 use log::{error, info, trace};
 use rtc::crypto;
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -204,7 +205,7 @@ async fn run_main_loop(
 
     // State for the main loop
     let mut peer_connection: Option<RTCPeerConnection> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut ws_stream: Option<WebSocketStream<TcpStream>> = None;
     let mut buf = vec![0; 2000];

--- a/examples/trickle-ice-srflx/trickle-ice-srflx.rs
+++ b/examples/trickle-ice-srflx/trickle-ice-srflx.rs
@@ -14,6 +14,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Response, Server, StatusCode};
 use ice::candidate::candidate_server_reflexive::CandidateServerReflexiveConfig;
 use log::{error, info, trace};
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -158,7 +159,7 @@ async fn run_main_loop() -> Result<()> {
 
     // State for the main loop
     let mut peer_connection: Option<RTCPeerConnection> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut ws_stream: Option<WebSocketStream<TcpStream>> = None;
     let mut buf = vec![0; 2000];

--- a/examples/trickle-ice/trickle-ice.rs
+++ b/examples/trickle-ice/trickle-ice.rs
@@ -22,6 +22,7 @@ use ice::candidate::candidate_relay::CandidateRelayConfig;
 use ice::candidate::candidate_server_reflexive::CandidateServerReflexiveConfig;
 use log::{error, info, trace, warn};
 use rtc::crypto;
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::RTCDataChannelEvent;
@@ -303,7 +304,7 @@ async fn run_main_loop(cli: Cli) -> Result<()> {
 
     // State for the main loop
     let mut peer_connection: Option<RTCPeerConnection> = None;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
     let mut last_send = Instant::now();
     let mut ws_stream: Option<WebSocketStream<TcpStream>> = None;
     let mut buf = vec![0; 2000];

--- a/rtc-shared/src/error.rs
+++ b/rtc-shared/src/error.rs
@@ -1728,6 +1728,16 @@ pub enum Error {
     #[error("data channel is not open yet")]
     ErrDataChannelNotOpen,
 
+    /// ErrDataChannelStreamIdNotAssigned indicates an operation that needs the channel's SCTP
+    /// stream identifier ran before one was assigned.
+    ///
+    /// A data channel announced in-band has no stream identifier until the SCTP connected
+    /// procedure assigns one, because RFC 8832 section 6 ties its parity to the DTLS role:
+    /// even for the client, odd for the server. Until that role is resolved there is no
+    /// correct identifier to pick, so the channel carries none rather than a guess.
+    #[error("data channel stream identifier has not been assigned yet")]
+    ErrDataChannelStreamIdNotAssigned,
+
     /// ErrDataChannelNonExist indicates an operation executed when the data
     /// channel not existed.
     #[error("data channel not existed")]

--- a/src/data_channel/init.rs
+++ b/src/data_channel/init.rs
@@ -1,3 +1,5 @@
+use sctp::StreamId;
+
 /// Dictionary for configuring properties of an RTCDataChannel.
 ///
 /// The `RTCDataChannelInit` dictionary is used to configure the properties of a data channel
@@ -75,7 +77,7 @@ pub struct RTCDataChannelInit {
     /// Corresponds to the `negotiated` and `id` attributes in the [W3C specification].
     ///
     /// [W3C specification]: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit-negotiated
-    pub negotiated: Option<u16>,
+    pub negotiated: Option<StreamId>,
 }
 
 impl Default for RTCDataChannelInit {

--- a/src/data_channel/internal.rs
+++ b/src/data_channel/internal.rs
@@ -3,13 +3,27 @@ use crate::data_channel::parameters::DataChannelParameters;
 use crate::data_channel::state::RTCDataChannelState;
 use datachannel::data_channel::DataChannelConfig;
 use sansio::Protocol;
-use sctp::PayloadProtocolIdentifier;
-use shared::error::Result;
+use sctp::{PayloadProtocolIdentifier, StreamId};
+use shared::error::{Error, Result};
 use std::time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct RTCDataChannelInternal {
+    /// Connection-local handle. Assigned by `DataChannelRegistry::insert`, stable for the
+    /// channel's lifetime, and the key this channel lives under. NOT the wire value — the
+    /// differing widths (`usize` vs `StreamId`) are what stop the two being confused.
+    ///
+    /// Carried on the value as well as the key so the close and assignment paths can read it
+    /// back without a reverse lookup.
     pub(crate) id: RTCDataChannelId,
+
+    /// The RFC 8832 §6 SCTP stream identifier.
+    ///
+    /// `None` until the SCTP connected procedure assigns it, which cannot happen before the
+    /// DTLS role is resolved because the role decides the parity: even for the client, odd for
+    /// the server. Out-of-band (`negotiated`) channels and channels accepted from the peer
+    /// have it from birth, since their id is already fixed by the application or the wire.
+    pub(crate) stream_id: Option<StreamId>,
     pub(crate) label: String,
     pub(crate) ordered: bool,
     pub(crate) max_packet_life_time: Option<u16>,
@@ -42,6 +56,7 @@ impl Default for RTCDataChannelInternal {
     fn default() -> Self {
         Self {
             id: 0,
+            stream_id: None,
             label: "".to_string(),
             ordered: false,
             max_packet_life_time: None,
@@ -60,10 +75,18 @@ impl Default for RTCDataChannelInternal {
 }
 
 impl RTCDataChannelInternal {
-    /// create the DataChannel object before the networking is set up.
-    pub(crate) fn new(id: RTCDataChannelId, params: DataChannelParameters) -> Self {
+    /// Creates the DataChannel object before the networking is set up.
+    ///
+    /// The handle is left at its placeholder; [`DataChannelRegistry::insert`] assigns the real
+    /// one. The stream id comes from `params.negotiated` — `Some` for an out-of-band channel,
+    /// whose id the application already fixed, and `None` for an in-band one, whose id has to
+    /// wait for the DTLS role.
+    ///
+    /// [`DataChannelRegistry::insert`]: crate::data_channel::registry::DataChannelRegistry::insert
+    pub(crate) fn new(params: DataChannelParameters) -> Self {
         Self {
-            id,
+            id: 0,
+            stream_id: params.negotiated,
             label: params.label,
             protocol: params.protocol,
             negotiated: params.negotiated.is_some(),
@@ -81,6 +104,13 @@ impl RTCDataChannelInternal {
     }
 
     pub(crate) fn dial(&mut self, association_handle: usize) -> Result<()> {
+        // A channel cannot be dialed before its stream id exists, and the stream id cannot
+        // exist before the DTLS role does. Making that an error rather than a fallback is the
+        // whole point: guessing a parity here is what issue #199 was.
+        let stream_id = self
+            .stream_id
+            .ok_or(Error::ErrDataChannelStreamIdNotAssigned)?;
+
         let (channel_type, reliability_parameter) =
             ::datachannel::data_channel::DataChannel::get_channel_type_and_reliability_parameter(
                 self.ordered,
@@ -98,7 +128,7 @@ impl RTCDataChannelInternal {
         };
 
         let mut data_channel =
-            ::datachannel::data_channel::DataChannel::dial(config, association_handle, self.id)?;
+            ::datachannel::data_channel::DataChannel::dial(config, association_handle, stream_id)?;
         data_channel.set_buffered_amount_low_threshold(self.buffered_amount_low_threshold)?;
         data_channel.set_buffered_amount_high_threshold(self.buffered_amount_high_threshold)?;
 
@@ -118,7 +148,7 @@ impl RTCDataChannelInternal {
 
     pub(crate) fn accept(
         association_handle: usize,
-        stream_id: u16,
+        stream_id: StreamId,
         ppi: PayloadProtocolIdentifier,
         buf: &[u8],
     ) -> Result<Self> {
@@ -137,17 +167,20 @@ impl RTCDataChannelInternal {
                 data_channel_config.channel_type,
             );
 
-        let mut data_channel_internal = RTCDataChannelInternal::new(
-            stream_id,
-            DataChannelParameters {
-                label: data_channel_config.label.clone(),
-                protocol: data_channel_config.protocol.clone(),
-                ordered: !unordered,
-                max_packet_life_time: None,
-                max_retransmits: None,
-                negotiated: None,
-            },
-        );
+        // `negotiated: None` — the peer opened this channel in-band over DCEP, so it is not an
+        // out-of-band channel however well-known its stream id now is. The stream id is set
+        // below instead of through `negotiated`, which would also flip the `negotiated` flag.
+        let mut data_channel_internal = RTCDataChannelInternal::new(DataChannelParameters {
+            label: data_channel_config.label.clone(),
+            protocol: data_channel_config.protocol.clone(),
+            ordered: !unordered,
+            max_packet_life_time: None,
+            max_retransmits: None,
+            negotiated: None,
+        });
+        // Known from the wire: no deferral needed, and it must be registered so locally
+        // generated ids cannot collide with it.
+        data_channel_internal.stream_id = Some(stream_id);
         data_channel_internal.data_channel = Some(data_channel);
         data_channel_internal.ready_state = RTCDataChannelState::Open;
 

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -46,12 +46,36 @@ pub(crate) mod init;
 pub(crate) mod internal;
 pub(crate) mod message;
 pub(crate) mod parameters;
+pub(crate) mod registry;
 pub(crate) mod state;
 
-/// Identifier for a data channel within a particular peer connection.
+/// Handle identifying a data channel within a particular peer connection.
 ///
-/// Each data channel has a unique 16-bit identifier within its peer connection.
-pub type RTCDataChannelId = u16;
+/// This is a connection-local handle, not the SCTP stream identifier the channel occupies on
+/// the wire — for that, see [`RTCDataChannel::stream_id`]. It is assigned when the channel is
+/// created, is stable for the channel's lifetime, and is never reused by a later channel.
+///
+/// The two are separate because they become known at different times. RFC 8832 §6 makes the
+/// parity of a stream identifier depend on the DTLS role — even for the client, odd for the
+/// server — and that role is not resolved until a remote description has been applied. A
+/// channel created before then has no stream id yet, but the application still needs a way to
+/// name it: to hold on to it, to match it against events, and to pass to
+/// [`RTCPeerConnection::data_channel`]. That is this handle.
+///
+/// It is a `usize`, like [`RTCRtpTransceiverId`], both to match the crate's convention for
+/// connection-local handles and so that it cannot be silently confused with a
+/// [`sctp::StreamId`], which is a `u16`.
+///
+/// [`RTCPeerConnection::data_channel`]: crate::peer_connection::RTCPeerConnection::data_channel
+/// [`RTCRtpTransceiverId`]: crate::rtp_transceiver::RTCRtpTransceiverId
+pub type RTCDataChannelId = usize;
+
+/// The SCTP stream identifier a data channel occupies on the wire.
+///
+/// Re-exported next to [`RTCDataChannelId`] because the two are easy to confuse and the
+/// distinction matters: this is the RFC 8832 §6 wire value, that is a connection-local handle.
+/// See [`RTCDataChannel::stream_id`].
+pub use sctp::StreamId;
 
 pub use init::RTCDataChannelInit;
 
@@ -151,14 +175,43 @@ impl RTCDataChannel<'_> {
             .negotiated
     }
 
-    /// ID represents the ID for this DataChannel. The value is initially
-    /// null, which is what will be returned if the ID was not provided at
-    /// channel creation time, and the DTLS role of the SCTP transport has not
-    /// yet been negotiated. Otherwise, it will return the ID that was either
-    /// selected by the script or generated. After the ID is set to a non-null
-    /// value, it will not change.
+    /// The handle identifying this DataChannel within its peer connection.
+    ///
+    /// Available immediately, stable for the channel's lifetime, and never reused by a later
+    /// channel. Use it to address this channel — pass it to
+    /// [`RTCPeerConnection::data_channel`], or match it against the id carried by an
+    /// [`RTCDataChannelEvent`].
+    ///
+    /// This is **not** the SCTP stream identifier: see [`Self::stream_id`], which is what
+    /// W3C's `RTCDataChannel.id` and RFC 8832 §6 refer to.
+    ///
+    /// [`RTCPeerConnection::data_channel`]: crate::peer_connection::RTCPeerConnection::data_channel
+    /// [`RTCDataChannelEvent`]: crate::peer_connection::event::RTCDataChannelEvent
     pub fn id(&self) -> RTCDataChannelId {
         self.id
+    }
+
+    /// The SCTP stream identifier carrying this DataChannel, or `None` if one has not been
+    /// assigned yet.
+    ///
+    /// This is W3C's `RTCDataChannel.id`: "The value is initially null, which is what will be
+    /// returned if the ID was not provided at channel creation time, and the DTLS role of the
+    /// SCTP transport has not yet been negotiated."
+    ///
+    /// It is `Some` from the outset for a channel negotiated out-of-band (created with
+    /// [`RTCDataChannelInit::negotiated`]) and for one opened by the remote peer, since both
+    /// already have a stream id. For a channel this endpoint opens in-band it stays `None`
+    /// until the SCTP connected procedure assigns one, because RFC 8832 §6 requires an even
+    /// identifier from the DTLS client and an odd one from the DTLS server, and which of those
+    /// this endpoint is may still be unknown. Once set it does not change.
+    pub fn stream_id(&self) -> Option<StreamId> {
+        // peer_connection is mutable borrow, its data_channels won't be resized,
+        // so, unwrap() here is safe.
+        self.peer_connection
+            .data_channels
+            .get(&self.id)
+            .unwrap()
+            .stream_id
     }
 
     /// ready_state represents the state of the DataChannel object.

--- a/src/data_channel/parameters.rs
+++ b/src/data_channel/parameters.rs
@@ -1,3 +1,4 @@
+use sctp::StreamId;
 use serde::{Deserialize, Serialize};
 
 /// Internal parameters describing the configuration of a DataChannel.
@@ -22,7 +23,8 @@ pub(crate) struct DataChannelParameters {
     /// The maximum number of retransmission attempts in unreliable mode.
     pub(crate) max_retransmits: Option<u16>,
 
-    /// The data channel ID if this channel was negotiated by the application.
-    /// None if the channel was not pre-negotiated.
-    pub(crate) negotiated: Option<u16>,
+    /// The SCTP stream identifier this channel was negotiated on out-of-band by the
+    /// application. `None` if the channel was not pre-negotiated, in which case the stream id
+    /// is assigned during the SCTP connected procedure once the DTLS role is known.
+    pub(crate) negotiated: Option<StreamId>,
 }

--- a/src/data_channel/registry.rs
+++ b/src/data_channel/registry.rs
@@ -1,0 +1,217 @@
+use crate::data_channel::RTCDataChannelId;
+use crate::data_channel::internal::RTCDataChannelInternal;
+use crate::peer_connection::transport::dtls::role::RTCDtlsRole;
+use crate::peer_connection::transport::sctp::SCTP_MAX_CHANNELS;
+use sctp::StreamId;
+use shared::error::{Error, Result};
+use std::collections::HashMap;
+
+/// Every data channel on a peer connection, indexed by both of its identifiers.
+///
+/// A channel has two: the [`RTCDataChannelId`] handle the application uses to address it, and
+/// the SCTP [`StreamId`] it occupies on the wire. They are deliberately different things.
+///
+/// The handle is allocated when the channel is created and never changes. The stream id cannot
+/// be, because RFC 8832 §6 makes its parity depend on the DTLS role — even for the client, odd
+/// for the server — and that role is not known until a remote description has been applied. An
+/// in-band channel therefore has no stream id between `create_data_channel` and the SCTP
+/// connected procedure, which is exactly the window in which an application wants to hold a
+/// reference to it. Keying the collection by the handle is what lets it do so.
+///
+/// The reverse index exists because the two directions arrive differently: the application and
+/// every event name a channel by handle, while SCTP hands us a stream id.
+#[derive(Default)]
+pub(crate) struct DataChannelRegistry {
+    channels: HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+
+    /// Wire stream id -> handle, for every channel that has been assigned one. Doubles as the
+    /// authoritative "which stream ids are taken" set consulted when assigning new ones: it is
+    /// fed by all three channel origins (locally deferred, out-of-band, and accepted from the
+    /// peer), so a generated id cannot collide with one the peer opened first.
+    by_stream: HashMap<StreamId, RTCDataChannelId>,
+
+    /// Monotonic handle counter. Never decremented, never reused.
+    next_handle: RTCDataChannelId,
+}
+
+impl DataChannelRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            channels: HashMap::new(),
+            by_stream: HashMap::new(),
+            next_handle: 0,
+        }
+    }
+
+    /// Registers `data_channel`, assigning it a fresh handle and indexing its stream id if it
+    /// already has one.
+    ///
+    /// Handles are issued monotonically and never reused, so a handle an application is still
+    /// holding can never come to name a different channel after the original closed. (The
+    /// stream id it occupied does become available again, as before.) `usize` is what makes
+    /// this affordable: exhausting the handle space is not a practical concern, so unlike
+    /// stream-id allocation this cannot fail.
+    ///
+    /// Issuing handles in increasing order also means ascending handle order *is* creation
+    /// order, which [`Self::pending_stream_id_handles`] relies on.
+    pub(crate) fn insert(&mut self, mut data_channel: RTCDataChannelInternal) -> RTCDataChannelId {
+        let handle = self.next_handle;
+        self.next_handle += 1;
+
+        // The channel carries its own handle: `pending_stream_id_handles` and the close path
+        // both read it back off the value rather than the key.
+        data_channel.id = handle;
+        if let Some(stream_id) = data_channel.stream_id {
+            self.by_stream.insert(stream_id, handle);
+        }
+        self.channels.insert(handle, data_channel);
+
+        handle
+    }
+
+    pub(crate) fn get(&self, handle: &RTCDataChannelId) -> Option<&RTCDataChannelInternal> {
+        self.channels.get(handle)
+    }
+
+    pub(crate) fn get_mut(
+        &mut self,
+        handle: &RTCDataChannelId,
+    ) -> Option<&mut RTCDataChannelInternal> {
+        self.channels.get_mut(handle)
+    }
+
+    pub(crate) fn contains(&self, handle: &RTCDataChannelId) -> bool {
+        self.channels.contains_key(handle)
+    }
+
+    /// The handle of the channel occupying `stream_id`, if any.
+    pub(crate) fn handle_of_stream(&self, stream_id: &StreamId) -> Option<RTCDataChannelId> {
+        self.by_stream.get(stream_id).copied()
+    }
+
+    pub(crate) fn get_by_stream(&self, stream_id: &StreamId) -> Option<&RTCDataChannelInternal> {
+        self.channels.get(self.by_stream.get(stream_id)?)
+    }
+
+    pub(crate) fn get_by_stream_mut(
+        &mut self,
+        stream_id: &StreamId,
+    ) -> Option<&mut RTCDataChannelInternal> {
+        let handle = *self.by_stream.get(stream_id)?;
+        self.channels.get_mut(&handle)
+    }
+
+    /// Removes the channel occupying `stream_id`, freeing that id for reuse.
+    pub(crate) fn remove_by_stream(
+        &mut self,
+        stream_id: &StreamId,
+    ) -> Option<RTCDataChannelInternal> {
+        let handle = self.by_stream.remove(stream_id)?;
+        self.channels.remove(&handle)
+    }
+
+    /// Whether `stream_id` is already claimed, by a channel of any origin.
+    pub(crate) fn stream_id_in_use(&self, stream_id: &StreamId) -> bool {
+        self.by_stream.contains_key(stream_id)
+    }
+
+    /// Handles of channels still awaiting a stream id, in creation order.
+    ///
+    /// Ascending handle order is creation order, because handles are issued monotonically.
+    /// Sorting matters: `channels` is a `HashMap`, so without it two runs of the same program
+    /// would hand out different stream ids.
+    pub(crate) fn pending_stream_id_handles(&self) -> Vec<RTCDataChannelId> {
+        let mut handles: Vec<_> = self
+            .channels
+            .values()
+            .filter(|dc| dc.stream_id.is_none())
+            .map(|dc| dc.id)
+            .collect();
+        handles.sort_unstable();
+        handles
+    }
+
+    /// Assigns SCTP stream identifiers to every channel still awaiting one.
+    ///
+    /// This is the W3C "RTCSctpTransport connected procedure" step that RFC 8832 §6 governs:
+    ///
+    /// > The peer that initiates opening a data channel selects a stream identifier for which
+    /// > the corresponding incoming and outgoing streams are unused. If the side is acting as
+    /// > the DTLS client, it MUST choose an even stream identifier; if the side is acting as
+    /// > the DTLS server, it MUST choose an odd one.
+    ///
+    /// `role` must already be resolved. An unresolved role is a caller bug, and returning an
+    /// error rather than defaulting is the entire point: silently treating
+    /// [`RTCDtlsRole::Auto`] as server parity — which is what the previous
+    /// `generate_data_channel_id` did, at channel-creation time when the role could not yet be
+    /// known — gave every channel an odd id regardless of role. The endpoint that later
+    /// resolved to DTLS client was then holding ids it was not allowed to use, and which the
+    /// peer acting as server was handing out at the same time
+    /// (<https://github.com/webrtc-rs/rtc/issues/199>).
+    ///
+    /// `max_channels` is the association's negotiated stream limit, bounding the id space;
+    /// `None` before the association reports one. Channels are served in creation order, so
+    /// the assignment is deterministic across runs.
+    ///
+    /// Lives here, on the type that owns the id space, because both callers need it: the SCTP
+    /// connected procedure in `DataChannelHandler`, which sees only the registry, and
+    /// `RTCPeerConnection::create_data_channel` when an association already exists.
+    pub(crate) fn assign_stream_ids(
+        &mut self,
+        role: RTCDtlsRole,
+        max_channels: Option<StreamId>,
+    ) -> Result<()> {
+        let mut next: StreamId = match role {
+            RTCDtlsRole::Client => 0,
+            RTCDtlsRole::Server => 1,
+            // Never guess a parity.
+            _ => return Err(Error::ErrDataChannelStreamIdNotAssigned),
+        };
+
+        // The negotiated stream count bounds stream ids, but only once it is known: a channel
+        // may be created before the association exists, and until it connects there is nothing
+        // to bound against. This matches W3C §6.1.1.3, which applies the limit at the connected
+        // procedure rather than at creation.
+        let max = max_channels.unwrap_or(SCTP_MAX_CHANNELS);
+
+        for handle in self.pending_stream_id_handles() {
+            // Skip ids already claimed — by an out-of-band channel the application pinned, or
+            // by one the peer opened first. Carrying the cursor across iterations rather than
+            // restarting the scan keeps this a single pass.
+            while next < max.saturating_sub(1) && self.stream_id_in_use(&next) {
+                next += 2;
+            }
+            if next >= max.saturating_sub(1) {
+                return Err(Error::ErrMaxDataChannelID);
+            }
+            self.assign_stream_id(handle, next);
+            next += 2;
+        }
+
+        Ok(())
+    }
+
+    /// Binds `handle` to `stream_id`. No-op if the handle is unknown.
+    pub(crate) fn assign_stream_id(&mut self, handle: RTCDataChannelId, stream_id: StreamId) {
+        if let Some(data_channel) = self.channels.get_mut(&handle) {
+            data_channel.stream_id = Some(stream_id);
+            self.by_stream.insert(stream_id, handle);
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.channels.len()
+    }
+
+    pub(crate) fn values(&self) -> impl Iterator<Item = &RTCDataChannelInternal> {
+        self.channels.values()
+    }
+
+    pub(crate) fn values_mut(&mut self) -> impl Iterator<Item = &mut RTCDataChannelInternal> {
+        self.channels.values_mut()
+    }
+}

--- a/src/peer_connection/event/mod.rs
+++ b/src/peer_connection/event/mod.rs
@@ -590,6 +590,26 @@ pub(crate) enum RTCEventInternal {
         u16,   /*StreamID*/
         usize, /*n_bytes*/
     ),
+
+    /// A stream's outgoing buffer fell to or below its low threshold.
+    ///
+    /// Carries the SCTP stream id, because that is all the SCTP layer knows. The data channel
+    /// handler translates it into the public
+    /// [`RTCDataChannelEvent::OnBufferedAmountLow`](crate::peer_connection::event::RTCDataChannelEvent::OnBufferedAmountLow),
+    /// which names the channel by handle like every other application-facing event.
+    ///
+    /// Parameters:
+    /// - Association handle
+    /// - Stream ID
+    SCTPBufferedAmountLow(usize /*AssociationHandle*/, u16 /*StreamID*/),
+
+    /// A stream's outgoing buffer rose to or above its high threshold. The handle/stream-id
+    /// note on [`Self::SCTPBufferedAmountLow`] applies here too.
+    ///
+    /// Parameters:
+    /// - Association handle
+    /// - Stream ID
+    SCTPBufferedAmountHigh(usize /*AssociationHandle*/, u16 /*StreamID*/),
 }
 
 pub(crate) struct TaggedRTCEventInternal {

--- a/src/peer_connection/handler/datachannel.rs
+++ b/src/peer_connection/handler/datachannel.rs
@@ -1,6 +1,7 @@
 use crate::data_channel::RTCDataChannelId;
 use crate::data_channel::internal::RTCDataChannelInternal;
 use crate::data_channel::message::RTCDataChannelMessage;
+use crate::data_channel::registry::DataChannelRegistry;
 use crate::data_channel::state::RTCDataChannelState;
 use crate::peer_connection::event::data_channel_event::RTCDataChannelEvent;
 use crate::peer_connection::event::{
@@ -9,12 +10,13 @@ use crate::peer_connection::event::{
 use crate::peer_connection::message::internal::{
     ApplicationMessage, DTLSMessage, DataChannelEvent, RTCMessageInternal, TaggedRTCMessageInternal,
 };
+use crate::peer_connection::transport::dtls::role::RTCDtlsRole;
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use log::{debug, warn};
 use sctp::PayloadProtocolIdentifier;
 use shared::TransportContext;
 use shared::error::{Error, Result};
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 pub(crate) struct DataChannelHandlerContext {
@@ -51,24 +53,35 @@ impl DataChannelHandlerContext {
 /// DataChannelHandler implements DataChannel Protocol handling
 pub(crate) struct DataChannelHandler<'a> {
     ctx: &'a mut DataChannelHandlerContext,
-    data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+    data_channels: &'a mut DataChannelRegistry,
     stats: &'a mut RTCStatsAccumulator,
     /// Configured DCEP handshake timeout for in-band channels. `None` disables it.
     dcep_handshake_timeout: Option<Duration>,
+    /// The DTLS role this endpoint negotiated, which RFC 8832 §6 turns into the parity of the
+    /// stream ids assigned at `SCTPHandshakeComplete`. Resolved by the time an association
+    /// exists, so the handler never has to guess it.
+    dtls_role: RTCDtlsRole,
+    /// Negotiated stream limit, bounding stream-id assignment. `None` until the association
+    /// reports one.
+    max_channels: Option<u16>,
 }
 
 impl<'a> DataChannelHandler<'a> {
     pub(crate) fn new(
         ctx: &'a mut DataChannelHandlerContext,
-        data_channels: &'a mut HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+        data_channels: &'a mut DataChannelRegistry,
         stats: &'a mut RTCStatsAccumulator,
         dcep_handshake_timeout: Option<Duration>,
+        dtls_role: RTCDtlsRole,
+        max_channels: Option<u16>,
     ) -> Self {
         DataChannelHandler {
             ctx,
             data_channels,
             stats,
             dcep_handshake_timeout,
+            dtls_role,
+            max_channels,
         }
     }
 
@@ -100,10 +113,19 @@ impl<'a> DataChannelHandler<'a> {
             })),
         });
 
+        // The channel is open, so it necessarily has a stream id by now; record it as the
+        // W3C `dataChannelIdentifier`, which is the wire value rather than the handle the
+        // accumulator is keyed by.
+        let stream_id = dc.stream_id;
+        let (label, protocol) = (dc.label.clone(), dc.protocol.clone());
+
         self.stats.peer_connection.on_data_channel_opened();
         self.stats
-            .get_or_create_data_channel(id, &dc.label, &dc.protocol)
+            .get_or_create_data_channel(id, &label, &protocol)
             .on_state_changed(RTCDataChannelState::Open);
+        if let Some(stream_id) = stream_id {
+            self.stats.set_data_channel_stream_id(id, stream_id);
+        }
         Ok(())
     }
 }
@@ -131,7 +153,10 @@ impl<'a>
             let stream_id = message.stream_id;
             let transport = msg.transport;
 
-            let opened = if let Some(data_channel_internal) = self.data_channels.get_mut(&stream_id)
+            // SCTP addresses channels by stream id; everything leaving this handler towards
+            // the application is keyed by handle instead.
+            let opened = if let Some(data_channel_internal) =
+                self.data_channels.get_by_stream_mut(&stream_id)
             {
                 // A closed channel is terminal: ignore any late DCEP or user data.
                 if data_channel_internal.ready_state == RTCDataChannelState::Closed {
@@ -163,20 +188,26 @@ impl<'a>
                     &message.payload,
                 )?;
 
-                self.data_channels
-                    .insert(message.stream_id, data_channel_internal);
+                self.data_channels.insert(data_channel_internal);
                 true
             };
 
+            // From here on the channel is addressed by handle, which is what the application
+            // and every event it receives use.
+            let channel_id = self
+                .data_channels
+                .handle_of_stream(&stream_id)
+                .ok_or(Error::ErrDataChannelNotExisted)?;
+
             if opened {
-                self.emit_data_channel_opened(now, transport, stream_id)?;
+                self.emit_data_channel_opened(now, transport, channel_id)?;
             }
 
             // Get label/protocol before taking mutable borrow for the loop
             let (label, protocol) = {
                 let dc = self
                     .data_channels
-                    .get(&stream_id)
+                    .get(&channel_id)
                     .ok_or(Error::ErrDataChannelNotExisted)?;
                 (dc.label.clone(), dc.protocol.clone())
             };
@@ -187,12 +218,12 @@ impl<'a>
             // discarded on close/timeout.
             let is_open = self
                 .data_channels
-                .get(&stream_id)
+                .get(&channel_id)
                 .is_some_and(|dc| dc.ready_state == RTCDataChannelState::Open);
 
             let data_channel = self
                 .data_channels
-                .get_mut(&stream_id)
+                .get_mut(&channel_id)
                 .ok_or(Error::ErrDataChannelNotExisted)?
                 .data_channel
                 .as_mut()
@@ -205,7 +236,7 @@ impl<'a>
 
                     // Track received message stats
                     self.stats
-                        .get_or_create_data_channel(stream_id, &label, &protocol)
+                        .get_or_create_data_channel(channel_id, &label, &protocol)
                         .on_message_received(payload_len);
 
                     // https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-12#section-6.6
@@ -227,7 +258,7 @@ impl<'a>
                         transport: msg.transport,
                         message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
                             ApplicationMessage {
-                                data_channel_id: stream_id,
+                                data_channel_id: channel_id,
                                 data_channel_event: DataChannelEvent::Message(
                                     RTCDataChannelMessage {
                                         is_string: matches!(
@@ -347,6 +378,13 @@ impl<'a>
         let now = evt.now;
         match evt.event {
             RTCEventInternal::SCTPHandshakeComplete(association_handle) => {
+                // The W3C "RTCSctpTransport connected procedure": the association is up, so
+                // the DTLS role is resolved and the negotiated stream count is known. This is
+                // the first moment a stream id can be chosen correctly, and therefore the
+                // moment it is chosen at all (RFC 8832 §6).
+                self.data_channels
+                    .assign_stream_ids(self.dtls_role, self.max_channels)?;
+
                 // Out-of-band negotiated channels have no DCEP handshake, so they are
                 // open immediately and fire the open event here. In-band channels stay
                 // connecting until their `DATA_CHANNEL_ACK` arrives in `handle_read`.
@@ -393,13 +431,16 @@ impl<'a>
             }
 
             RTCEventInternal::SCTPStreamClosed(_association_handle, stream_id) => {
-                if let Some(dc) = self.data_channels.remove(&stream_id) {
+                if let Some(dc) = self.data_channels.remove_by_stream(&stream_id) {
+                    // The event names the channel by handle, as every application-facing
+                    // event does; the stream id was only how SCTP referred to it.
+                    let channel_id = dc.id;
                     // A channel already closed by handshake timeout has already fired OnClose
                     // and been counted; do not emit or count it twice.
                     if !dc.close_emitted {
                         // Track data channel closed
                         self.stats.peer_connection.on_data_channel_closed();
-                        if let Some(dc_stats) = self.stats.data_channels.get_mut(&stream_id) {
+                        if let Some(dc_stats) = self.stats.data_channels.get_mut(&channel_id) {
                             dc_stats.on_state_changed(RTCDataChannelState::Closed);
                         }
 
@@ -407,7 +448,7 @@ impl<'a>
                             now,
                             event: RTCEventInternal::RTCPeerConnectionEvent(
                                 RTCPeerConnectionEvent::OnDataChannel(
-                                    RTCDataChannelEvent::OnClose(stream_id),
+                                    RTCDataChannelEvent::OnClose(channel_id),
                                 ),
                             ),
                         });
@@ -419,10 +460,39 @@ impl<'a>
                 // Pure accounting: SCTP released (acked or abandoned) `n_bytes` of
                 // this channel's outgoing buffer. Decrement the synchronous send
                 // back-pressure counter; do NOT forward the event further.
-                if let Some(dc) = self.data_channels.get_mut(&stream_id) {
+                if let Some(dc) = self.data_channels.get_by_stream_mut(&stream_id) {
                     dc.outstanding_bytes = dc.outstanding_bytes.saturating_sub(n_bytes);
                 }
             }
+            // The SCTP layer knows only stream ids; the application-facing events name the
+            // channel by handle, like every other event it receives. This is the layer that
+            // owns the mapping, so the translation happens here.
+            RTCEventInternal::SCTPBufferedAmountLow(_association_handle, stream_id) => {
+                if let Some(channel_id) = self.data_channels.handle_of_stream(&stream_id) {
+                    self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                        now,
+                        event: RTCEventInternal::RTCPeerConnectionEvent(
+                            RTCPeerConnectionEvent::OnDataChannel(
+                                RTCDataChannelEvent::OnBufferedAmountLow(channel_id),
+                            ),
+                        ),
+                    });
+                }
+            }
+
+            RTCEventInternal::SCTPBufferedAmountHigh(_association_handle, stream_id) => {
+                if let Some(channel_id) = self.data_channels.handle_of_stream(&stream_id) {
+                    self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                        now,
+                        event: RTCEventInternal::RTCPeerConnectionEvent(
+                            RTCPeerConnectionEvent::OnDataChannel(
+                                RTCDataChannelEvent::OnBufferedAmountHigh(channel_id),
+                            ),
+                        ),
+                    });
+                }
+            }
+
             // Events propagate rather than being re-stamped: the forwarded event keeps the
             // instant at which its condition was observed, not the instant this hop ran.
             event => {
@@ -513,34 +583,44 @@ mod tests {
     use datachannel::message::Message;
     use datachannel::message::message_channel_ack::DataChannelAck;
     use sansio::Protocol;
+    use sctp::StreamId;
     use shared::marshal::Marshal;
 
-    fn in_band_channel(id: u16) -> RTCDataChannelInternal {
-        RTCDataChannelInternal::new(
-            id,
-            DataChannelParameters {
-                label: "timing-test".to_string(),
-                protocol: String::new(),
-                ordered: true,
-                max_packet_life_time: None,
-                max_retransmits: None,
-                negotiated: None,
-            },
-        )
+    /// An in-band channel that already has its stream id, i.e. one past the point where
+    /// `assign_stream_ids` would have run. These tests are about DCEP open/ack timing, not
+    /// about stream-id assignment.
+    fn in_band_channel(stream_id: StreamId) -> RTCDataChannelInternal {
+        let mut dc = RTCDataChannelInternal::new(DataChannelParameters {
+            label: "timing-test".to_string(),
+            protocol: String::new(),
+            ordered: true,
+            max_packet_life_time: None,
+            max_retransmits: None,
+            negotiated: None,
+        });
+        dc.stream_id = Some(stream_id);
+        dc
     }
 
-    fn negotiated_channel(id: u16) -> RTCDataChannelInternal {
-        RTCDataChannelInternal::new(
-            id,
-            DataChannelParameters {
-                label: "timing-test".to_string(),
-                protocol: String::new(),
-                ordered: true,
-                max_packet_life_time: None,
-                max_retransmits: None,
-                negotiated: Some(id),
-            },
-        )
+    fn negotiated_channel(stream_id: StreamId) -> RTCDataChannelInternal {
+        RTCDataChannelInternal::new(DataChannelParameters {
+            label: "timing-test".to_string(),
+            protocol: String::new(),
+            ordered: true,
+            max_packet_life_time: None,
+            max_retransmits: None,
+            negotiated: Some(stream_id),
+        })
+    }
+
+    /// A registry seeded with `channels`, returning it alongside their handles in the order
+    /// given.
+    fn registry(
+        channels: Vec<RTCDataChannelInternal>,
+    ) -> (DataChannelRegistry, Vec<RTCDataChannelId>) {
+        let mut reg = DataChannelRegistry::new();
+        let handles = channels.into_iter().map(|dc| reg.insert(dc)).collect();
+        (reg, handles)
     }
 
     fn ack(association_handle: usize, stream_id: u16) -> DataChannelMessage {
@@ -586,13 +666,19 @@ mod tests {
     fn in_band_channel_fires_open_only_when_ack_is_processed() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
+        let (mut data_channels, handles) = registry(vec![in_band_channel(1)]);
+        let handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -601,7 +687,7 @@ mod tests {
                 .unwrap();
         }
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = data_channels.get(&handle).unwrap();
         assert!(
             dc.data_channel.is_some(),
             "SCTPHandshakeComplete must dial the in-band channel"
@@ -621,8 +707,14 @@ mod tests {
         );
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -633,12 +725,12 @@ mod tests {
         }
 
         assert_eq!(
-            data_channels.get(&1).unwrap().ready_state,
+            data_channels.get(&handle).unwrap().ready_state,
             RTCDataChannelState::Open,
             "ready_state flips to Open exactly when the ACK is processed"
         );
 
-        let open_events: Vec<u16> = ctx
+        let open_events: Vec<RTCDataChannelId> = ctx
             .read_outs
             .iter()
             .filter_map(|m| match &m.message {
@@ -652,7 +744,7 @@ mod tests {
             .collect();
         assert_eq!(
             open_events,
-            vec![1],
+            vec![handle],
             "exactly one open event, fired on the ACK"
         );
         assert_eq!(
@@ -667,11 +759,18 @@ mod tests {
     fn negotiated_channel_fires_open_at_handshake_complete() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, negotiated_channel(1));
+        let (mut data_channels, handles) = registry(vec![negotiated_channel(1)]);
+        let handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = DataChannelHandler::new(
+            &mut ctx,
+            &mut data_channels,
+            &mut stats,
+            None,
+            RTCDtlsRole::Server,
+            None,
+        );
         handler
             .handle_event(TaggedRTCEventInternal {
                 now,
@@ -679,7 +778,7 @@ mod tests {
             })
             .unwrap();
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = data_channels.get(&handle).unwrap();
         assert_eq!(
             dc.ready_state,
             RTCDataChannelState::Open,
@@ -690,7 +789,7 @@ mod tests {
             "a negotiated channel has no DCEP handshake deadline"
         );
 
-        let open_events: Vec<u16> = ctx
+        let open_events: Vec<RTCDataChannelId> = ctx
             .read_outs
             .iter()
             .filter_map(|m| match &m.message {
@@ -704,7 +803,7 @@ mod tests {
             .collect();
         assert_eq!(
             open_events,
-            vec![1],
+            vec![handle],
             "exactly one open event at SCTPHandshakeComplete for a negotiated channel"
         );
         assert_eq!(
@@ -718,10 +817,17 @@ mod tests {
     fn emit_data_channel_opened_missing_channel_returns_error() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
+        let mut data_channels = DataChannelRegistry::new();
         let mut stats = RTCStatsAccumulator::new();
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = DataChannelHandler::new(
+            &mut ctx,
+            &mut data_channels,
+            &mut stats,
+            None,
+            RTCDtlsRole::Server,
+            None,
+        );
         let err = handler
             .emit_data_channel_opened(now, TransportContext::default(), 99)
             .unwrap_err();
@@ -735,14 +841,20 @@ mod tests {
     fn sctp_handshake_complete_does_not_redial() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
+        let (mut data_channels, handles) = registry(vec![in_band_channel(1)]);
+        let _handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
         // Fire SCTPHandshakeComplete once; this dials the channel and queues its OPEN.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -759,8 +871,14 @@ mod tests {
 
         // Fire it again: no new dial, so nothing new is queued.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -781,13 +899,20 @@ mod tests {
     fn ack_on_closed_channel_is_ignored() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
         let mut dc = in_band_channel(1);
         dc.ready_state = RTCDataChannelState::Closed;
-        data_channels.insert(1, dc);
+        let (mut data_channels, handles) = registry(vec![dc]);
+        let handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
-        let mut handler = DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+        let mut handler = DataChannelHandler::new(
+            &mut ctx,
+            &mut data_channels,
+            &mut stats,
+            None,
+            RTCDtlsRole::Server,
+            None,
+        );
         handler
             .handle_read(TaggedRTCMessageInternal {
                 now,
@@ -797,7 +922,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            data_channels.get(&1).unwrap().ready_state,
+            data_channels.get(&handle).unwrap().ready_state,
             RTCDataChannelState::Closed,
             "a closed channel must ignore a late ACK"
         );
@@ -816,14 +941,20 @@ mod tests {
         let now = Instant::now();
         let timeout = Duration::from_millis(100);
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
+        let (mut data_channels, handles) = registry(vec![in_band_channel(1)]);
+        let handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
         // Dial the in-band channel and arm a deadline.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -834,8 +965,14 @@ mod tests {
 
         // A deadline must be reported.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             let deadline = handler
                 .poll_timeout()
                 .expect("a dialed in-band channel must have a deadline");
@@ -845,12 +982,18 @@ mod tests {
         // Advance past the deadline and let handle_timeout fire.
         let later = now + timeout + Duration::from_secs(1);
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             handler.handle_timeout(later).unwrap();
         }
 
-        let dc = data_channels.get(&1).unwrap();
+        let dc = data_channels.get(&handle).unwrap();
         assert_eq!(
             dc.ready_state,
             RTCDataChannelState::Closed,
@@ -874,8 +1017,8 @@ mod tests {
                 matches!(
                     &e.event,
                     RTCEventInternal::RTCPeerConnectionEvent(
-                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(1))
-                    )
+                        RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(id))
+                    ) if *id == handle
                 )
             })
             .count();
@@ -886,8 +1029,14 @@ mod tests {
 
         // No further deadlines remain.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             assert!(
                 handler.poll_timeout().is_none(),
                 "no deadline after the timeout fired"
@@ -901,14 +1050,20 @@ mod tests {
     fn pre_open_data_is_buffered_until_open() {
         let now = Instant::now();
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
+        let (mut data_channels, handles) = registry(vec![in_band_channel(1)]);
+        let _handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
         // Dial first.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -919,8 +1074,14 @@ mod tests {
 
         // A user data message arrives while the channel is still Connecting.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -943,8 +1104,14 @@ mod tests {
         // The ACK arrives: the channel opens and the buffered message is delivered,
         // with the open event first.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, None);
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                None,
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -972,13 +1139,19 @@ mod tests {
         let now = Instant::now();
         let timeout = Duration::from_millis(100);
         let mut ctx = DataChannelHandlerContext::new(now);
-        let mut data_channels = HashMap::new();
-        data_channels.insert(1, in_band_channel(1));
+        let (mut data_channels, handles) = registry(vec![in_band_channel(1)]);
+        let _handle = handles[0];
         let mut stats = RTCStatsAccumulator::new();
 
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_event(TaggedRTCEventInternal {
                     now,
@@ -989,8 +1162,14 @@ mod tests {
 
         // Buffer a user message while Connecting.
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             handler
                 .handle_read(TaggedRTCMessageInternal {
                     now,
@@ -1005,8 +1184,14 @@ mod tests {
         // Time out; the channel closes and the buffered message must not be delivered.
         let later = now + timeout + Duration::from_secs(1);
         {
-            let mut handler =
-                DataChannelHandler::new(&mut ctx, &mut data_channels, &mut stats, Some(timeout));
+            let mut handler = DataChannelHandler::new(
+                &mut ctx,
+                &mut data_channels,
+                &mut stats,
+                Some(timeout),
+                RTCDtlsRole::Server,
+                None,
+            );
             handler.handle_timeout(later).unwrap();
         }
 

--- a/src/peer_connection/handler/endpoint.rs
+++ b/src/peer_connection/handler/endpoint.rs
@@ -1,3 +1,4 @@
+use crate::data_channel::RTCDataChannelId;
 use crate::data_channel::message::RTCDataChannelMessage;
 use crate::peer_connection::event::RTCPeerConnectionEvent;
 use crate::peer_connection::event::data_channel_event::RTCDataChannelEvent;
@@ -236,7 +237,7 @@ impl<'a> EndpointHandler<'a> {
         &mut self,
         now: Instant,
         transport_context: TransportContext,
-        data_channel_id: u16,
+        data_channel_id: RTCDataChannelId,
     ) -> Result<()> {
         debug!("data channel is open for {:?}", transport_context);
         self.ctx.event_outs.push_back(TaggedRTCEventInternal {
@@ -253,7 +254,7 @@ impl<'a> EndpointHandler<'a> {
         &mut self,
         now: Instant,
         transport_context: TransportContext,
-        data_channel_id: u16,
+        data_channel_id: RTCDataChannelId,
     ) -> Result<()> {
         debug!("data channel is close for {:?}", transport_context);
         self.ctx.event_outs.push_back(TaggedRTCEventInternal {
@@ -270,7 +271,7 @@ impl<'a> EndpointHandler<'a> {
         &mut self,
         now: Instant,
         transport_context: TransportContext,
-        data_channel_id: u16,
+        data_channel_id: RTCDataChannelId,
         data_channel_message: RTCDataChannelMessage,
     ) -> Result<()> {
         debug!("data channel recv message for {:?}", transport_context);

--- a/src/peer_connection/handler/mod.rs
+++ b/src/peer_connection/handler/mod.rs
@@ -196,11 +196,18 @@ impl RTCPeerConnection {
     }
 
     pub(crate) fn get_datachannel_handler(&mut self) -> DataChannelHandler<'_> {
+        // Read the Copy values before `&mut self.data_channels` borrows self mutably. The
+        // handler needs the DTLS role to give stream ids the parity RFC 8832 §6 requires, and
+        // the negotiated stream count to bound them.
+        let dtls_role = self.dtls_transport().role();
+        let max_channels = self.sctp_transport().max_channels();
         DataChannelHandler::new(
             &mut self.pipeline_context.datachannel_handler_context,
             &mut self.data_channels,
             &mut self.pipeline_context.stats,
             self.setting_engine.data_channel.dcep_handshake_timeout,
+            dtls_role,
+            max_channels,
         )
     }
 

--- a/src/peer_connection/handler/sctp.rs
+++ b/src/peer_connection/handler/sctp.rs
@@ -1,5 +1,3 @@
-use crate::peer_connection::event::RTCPeerConnectionEvent;
-use crate::peer_connection::event::data_channel_event::RTCDataChannelEvent;
 use crate::peer_connection::event::{RTCEventInternal, TaggedRTCEventInternal};
 use crate::peer_connection::message::internal::{
     DTLSMessage, RTCMessageInternal, TaggedRTCMessageInternal,
@@ -400,11 +398,7 @@ impl<'a>
                                 );
                                 self.ctx.event_outs.push_back(TaggedRTCEventInternal {
                                     now,
-                                    event: RTCEventInternal::RTCPeerConnectionEvent(
-                                        RTCPeerConnectionEvent::OnDataChannel(
-                                            RTCDataChannelEvent::OnBufferedAmountLow(id),
-                                        ),
-                                    ),
+                                    event: RTCEventInternal::SCTPBufferedAmountLow(ch.0, id),
                                 });
                             }
                             Event::Stream(StreamEvent::BufferedAmountHigh { id }) => {
@@ -414,11 +408,7 @@ impl<'a>
                                 );
                                 self.ctx.event_outs.push_back(TaggedRTCEventInternal {
                                     now,
-                                    event: RTCEventInternal::RTCPeerConnectionEvent(
-                                        RTCPeerConnectionEvent::OnDataChannel(
-                                            RTCDataChannelEvent::OnBufferedAmountHigh(id),
-                                        ),
-                                    ),
+                                    event: RTCEventInternal::SCTPBufferedAmountHigh(ch.0, id),
                                 });
                             }
                             Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) => {

--- a/src/peer_connection/internal.rs
+++ b/src/peer_connection/internal.rs
@@ -16,7 +16,6 @@ use crate::peer_connection::transport::ice::candidate::{
     RTCIceCandidate, rtc_ice_candidates_from_ice_candidates,
 };
 use crate::peer_connection::transport::ice::candidate_type::RTCIceCandidateType;
-use crate::peer_connection::transport::sctp::SCTP_MAX_CHANNELS;
 use crate::peer_connection::transport::{RTCTransportId, TransportKind};
 use crate::rtp_transceiver::rtp_sender::RTCRtpCodec;
 use crate::rtp_transceiver::rtp_sender::rtp_coding_parameters::{
@@ -186,7 +185,7 @@ impl RTCPeerConnection {
             peer_connection_state: RTCPeerConnectionState::New,
             can_trickle_ice_candidates: None,
             pipeline_context,
-            data_channels: HashMap::new(),
+            data_channels: DataChannelRegistry::new(),
             rtp_transceivers: Vec::new(),
             greater_mid: -1,
             sdp_origin: Origin::default(),
@@ -989,33 +988,6 @@ impl RTCPeerConnection {
         self.pipeline_context.event_outs.push_back(
             RTCPeerConnectionEvent::OnConnectionStateChangeEvent(connection_state),
         );
-    }
-
-    pub(crate) fn generate_data_channel_id(&self) -> Result<RTCDataChannelId> {
-        let mut id = 0u16;
-        if self.dtls_transport().role() != RTCDtlsRole::Client {
-            id += 1;
-        }
-
-        // Create map of ids so we can compare without double-looping each time.
-        let ids: HashSet<RTCDataChannelId> = self.data_channels.keys().cloned().collect();
-        // The negotiated stream count bounds data channel ids, but only once it is known: a
-        // channel may be created before the association exists, and until it connects there is
-        // nothing to bound against. This matches W3C §6.1.1.3, which applies the limit at the
-        // connected procedure rather than at creation.
-        let max = self
-            .sctp_transport()
-            .max_channels()
-            .unwrap_or(SCTP_MAX_CHANNELS);
-        while id < max.saturating_sub(1) {
-            if ids.contains(&id) {
-                id += 2;
-            } else {
-                return Ok(id);
-            }
-        }
-
-        Err(Error::ErrMaxDataChannelID)
     }
 
     /// Called by the public `RTCRtpTransceiver::set_direction` when a transceiver's preferred

--- a/src/peer_connection/mod.rs
+++ b/src/peer_connection/mod.rs
@@ -253,6 +253,7 @@ pub mod transport;
 
 use crate::data_channel::init::RTCDataChannelInit;
 use crate::data_channel::parameters::DataChannelParameters;
+use crate::data_channel::registry::DataChannelRegistry;
 use crate::data_channel::state::RTCDataChannelState;
 use crate::data_channel::{RTCDataChannel, RTCDataChannelId, internal::RTCDataChannelInternal};
 use crate::media_stream::track::MediaStreamTrack;
@@ -316,7 +317,6 @@ use ice::candidate::{Candidate, unmarshal_candidate};
 use interceptor::{Interceptor, Registry};
 use shared::error::{Error, Result};
 use shared::util::math_rand_alpha;
-use std::collections::HashMap;
 use std::time::Instant;
 
 /// Builder for creating RTCPeerConnection instances.
@@ -687,7 +687,7 @@ pub struct RTCPeerConnection {
     // PeerConnection Internal State Machine
     //////////////////////////////////////////////////
     pub(crate) pipeline_context: PipelineContext,
-    pub(crate) data_channels: HashMap<RTCDataChannelId, RTCDataChannelInternal>,
+    pub(crate) data_channels: DataChannelRegistry,
     pub(super) rtp_transceivers: Vec<RTCRtpTransceiverInternal>,
 
     greater_mid: isize,
@@ -1853,8 +1853,6 @@ impl RTCPeerConnection {
             ..Default::default()
         };
 
-        let mut id = self.generate_data_channel_id()?;
-
         // `None` means "the dictionary defaults", which is what `RTCDataChannelInit::default()`
         // spells out. Taking that route rather than leaving `params` on its derived default
         // keeps a single definition of those defaults — notably `ordered`, which is `true`.
@@ -1885,29 +1883,52 @@ impl RTCPeerConnection {
         }
 
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #12)
+        //
+        // `negotiated` doubles as the out-of-band stream id. When it is set the id is fixed by
+        // the application and known now; when it is not, the channel is announced in-band and
+        // its stream id has to wait for the DTLS role, per RFC 8832 §6. Nothing is guessed
+        // here — see `assign_stream_ids`.
         params.negotiated = options.negotiated;
 
-        if let Some(negotiated_id) = &params.negotiated {
-            id = *negotiated_id;
-        }
-
-        let mut data_channel = RTCDataChannelInternal::new(id, params);
+        // The registry assigns the handle. Note this happens before any dial: the channel is
+        // addressable from the moment it exists, whether or not it has a stream id yet.
+        let id = self
+            .data_channels
+            .insert(RTCDataChannelInternal::new(params));
 
         // https://w3c.github.io/webrtc-pc/#peer-to-peer-data-api (Step #23)
-        // Open the channel's data transport immediately when an SCTP association already exists.
+        // Open the channel's data transport immediately when an SCTP association already
+        // exists. The DTLS role is necessarily resolved by then, so a stream id can be
+        // assigned right here rather than waiting for a connected procedure that has passed.
+        //
+        // The role guard is not redundant with the association check. In practice an
+        // association only exists once a description has been applied, which resolves the
+        // role — but if it somehow is not resolved, there is no correct parity to pick, and
+        // "wait for the connected procedure" is the right answer rather than an error. That is
+        // the ordinary path for every channel created before negotiation.
+        let dtls_role = self.dtls_transport().role();
         if let Some(handle) = self
             .sctp_transport()
             .sctp_associations
             .keys()
             .next()
             .copied()
-            && data_channel.ready_state == RTCDataChannelState::Connecting
-            && data_channel.data_channel.is_none()
+            && matches!(dtls_role, RTCDtlsRole::Client | RTCDtlsRole::Server)
         {
-            data_channel.dial(handle.0)?;
-        }
+            let max_channels = self.sctp_transport().max_channels();
+            self.data_channels
+                .assign_stream_ids(dtls_role, max_channels)?;
 
-        self.data_channels.insert(id, data_channel);
+            let data_channel = self
+                .data_channels
+                .get_mut(&id)
+                .ok_or(Error::ErrDataChannelNotExisted)?;
+            if data_channel.ready_state == RTCDataChannelState::Connecting
+                && data_channel.data_channel.is_none()
+            {
+                data_channel.dial(handle.0)?;
+            }
+        }
 
         self.trigger_negotiation_needed();
 
@@ -2195,7 +2216,7 @@ impl RTCPeerConnection {
 
     /// data_channel provides the access to RTCDataChannel object with the given id
     pub fn data_channel(&mut self, id: RTCDataChannelId) -> Option<RTCDataChannel<'_>> {
-        if self.data_channels.contains_key(&id) {
+        if self.data_channels.contains(&id) {
             Some(RTCDataChannel {
                 id,
                 peer_connection: self,
@@ -2623,7 +2644,11 @@ mod tests {
             .unwrap();
 
         // Simulate an SCTP association so create_data_channel sees a transport
-        // that is ready to open streams.
+        // that is ready to open streams, and the resolved DTLS role that always accompanies
+        // one in practice — the association is built by `SCTPTransport::start`, which runs
+        // after `prepare_transport` has settled the role. Without it there is no correct
+        // stream-id parity to pick and the channel would rightly defer (RFC 8832 §6).
+        pc.dtls_transport_mut().dtls_role = RTCDtlsRole::Client;
         pc.sctp_transport_mut()
             .sctp_associations
             .insert(AssociationHandle(0), sctp::Association::default());
@@ -2640,6 +2665,34 @@ mod tests {
             internal.ready_state,
             RTCDataChannelState::Connecting,
             "a dialed in-band channel stays Connecting until its DATA_CHANNEL_ACK arrives"
+        );
+        assert_eq!(
+            internal.stream_id,
+            Some(0),
+            "the DTLS client must take an even stream id (RFC 8832 §6)"
+        );
+    }
+
+    /// The mirror of the case above: with no resolved DTLS role there is no correct parity, so
+    /// the channel is created without a stream id and waits for the connected procedure rather
+    /// than being dialed or rejected.
+    #[test]
+    fn create_data_channel_defers_stream_id_when_dtls_role_unresolved() {
+        let mut pc = RTCPeerConnectionBuilder::new()
+            .build(Instant::now())
+            .unwrap();
+        pc.sctp_transport_mut()
+            .sctp_associations
+            .insert(AssociationHandle(0), sctp::Association::default());
+
+        let dc = pc.create_data_channel("test", None).unwrap();
+        let id = dc.id();
+
+        let internal = pc.data_channels.get(&id).unwrap();
+        assert_eq!(internal.stream_id, None, "no parity is knowable yet");
+        assert!(
+            internal.data_channel.is_none(),
+            "a channel with no stream id cannot be dialed"
         );
     }
 

--- a/src/statistics/accumulator/data_channel.rs
+++ b/src/statistics/accumulator/data_channel.rs
@@ -3,6 +3,7 @@
 use crate::data_channel::RTCDataChannelState;
 use crate::statistics::stats::data_channel::RTCDataChannelStats;
 use crate::statistics::stats::{RTCStats, RTCStatsType};
+use sctp::StreamId;
 use shared::time::SystemInstant;
 use std::time::Instant;
 
@@ -11,8 +12,8 @@ use std::time::Instant;
 /// This struct tracks message/byte counters and state for a data channel.
 #[derive(Debug, Default)]
 pub struct DataChannelStatsAccumulator {
-    /// The data channel identifier.
-    pub data_channel_identifier: u16,
+    /// The SCTP stream identifier, or 0 while the channel has not been assigned one.
+    pub data_channel_identifier: StreamId,
     /// The label assigned to the data channel.
     pub label: String,
     /// The sub-protocol name.

--- a/src/statistics/accumulator/mod.rs
+++ b/src/statistics/accumulator/mod.rs
@@ -34,6 +34,7 @@ use crate::rtp_transceiver::{PayloadType, RTCRtpTransceiverId, SSRC};
 use crate::statistics::StatsSelector;
 use crate::statistics::report::{RTCStatsReport, RTCStatsReportEntry};
 use ice::CandidatePairStats;
+use sctp::StreamId;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -510,11 +511,26 @@ impl RTCStatsAccumulator {
         self.data_channels
             .entry(id)
             .or_insert_with(|| DataChannelStatsAccumulator {
-                data_channel_identifier: id,
+                // The wire value is filled in by `set_data_channel_stream_id` once the SCTP
+                // connected procedure assigns one; the map itself is keyed by handle, so an
+                // accumulator can exist before then.
+                data_channel_identifier: 0,
                 label: label.to_string(),
                 protocol: protocol.to_string(),
                 ..Default::default()
             })
+    }
+
+    /// Records the SCTP stream identifier a data channel was assigned.
+    ///
+    /// The accumulator is keyed by the channel's handle, which exists from creation, but
+    /// `data_channel_identifier` is the W3C-defined *wire* value and is only known once the
+    /// SCTP connected procedure assigns one (RFC 8832 section 6). This fills it in at that
+    /// point; until then it reads 0.
+    pub(crate) fn set_data_channel_stream_id(&mut self, id: RTCDataChannelId, stream_id: StreamId) {
+        if let Some(dc) = self.data_channels.get_mut(&id) {
+            dc.data_channel_identifier = stream_id;
+        }
     }
 
     /// Gets or creates an ICE candidate pair accumulator.

--- a/src/statistics/stats/data_channel.rs
+++ b/src/statistics/stats/data_channel.rs
@@ -5,6 +5,7 @@
 
 use super::RTCStats;
 use crate::data_channel::RTCDataChannelState;
+use sctp::StreamId;
 use serde::{Deserialize, Serialize};
 
 /// Statistics for a data channel.
@@ -25,8 +26,10 @@ pub struct RTCDataChannelStats {
 
     /// The data channel identifier.
     ///
-    /// This is the SCTP stream ID used for this data channel.
-    pub data_channel_identifier: u16,
+    /// This is the SCTP stream ID used for this data channel. It is 0 while the channel has
+    /// not been assigned one, which per RFC 8832 section 6 cannot happen before the DTLS role
+    /// is resolved.
+    pub data_channel_identifier: StreamId,
 
     /// The label assigned to the data channel.
     ///

--- a/tests/data_channel_backpressure_rtc2rtc.rs
+++ b/tests/data_channel_backpressure_rtc2rtc.rs
@@ -124,10 +124,17 @@ async fn test_slow_consumer_throttles_the_peer_without_losing_data() -> Result<(
         negotiated: Some(NEGOTIATED_ID),
         ..Default::default()
     };
-    p.offer_pc
-        .create_data_channel("backpressure", Some(init.clone()))?;
-    p.answer_pc
-        .create_data_channel("backpressure", Some(init))?;
+    // `NEGOTIATED_ID` is the SCTP stream id the two sides agree on out-of-band. The handle
+    // returned here is a separate, connection-local identifier — it is what addresses the
+    // channel through `data_channel()` and what events carry.
+    let offer_dc = p
+        .offer_pc
+        .create_data_channel("backpressure", Some(init.clone()))?
+        .id();
+    let answer_dc = p
+        .answer_pc
+        .create_data_channel("backpressure", Some(init))?
+        .id();
 
     let offer = p.offer_pc.create_offer(None)?;
     p.offer_pc
@@ -189,7 +196,7 @@ async fn test_slow_consumer_throttles_the_peer_without_losing_data() -> Result<(
         if answerer_consuming {
             while let Some(TaggedRTCMessage { message, .. }) = p.answer_pc.poll_read() {
                 if let RTCMessage::DataChannelMessage(id, msg) = message {
-                    assert_eq!(id, NEGOTIATED_ID);
+                    assert_eq!(id, answer_dc);
                     let text = String::from_utf8_lossy(&msg.data);
                     let index: usize = text.parse().expect("message payload is its index");
                     received.push(index);
@@ -202,7 +209,7 @@ async fn test_slow_consumer_throttles_the_peer_without_losing_data() -> Result<(
         if offer_connected
             && dc_open
             && sent < MESSAGE_COUNT
-            && let Some(mut dc) = p.offer_pc.data_channel(NEGOTIATED_ID)
+            && let Some(mut dc) = p.offer_pc.data_channel(offer_dc)
             && dc.send_text(Instant::now(), sent.to_string()).is_ok()
         {
             sent += 1;

--- a/tests/data_channel_stream_id_parity.rs
+++ b/tests/data_channel_stream_id_parity.rs
@@ -29,6 +29,7 @@
 
 use anyhow::Result;
 use bytes::BytesMut;
+use rtc::data_channel::{RTCDataChannelId, StreamId};
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
 use rtc::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent};
@@ -96,15 +97,20 @@ fn parity_name(parity: u16) -> &'static str {
 }
 
 struct Outcome {
-    /// Stream ids each peer committed to at `create_data_channel` time.
-    offer_ids: Vec<u16>,
-    answer_ids: Vec<u16>,
+    /// The SCTP stream ids each peer ended up with, in creation order. `None` means the
+    /// channel never received one.
+    offer_ids: Vec<Option<StreamId>>,
+    answer_ids: Vec<Option<StreamId>>,
+    /// Whether every channel had `stream_id() == None` at creation time, i.e. whether
+    /// assignment was actually deferred rather than guessed.
+    offer_deferred: bool,
+    answer_deferred: bool,
     /// The DTLS role each peer negotiated, per its own transport stats.
     offer_role: RTCDtlsRole,
     answer_role: RTCDtlsRole,
-    /// Stream id -> label, for every channel each peer saw open.
-    offer_open: BTreeMap<u16, String>,
-    answer_open: BTreeMap<u16, String>,
+    /// Channel handle -> label, for every channel each peer saw open.
+    offer_open: BTreeMap<RTCDataChannelId, String>,
+    answer_open: BTreeMap<RTCDataChannelId, String>,
     connected: bool,
 }
 
@@ -139,20 +145,29 @@ async fn connect(offer_cfg: RTCDtlsRole, answer_cfg: RTCDtlsRole) -> Result<Outc
 
     // Both sides create channels while their DTLS role is still `Auto`. This is the
     // "both peers rapidly create data channels before the DTLS role is negotiated" case.
-    let mut offer_ids = Vec::new();
-    let mut answer_ids = Vec::new();
+    let mut offer_handles: Vec<RTCDataChannelId> = Vec::new();
+    let mut answer_handles: Vec<RTCDataChannelId> = Vec::new();
     for i in 0..CHANNELS_PER_PEER {
-        offer_ids.push(
+        offer_handles.push(
             offer_pc
                 .create_data_channel(&format!("offerer-{i}"), None)?
                 .id(),
         );
-        answer_ids.push(
+        answer_handles.push(
             answer_pc
                 .create_data_channel(&format!("answerer-{i}"), None)?
                 .id(),
         );
     }
+
+    // Before any SDP the DTLS role is unresolved, so RFC 8832 §6 supplies no parity and there
+    // is no correct stream id to hand out. W3C says the id "is initially null"; this is that.
+    let offer_deferred = offer_handles
+        .iter()
+        .all(|h| offer_pc.data_channel(*h).unwrap().stream_id().is_none());
+    let answer_deferred = answer_handles
+        .iter()
+        .all(|h| answer_pc.data_channel(*h).unwrap().stream_id().is_none());
 
     let offer = offer_pc.create_offer(None)?;
     offer_pc.set_local_description(Instant::now(), offer.clone())?;
@@ -161,8 +176,8 @@ async fn connect(offer_cfg: RTCDtlsRole, answer_cfg: RTCDtlsRole) -> Result<Outc
     answer_pc.set_local_description(Instant::now(), answer.clone())?;
     offer_pc.set_remote_description(Instant::now(), answer)?;
 
-    let mut offer_open: BTreeMap<u16, String> = BTreeMap::new();
-    let mut answer_open: BTreeMap<u16, String> = BTreeMap::new();
+    let mut offer_open: BTreeMap<RTCDataChannelId, String> = BTreeMap::new();
+    let mut answer_open: BTreeMap<RTCDataChannelId, String> = BTreeMap::new();
     let mut offer_connected = false;
     let mut answer_connected = false;
     // When both roles first became readable; starts the `CHANNEL_SETTLE` grace period.
@@ -298,12 +313,24 @@ async fn connect(offer_cfg: RTCDtlsRole, answer_cfg: RTCDtlsRole) -> Result<Outc
     let offer_role = negotiated_role(&mut offer_pc);
     let answer_role = negotiated_role(&mut answer_pc);
 
+    // The wire values, read back once the connected procedure has had its chance to assign.
+    let offer_ids = offer_handles
+        .iter()
+        .map(|h| offer_pc.data_channel(*h).and_then(|dc| dc.stream_id()))
+        .collect();
+    let answer_ids = answer_handles
+        .iter()
+        .map(|h| answer_pc.data_channel(*h).and_then(|dc| dc.stream_id()))
+        .collect();
+
     offer_pc.close().ok();
     answer_pc.close().ok();
 
     Ok(Outcome {
         offer_ids,
         answer_ids,
+        offer_deferred,
+        answer_deferred,
         offer_role,
         answer_role,
         offer_open,
@@ -322,18 +349,43 @@ fn violations(case: &str, out: &Outcome) -> Vec<String> {
         return failures;
     }
 
-    for (who, ids, role) in [
-        ("offerer", &out.offer_ids, out.offer_role),
-        ("answerer", &out.answer_ids, out.answer_role),
+    for (who, ids, role, deferred) in [
+        (
+            "offerer",
+            &out.offer_ids,
+            out.offer_role,
+            out.offer_deferred,
+        ),
+        (
+            "answerer",
+            &out.answer_ids,
+            out.answer_role,
+            out.answer_deferred,
+        ),
     ] {
+        if !deferred {
+            failures.push(format!(
+                "{case}: {who} assigned a stream id at create_data_channel time, before any \
+                 SDP fixed the DTLS role — W3C requires the id to be null until then"
+            ));
+        }
+
         if role == RTCDtlsRole::Unspecified {
             failures.push(format!(
                 "{case}: {who} never recorded a negotiated DTLS role"
             ));
             continue;
         }
+
+        if ids.iter().any(|id| id.is_none()) {
+            failures.push(format!(
+                "{case}: {who} left a channel without a stream id after connecting: {ids:?}"
+            ));
+            continue;
+        }
+
         let want = required_parity(role);
-        if ids.iter().any(|id| id % 2 != want) {
+        if ids.iter().flatten().any(|id| id % 2 != want) {
             failures.push(format!(
                 "{case}: {who} negotiated DTLS {role} so RFC 8832 §6 requires {} stream ids, \
                  but got {ids:?}",
@@ -355,8 +407,9 @@ fn violations(case: &str, out: &Outcome) -> Vec<String> {
         let collisions: Vec<_> = out
             .offer_ids
             .iter()
+            .flatten()
             .copied()
-            .filter(|id| out.answer_ids.contains(id))
+            .filter(|id| out.answer_ids.contains(&Some(*id)))
             .collect();
         if !collisions.is_empty() {
             failures.push(format!(
@@ -377,9 +430,7 @@ fn violations(case: &str, out: &Outcome) -> Vec<String> {
 /// uses odd ones, and the two sets are therefore disjoint. Runs all seven and reports every
 /// violation at once, so one run shows the whole shape of the bug rather than only the first
 /// case that trips.
-//TODO: https://github.com/webrtc-rs/rtc/issues/199
 #[tokio::test]
-#[ignore]
 async fn stream_id_parity_matches_negotiated_dtls_role_across_all_role_configurations() -> Result<()>
 {
     env_logger::builder()
@@ -436,9 +487,7 @@ async fn stream_id_parity_matches_negotiated_dtls_role_across_all_role_configura
 /// remote's `DATA_CHANNEL_OPEN` lands on a stream id a local channel already occupies, so the
 /// peer's channels are never surfaced as distinct channels and the expected label set never
 /// completes.
-//TODO: https://github.com/webrtc-rs/rtc/issues/199
 #[tokio::test]
-#[ignore]
 async fn colliding_stream_ids_prevent_both_peers_channels_from_opening() -> Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)

--- a/tests/data_channels_close_by_rtc_interop.rs
+++ b/tests/data_channels_close_by_rtc_interop.rs
@@ -18,6 +18,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
@@ -194,7 +195,7 @@ async fn test_data_channel_close_interop() -> Result<()> {
     let mut rtc_connected = false;
     let mut webrtc_connected = false;
     let mut rtc_data_channel_opened = false;
-    let mut rtc_dc_id: Option<u16> = None;
+    let mut rtc_dc_id: Option<RTCDataChannelId> = None;
     let mut last_message_time = Instant::now();
     let message_interval = Duration::from_millis(500); // Send every 500ms for testing
 

--- a/tests/data_channels_create_interop.rs
+++ b/tests/data_channels_create_interop.rs
@@ -19,6 +19,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
@@ -192,7 +193,7 @@ async fn test_data_channel_create_rtc_to_webrtc() -> Result<()> {
     let mut webrtc_connected = false;
     let mut message_sent = false;
     let mut rtc_data_channel_opened = false;
-    let mut rtc_dc_id: Option<u16> = None;
+    let mut rtc_dc_id: Option<RTCDataChannelId> = None;
 
     let test_message = "Hello from RTC!";
 

--- a/tests/data_channels_negotiated_rtc2rtc.rs
+++ b/tests/data_channels_negotiated_rtc2rtc.rs
@@ -142,12 +142,17 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
         negotiated: Some(NEGOTIATED_ID),
         ..Default::default()
     };
-    runner
+    // `NEGOTIATED_ID` is the SCTP stream id both sides agreed on out-of-band. The handles
+    // below are separate, connection-local identifiers: they are what `data_channel()` takes
+    // and what events carry, and the two peers' handles need not match each other.
+    let offer_dc = runner
         .offer_pc
-        .create_data_channel("negotiated", Some(init.clone()))?;
-    runner
+        .create_data_channel("negotiated", Some(init.clone()))?
+        .id();
+    let answer_dc = runner
         .answer_pc
-        .create_data_channel("negotiated", Some(init))?;
+        .create_data_channel("negotiated", Some(init))?
+        .id();
 
     // Exchange offer/answer
     let offer = runner.offer_pc.create_offer(None)?;
@@ -197,7 +202,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
                     RTCPeerConnectionState::Connected,
                 ) => offer_connected = true,
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
-                    assert_eq!(id, NEGOTIATED_ID, "offer opened unexpected channel id");
+                    assert_eq!(id, offer_dc, "offer opened unexpected channel id");
                     offer_dc_open = true;
                 }
                 _ => {}
@@ -211,7 +216,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
             ..
         }) = runner.offer_pc.poll_read()
         {
-            assert_eq!(id, NEGOTIATED_ID);
+            assert_eq!(id, offer_dc);
             offer_received.push(String::from_utf8_lossy(&msg.data).into_owned());
         }
 
@@ -230,7 +235,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
                     RTCPeerConnectionState::Connected,
                 ) => answer_connected = true,
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
-                    assert_eq!(id, NEGOTIATED_ID, "answer opened unexpected channel id");
+                    assert_eq!(id, answer_dc, "answer opened unexpected channel id");
                     answer_dc_open = true;
                 }
                 _ => {}
@@ -244,7 +249,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
             ..
         }) = runner.answer_pc.poll_read()
         {
-            assert_eq!(id, NEGOTIATED_ID);
+            assert_eq!(id, answer_dc);
             answer_received.push(String::from_utf8_lossy(&msg.data).into_owned());
         }
 
@@ -253,7 +258,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
         if offer_connected && offer_dc_open && offer_sent < OFFER_TO_ANSWER {
             let mut dc = runner
                 .offer_pc
-                .data_channel(NEGOTIATED_ID)
+                .data_channel(offer_dc)
                 .expect("negotiated channel must exist once open");
             dc.send_text(Instant::now(), format!("o2a-{offer_sent}"))?;
             offer_sent += 1;
@@ -261,7 +266,7 @@ async fn test_negotiated_data_channel_bidirectional_messaging() -> Result<()> {
         if answer_connected && answer_dc_open && answer_sent < ANSWER_TO_OFFER {
             let mut dc = runner
                 .answer_pc
-                .data_channel(NEGOTIATED_ID)
+                .data_channel(answer_dc)
                 .expect("negotiated channel must exist once open");
             dc.send_text(Instant::now(), format!("a2o-{answer_sent}"))?;
             answer_sent += 1;
@@ -377,12 +382,17 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
         negotiated: Some(NEGOTIATED_ID),
         ..Default::default()
     };
-    runner
+    // `NEGOTIATED_ID` is the SCTP stream id both sides agreed on out-of-band. The handles
+    // below are separate, connection-local identifiers: they are what `data_channel()` takes
+    // and what events carry, and the two peers' handles need not match each other.
+    let offer_dc = runner
         .offer_pc
-        .create_data_channel("negotiated", Some(init.clone()))?;
-    runner
+        .create_data_channel("negotiated", Some(init.clone()))?
+        .id();
+    let answer_dc = runner
         .answer_pc
-        .create_data_channel("negotiated", Some(init))?;
+        .create_data_channel("negotiated", Some(init))?
+        .id();
 
     let offer = runner.offer_pc.create_offer(None)?;
     runner
@@ -428,7 +438,7 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
                     RTCPeerConnectionState::Connected,
                 ) => offer_connected = true,
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
-                    assert_eq!(id, NEGOTIATED_ID);
+                    assert_eq!(id, offer_dc);
                     offer_dc_open = true;
                 }
                 _ => {}
@@ -449,7 +459,7 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
                     RTCPeerConnectionState::Connected,
                 ) => answer_connected = true,
                 RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnOpen(id)) => {
-                    assert_eq!(id, NEGOTIATED_ID);
+                    assert_eq!(id, answer_dc);
                     answer_dc_open = true;
                 }
                 _ => {}
@@ -460,7 +470,7 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
             ..
         }) = runner.answer_pc.poll_read()
         {
-            assert_eq!(id, NEGOTIATED_ID);
+            assert_eq!(id, answer_dc);
             received += msg.data.len();
         }
 
@@ -469,7 +479,7 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
         if offer_connected && offer_dc_open && !sent {
             let mut dc = runner
                 .offer_pc
-                .data_channel(NEGOTIATED_ID)
+                .data_channel(offer_dc)
                 .expect("negotiated channel must exist once open");
             assert_eq!(
                 dc.outstanding_bytes(),
@@ -489,7 +499,7 @@ async fn test_data_channel_outstanding_bytes_tracks_send_and_drains() -> Result<
         if sent {
             let outstanding = runner
                 .offer_pc
-                .data_channel(NEGOTIATED_ID)
+                .data_channel(offer_dc)
                 .map(|dc| dc.outstanding_bytes())
                 .unwrap_or(0);
             peak_outstanding = peak_outstanding.max(outstanding);

--- a/tests/ice_restart_by_rtc_interop.rs
+++ b/tests/ice_restart_by_rtc_interop.rs
@@ -14,6 +14,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, timeout};
 
+use rtc::data_channel::RTCDataChannelId;
 use rtc::peer_connection::RTCPeerConnectionBuilder;
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
 use rtc::peer_connection::configuration::setting_engine::SettingEngineBuilder;
@@ -168,7 +169,7 @@ async fn test_ice_restart_by_rtc_interop() -> Result<()> {
         let _ = rtc_pc.create_data_channel("test", None)?;
         log::info!("RTC: Created data channel");
 
-        let mut dc_id: Option<u16> = None;
+        let mut dc_id: Option<RTCDataChannelId> = None;
         let mut buf = vec![0u8; 8192];
         let mut write_buf = BytesMut::new();
 

--- a/tests/mdns_query_and_gather_interop.rs
+++ b/tests/mdns_query_and_gather_interop.rs
@@ -19,6 +19,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+use rtc::data_channel::RTCDataChannelId;
 use rtc::ice::mdns::MulticastDnsMode;
 use rtc::mdns::{MDNS_PORT, MulticastSocket};
 use rtc::peer_connection::configuration::RTCConfigurationBuilder;
@@ -129,12 +130,12 @@ async fn run_rtc_event_loop(
     local_addr: std::net::SocketAddr,
     rtc_received_messages: &Arc<Mutex<Vec<String>>>,
     echo_messages: bool,
-) -> Result<(bool, bool, Option<u16>)> {
+) -> Result<(bool, bool, Option<RTCDataChannelId>)> {
     let mut pc_buf = vec![0u8; 2000];
     let mut mdns_buf = vec![0u8; 2000];
     let mut rtc_connected = false;
     let mut data_channel_opened = false;
-    let mut data_channel_id: Option<u16> = None;
+    let mut data_channel_id: Option<RTCDataChannelId> = None;
 
     // Process writes - route to appropriate socket based on port
     while let Some(msg) = rtc_pc.poll_write() {


### PR DESCRIPTION
…(breaking API change) #199

```
The reproduction test data_channel_stream_id_parity.rs now passes, all 7 role configurations:

1. offer=Client answer=Server: client/server, ids [Some(0), Some(2)] / [Some(1), Some(3)], open 4/4
2. offer=Server answer=Client: server/client, ids [Some(1), Some(3)] / [Some(0), Some(2)], open 4/4
3. offer=Client answer=Auto  : server/client, ids [Some(1), Some(3)] / [Some(0), Some(2)], open 4/4
4. offer=Auto   answer=Server: client/server, ids [Some(0), Some(2)] / [Some(1), Some(3)], open 4/4
5. offer=Server answer=Auto  : server/client, ids [Some(1), Some(3)] / [Some(0), Some(2)], open 4/4
6. offer=Auto   answer=Client: server/client, ids [Some(1), Some(3)] / [Some(0), Some(2)], open 4/4
7. offer=Auto   answer=Auto  : server/client, ids [Some(1), Some(3)] / [Some(0), Some(2)], open 4/4
```