### PR TITLE
rtc-sctp: use RFC 9260 initial retransmission RTO

### DIFF
--- a/rtc-sctp/src/association/timer.rs
+++ b/rtc-sctp/src/association/timer.rs
@@ -10,7 +10,7 @@ const TIMER_COUNT: usize = 6;
 /// Retransmission limits for the association's timers.
 ///
 /// Each field caps how many times the corresponding timer may fire before the association is
-/// abandoned. `Default` follows the RFC 4960 recommendations.
+/// abandoned. `Default` follows the RFC 9260 recommendations.
 pub struct TimerConfig {
     /// How many times INIT may be retransmitted (T1-init) before the association fails.
     pub max_t1_init_retrans: usize,
@@ -138,7 +138,9 @@ impl TimerTable {
     }
 }
 
-const RTO_INITIAL: u64 = 3000; // msec
+// RFC 9260 §16 recommends a one-second initial RTO.  This value is used by
+// both T1-init and T1-cookie before an RTT measurement is available.
+const RTO_INITIAL: u64 = 1000; // msec
 const RTO_MIN: u64 = 1000; // msec
 const RTO_MAX: u64 = 60000; // msec
 const RTO_ALPHA: u64 = 1;
@@ -146,7 +148,7 @@ const RTO_BETA: u64 = 2;
 const RTO_BASE: u64 = 8;
 
 /// rtoManager manages Rtx timeout values.
-/// This is an implementation of RFC 4960 sec 6.3.1.
+/// This is an implementation of RFC 9260 sec 6.3.1.
 #[derive(Default, Debug)]
 pub(crate) struct RtoManager {
     pub(crate) srtt: u64,
@@ -220,5 +222,26 @@ fn calculate_next_timeout(rto: u64, n_rtos: usize) -> u64 {
         std::cmp::min(rto << n_rtos, RTO_MAX)
     } else {
         RTO_MAX
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rto_manager_uses_rfc9260_initial_rto() {
+        assert_eq!(RTO_INITIAL, 1000);
+        assert_eq!(RtoManager::new().get_rto(), RTO_INITIAL);
+    }
+
+    #[test]
+    fn t1_init_starts_at_initial_rto_before_an_rtt_is_measured() {
+        let now = Instant::now();
+        let mut timers = TimerTable::new(TimerConfig::default());
+
+        timers.start(Timer::T1Init, now, RtoManager::new().get_rto());
+
+        assert_eq!(timers.next_timeout(), Some(now + Duration::from_secs(1)));
     }
 }


### PR DESCRIPTION
## Summary

Update the SCTP initial retransmission timeout used by T1-init and T1-cookie from 3 seconds to 1 second, matching the RFC 9260 Section 16 recommendation.

When the first SCTP handshake packet or acknowledgement is delayed or lost, the previous 3-second T1 timer could exceed application-level WebRTC DataChannel readiness windows. This was observed on Android after background-to-foreground recovery: ICE connected successfully, but the peer was closed before the first SCTP retransmission, adding multiple connection attempts and approximately 13.95 seconds to the first RPC.

This change does not alter retransmission backoff or maximum retransmission limits.

## Changes

- Set `RTO_INITIAL` to 1000 ms.
- Update timer documentation to reference RFC 9260.
- Add unit tests covering the initial RTO and the first T1-init deadline.

The application-level readiness timeout is outside the scope of this PR; callers should still allow enough time for SCTP establishment.

Fixes #225.

## Validation

- `cargo fmt --all`
- `cargo clippy --fix --lib --bins --all-targets --allow-dirty`
- `cargo test -p rtc-sctp --lib -- --test-threads=1` (135 passed)
