### PR TITLE
fix 0.20 (sans-IO): TURN relayer consumes STUN Binding responses when…

### DIFF
--- a/rtc-turn/src/client/client_test.rs
+++ b/rtc-turn/src/client/client_test.rs
@@ -52,6 +52,33 @@ fn create_listening_test_client_with_stun_serv() -> Result<(UdpSocket, Client)> 
     Ok((udp_socket, client))
 }
 
+/// A host demultiplexing STUN on a socket it shares — a STUN gatherer and this client pointed at
+/// one server address — routes a response by transaction id, because nothing else identifies its
+/// owner. See webrtc-rs/webrtc#890.
+#[test]
+fn test_has_transaction_reports_outstanding_requests() -> Result<()> {
+    let (_conn, mut client) = create_listening_test_client(0)?;
+    let server = "127.0.0.1:3478".parse::<std::net::SocketAddr>().unwrap();
+
+    let unknown = TransactionId::new();
+    assert!(
+        !client.has_transaction(&unknown),
+        "a fresh client is waiting on nothing"
+    );
+
+    let tid = client.send_binding_request_to(Instant::now(), server)?;
+    assert!(
+        client.has_transaction(&tid),
+        "the transaction just started is outstanding"
+    );
+    assert!(
+        !client.has_transaction(&unknown),
+        "an id this client never sent is not its own"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_client_with_stun_send_binding_request() -> Result<()> {
     //env_logger::init();

--- a/rtc-turn/src/client/mod.rs
+++ b/rtc-turn/src/client/mod.rs
@@ -421,6 +421,28 @@ impl Client {
         }
     }
 
+    /// Whether this client is waiting on a response for transaction `id`.
+    ///
+    /// A STUN response belongs to whoever sent the matching request — [RFC 5389 §7.3.3] matches
+    /// them by transaction ID, and nothing else identifies the owner. That is only a question
+    /// worth asking when several STUN users share one socket, which is exactly the situation a
+    /// host is in when it points a STUN gatherer and this client at the same server address: both
+    /// see every response, and the four-tuple is identical for both, so addresses cannot say whose
+    /// a response is.
+    ///
+    /// Such a host calls this to route a response, rather than guessing from the peer address and
+    /// handing it to a client that will silently discard it — [`handle_read`](Self::handle_read)
+    /// drops a response with no matching transaction, as it must.
+    ///
+    /// Applies to responses only. TURN ChannelData carries no transaction ID at all, and
+    /// indications are not transaction-matched; both are routed by address.
+    ///
+    /// [RFC 5389 §7.3.3]: https://www.rfc-editor.org/rfc/rfc5389#section-7.3.3
+    #[must_use]
+    pub fn has_transaction(&self, id: &TransactionId) -> bool {
+        self.tr_map.find(id).is_some()
+    }
+
     /// send_binding_request_to sends a new STUN request to the given transport address
     /// return key to find out corresponding Event either BindingResponse or BindingRequestTimeout
     pub fn send_binding_request_to(


### PR DESCRIPTION
… STUN and TURN share the same server address — no srflx candidates gathered #890