### PR TITLE
fix(sctp): measure maxPacketLifeTime from when a message is queued

### DIFF
--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2597,6 +2597,81 @@ impl Association {
         self.bundle_data_chunks_into_packets(chunks, raw_packets);
     }
 
+    /// Whether the message at the head of the pending queue has outlived the
+    /// timed-reliability lifetime configured on its stream.
+    ///
+    /// Restricted to unordered messages: an ordered one has already consumed a
+    /// stream sequence number in `packetize`, so abandoning it before it is ever
+    /// transmitted would leave a gap that only a ForwardTSN carrying that SSN can
+    /// close. Restricted to a beginning fragment so a partially drained message is
+    /// never truncated mid-run.
+    fn pending_message_expired(&self, c: &ChunkPayloadData, now: Instant) -> bool {
+        if !c.unordered
+            || !c.beginning_fragment
+            || c.payload_type == PayloadProtocolIdentifier::Dcep
+        {
+            return false;
+        }
+
+        let Some(s) = self.streams.get(&c.stream_identifier) else {
+            return false;
+        };
+
+        // A zero lifetime keeps its established meaning â transmit once, never
+        // retransmit â rather than silently becoming "never transmit at all".
+        if s.reliability_type != ReliabilityType::Timed || s.reliability_value == 0 {
+            return false;
+        }
+
+        let Some(created_at) = c.created_at else {
+            return false;
+        };
+
+        now.saturating_duration_since(created_at).as_millis() as u32 >= s.reliability_value
+    }
+
+    /// Drop every fragment of the message at the head of the pending queue and
+    /// release the bytes it was holding in the stream's send buffer.
+    fn abandon_pending_message(&mut self, unordered: bool) {
+        let mut beginning_fragment = true;
+        let mut released = 0usize;
+        let mut stream_identifier = None;
+
+        loop {
+            let Some(c) = self.pending_queue.pop(beginning_fragment, unordered) else {
+                break;
+            };
+            beginning_fragment = false;
+            released += c.user_data.len();
+            stream_identifier = Some(c.stream_identifier);
+            if c.ending_fragment {
+                break;
+            }
+        }
+
+        let (Some(si), true) = (stream_identifier, released > 0) else {
+            return;
+        };
+
+        trace!(
+            "[{}] abandoned {} pending bytes on stream {} (maxPacketLifeTime)",
+            self.side, released, si
+        );
+
+        self.events
+            .push_back(Event::Stream(StreamEvent::BufferedAmountReleased {
+                id: si,
+                n_bytes: released,
+            }));
+
+        if let Some(s) = self.streams.get_mut(&si)
+            && s.on_buffer_released(released as i64)
+        {
+            self.events
+                .push_back(Event::Stream(StreamEvent::BufferedAmountLow { id: si }))
+        }
+    }
+
     /// pop_pending_data_chunks_to_send pops chunks from the pending queues as many as
     /// the cwnd and rwnd allows to send.
     fn pop_pending_data_chunks_to_send(
@@ -2631,6 +2706,16 @@ impl Association {
                     {
                         error!("[{}] failed to pop from pending queue", self.side);
                     }
+                    continue;
+                }
+
+                // RFC 3758 timed reliability: a message whose lifetime has run
+                // out must be abandoned even if it was never transmitted. Doing
+                // this here, ahead of the window checks and before a TSN is
+                // allocated, means there is no gap for the peer to reconcile and
+                // no ForwardTSN to send.
+                if self.pending_message_expired(c, now) {
+                    self.abandon_pending_message(unordered);
                     continue;
                 }
 
@@ -2801,8 +2886,11 @@ impl Association {
                     );
                 }
             } else if reliability_type == ReliabilityType::Timed {
-                if let Some(since) = &c.since {
-                    let elapsed = now.duration_since(*since);
+                // Age is measured from when the message was queued, not from its
+                // most recent transmission: `since` is the RTT baseline and is
+                // reassigned on every (re)transmission.
+                if let Some(since) = c.created_at.as_ref().or(c.since.as_ref()) {
+                    let elapsed = now.saturating_duration_since(*since);
                     if elapsed.as_millis() as u32 >= reliability_value {
                         c.set_abandoned(true);
                         trace!(

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2600,12 +2600,28 @@ impl Association {
     /// Whether the message at the head of the pending queue has outlived the
     /// timed-reliability lifetime configured on its stream.
     ///
+    /// Gated on `use_forward_tsn` for the same reason as
+    /// `check_partial_reliability_status`: when the peer did not negotiate
+    /// Forward-TSN the association falls back to reliable delivery, and partial
+    /// reliability must be off everywhere rather than in half the code.
+    ///
     /// Restricted to unordered messages: an ordered one has already consumed a
     /// stream sequence number in `packetize`, so abandoning it before it is ever
     /// transmitted would leave a gap that only a ForwardTSN carrying that SSN can
     /// close. Restricted to a beginning fragment so a partially drained message is
     /// never truncated mid-run.
+    ///
+    /// Only the head of the queue is inspected, so an expired message sitting
+    /// behind a fresh one keeps its buffered bytes until it reaches the head. It
+    /// is still never transmitted: it is re-checked once it gets there.
     fn pending_message_expired(&self, c: &ChunkPayloadData, now: Instant) -> bool {
+        if !self.use_forward_tsn {
+            return false;
+        }
+
+        // `packetize` forces `unordered = false` for DCEP, so the ordering test
+        // already excludes it; the explicit check keeps that non-obvious coupling
+        // from becoming load-bearing.
         if !c.unordered
             || !c.beginning_fragment
             || c.payload_type == PayloadProtocolIdentifier::Dcep
@@ -2632,21 +2648,38 @@ impl Association {
 
     /// Drop every fragment of the message at the head of the pending queue and
     /// release the bytes it was holding in the stream's send buffer.
-    fn abandon_pending_message(&mut self, unordered: bool) {
+    ///
+    /// Only called for an unordered message whose first fragment is at the head,
+    /// so the whole fragment run is contiguous: `send_payload_data` appends a
+    /// message's chunks without anything else interleaving. Running out before
+    /// the ending fragment would leave `PendingQueue` selected on an empty queue
+    /// and stall every later send, so that case asserts in debug builds and is
+    /// reported rather than silently tolerated.
+    fn abandon_pending_message(&mut self) {
         let mut beginning_fragment = true;
         let mut released = 0usize;
         let mut stream_identifier = None;
+        let mut completed = false;
 
-        loop {
-            let Some(c) = self.pending_queue.pop(beginning_fragment, unordered) else {
-                break;
-            };
+        while let Some(c) = self.pending_queue.pop(beginning_fragment, true) {
             beginning_fragment = false;
             released += c.user_data.len();
             stream_identifier = Some(c.stream_identifier);
             if c.ending_fragment {
+                completed = true;
                 break;
             }
+        }
+
+        if !completed {
+            debug_assert!(
+                false,
+                "pending queue ran out mid-message while abandoning an expired message"
+            );
+            error!(
+                "[{}] abandoned an incomplete fragment run; pending queue selection is now stale",
+                self.side
+            );
         }
 
         let (Some(si), true) = (stream_identifier, released > 0) else {
@@ -2715,7 +2748,7 @@ impl Association {
                 // allocated, means there is no gap for the peer to reconcile and
                 // no ForwardTSN to send.
                 if self.pending_message_expired(c, now) {
-                    self.abandon_pending_message(unordered);
+                    self.abandon_pending_message();
                     continue;
                 }
 
@@ -2889,8 +2922,8 @@ impl Association {
                 // Age is measured from when the message was queued, not from its
                 // most recent transmission: `since` is the RTT baseline and is
                 // reassigned on every (re)transmission.
-                if let Some(since) = c.created_at.as_ref().or(c.since.as_ref()) {
-                    let elapsed = now.saturating_duration_since(*since);
+                if let Some(queued_at) = c.created_at.as_ref().or(c.since.as_ref()) {
+                    let elapsed = now.saturating_duration_since(*queued_at);
                     if elapsed.as_millis() as u32 >= reliability_value {
                         c.set_abandoned(true);
                         trace!(
@@ -2899,7 +2932,7 @@ impl Association {
                         );
                     }
                 } else {
-                    error!("[{}] invalid c.since", side);
+                    error!("[{}] chunk has neither created_at nor since", side);
                 }
             }
         } else {
@@ -2999,7 +3032,8 @@ impl Association {
             // Assign TSN
             c.tsn = self.generate_next_tsn();
 
-            c.since = Some(now); // use to calculate RTT and also for maxPacketLifeTime
+            // RTT baseline only; maxPacketLifeTime measures from `created_at`.
+            c.since = Some(now);
             c.nsent = 1; // being sent for the first time
 
             Association::check_partial_reliability_status(
@@ -3033,11 +3067,11 @@ impl Association {
 
     /// Queues the outgoing stream-reset chunk (RFC 6525).
     ///
-    /// `now` is when the caller asked for the reset; threaded from `Stream::stop` for the same
-    /// reason `send_payload_data` takes one. Not yet consumed.
+    /// `now` is when the caller asked for the reset; threaded from `Stream::stop` and recorded
+    /// on the EOS chunk so every locally created chunk carries its queueing instant.
     pub(crate) fn send_reset_request(
         &mut self,
-        _now: Instant,
+        now: Instant,
         stream_identifier: StreamId,
     ) -> Result<()> {
         let state = self.state();
@@ -3048,6 +3082,7 @@ impl Association {
         // Create DATA chunk which only contains valid stream identifier with
         // nil userData and use it as a EOS from the stream.
         let c = ChunkPayloadData {
+            created_at: Some(now),
             stream_identifier,
             beginning_fragment: true,
             ending_fragment: true,
@@ -3063,14 +3098,9 @@ impl Association {
 
     /// send_payload_data sends the data chunks.
     ///
-    /// `now` is when the application handed the message to the stack. It is threaded from
-    /// `Stream::write*` rather than read here, so the queueing instant is the caller's own and
-    /// not "whenever the association was last driven". Not yet consumed.
-    pub(crate) fn send_payload_data(
-        &mut self,
-        _now: Instant,
-        chunks: Vec<ChunkPayloadData>,
-    ) -> Result<()> {
+    /// The queueing instant is already recorded on each chunk by `Stream::packetize`, so this
+    /// does not need one of its own.
+    pub(crate) fn send_payload_data(&mut self, chunks: Vec<ChunkPayloadData>) -> Result<()> {
         let state = self.state();
         if state != AssociationState::Established {
             return Err(Error::ErrPayloadDataStateNotExist);

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -240,7 +240,7 @@ impl Stream<'_> {
         let (p, _) = source.pop_chunk(self.association.max_message_size() as usize);
 
         if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
-            let (is_buffered_amount_high, chunks) = s.packetize(&p, ppi);
+            let (is_buffered_amount_high, chunks) = s.packetize(now, &p, ppi);
 
             if is_buffered_amount_high {
                 trace!("StreamEvent::BufferedAmountHigh");
@@ -510,6 +510,7 @@ impl StreamState {
 
     fn packetize(
         &mut self,
+        now: Instant,
         raw: &Bytes,
         ppi: PayloadProtocolIdentifier,
     ) -> (bool, Vec<ChunkPayloadData>) {
@@ -533,6 +534,9 @@ impl StreamState {
             let user_data = raw.slice(i..i + fragment_size);
 
             let chunk = ChunkPayloadData {
+                // Timed reliability measures a message's age from here, so that
+                // a long wait for cwnd or rwnd counts against maxPacketLifeTime.
+                created_at: Some(now),
                 stream_identifier: self.stream_identifier,
                 user_data,
                 unordered,

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -251,7 +251,7 @@ impl Stream<'_> {
                     }))
             }
 
-            self.association.send_payload_data(now, chunks)?;
+            self.association.send_payload_data(chunks)?;
 
             Ok(p.len())
         } else {

--- a/rtc-sctp/src/chunk/chunk_payload_data.rs
+++ b/rtc-sctp/src/chunk/chunk_payload_data.rs
@@ -112,8 +112,18 @@ pub struct ChunkPayloadData {
     pub(crate) acked: bool,
     pub(crate) miss_indicator: u32,
 
-    /// Partial-reliability parameters used only by sender
+    /// Partial-reliability parameters used only by sender.
+    ///
+    /// Reassigned on every (re)transmission, so it is the RTT baseline. It is
+    /// deliberately *not* the timed-reliability baseline: a message may wait in
+    /// the pending queue for a long time before it is first transmitted, and
+    /// `maxPacketLifeTime` has to cover that wait. See `created_at`.
     pub(crate) since: Option<Instant>,
+    /// When the message this chunk belongs to was handed to the association.
+    ///
+    /// Set once, from the instant the caller passed to `Stream::write*`, and
+    /// never reassigned. This is the baseline for `ReliabilityType::Timed`.
+    pub(crate) created_at: Option<Instant>,
     /// number of transmission made for this chunk
     pub(crate) nsent: u32,
 
@@ -142,6 +152,7 @@ impl Default for ChunkPayloadData {
             acked: false,
             miss_indicator: 0,
             since: None,
+            created_at: None,
             nsent: 0,
             abandoned: false,
             all_inflight: false,
@@ -224,6 +235,7 @@ impl Chunk for ChunkPayloadData {
             acked: false,
             miss_indicator: 0,
             since: None,
+            created_at: None,
             nsent: 0,
             abandoned: false,
             all_inflight: false,

--- a/rtc-sctp/src/endpoint/endpoint_test.rs
+++ b/rtc-sctp/src/endpoint/endpoint_test.rs
@@ -1485,10 +1485,104 @@ fn test_assoc_timed_reliability_bounds_time_spent_in_pending_queue() -> Result<(
         received.push(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]));
     }
 
-    assert!(
-        !received.contains(&1),
+    // Message 1 outlived its lifetime while queued and must be abandoned;
+    // message 0 was already in flight when the stall began and must survive.
+    // Asserting the whole vector also catches a fix that drops everything.
+    assert_eq!(
+        received,
+        vec![0],
         "message 1 waited {stall:?} in the pending queue with maxPacketLifeTime={lifetime_ms}ms \
-         and must have been abandoned, but it was transmitted anyway (received={received:?})"
+         and must have been abandoned, while message 0 must still arrive"
+    );
+    assert_eq!(
+        0,
+        pair.client_conn_mut(client_ch).buffered_amount(),
+        "abandoning the expired message must release its buffered bytes"
+    );
+
+    close_association_pair(&mut pair, client_ch, server_ch, si);
+
+    Ok(())
+}
+
+/// The expired-message path pops a whole fragment run, which is the part that
+/// interacts with `PendingQueue`'s selected-queue state. A single-chunk message
+/// never exercises it, so this drives a message large enough to fragment and
+/// then checks that the queue is still usable afterwards.
+#[test]
+fn test_assoc_timed_reliability_abandons_a_whole_fragmented_message() -> Result<()> {
+    let si: u16 = 8;
+    let lifetime_ms: u32 = 100;
+    let stall = Duration::from_secs(1);
+
+    let small = Bytes::from(vec![0xAAu8; 1000]);
+    // Comfortably over max_payload_size_for_mtu(INITIAL_MTU), so this fragments.
+    let large = Bytes::from(vec![0xBBu8; 4000]);
+    let tail = Bytes::from(vec![0xCCu8; 700]);
+
+    let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+    establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+
+    pair.client_stream(client_ch, si)?.set_reliability_params(
+        true,
+        ReliabilityType::Timed,
+        lifetime_ms,
+    )?;
+    pair.server_stream(server_ch, si)?.set_reliability_params(
+        true,
+        ReliabilityType::Timed,
+        lifetime_ms,
+    )?;
+
+    pair.client_conn_mut(client_ch).cwnd = 1200;
+
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &small,
+        PayloadProtocolIdentifier::Binary,
+    )?;
+
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &large,
+        PayloadProtocolIdentifier::Binary,
+    )?;
+
+    pair.drive_client();
+    assert!(
+        pair.client_conn_mut(client_ch).buffered_amount() >= large.len(),
+        "the fragmented message should still be waiting in the pending queue"
+    );
+
+    pair.time += stall;
+    pair.drive();
+
+    // A message that is still usable after the stall must get through, which is
+    // only possible if abandoning the fragment run left the queue consistent.
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?
+        .write_sctp(now, &tail, PayloadProtocolIdentifier::Binary)?;
+    pair.drive();
+
+    let mut buf = vec![0u8; 8000];
+    let mut lengths = vec![];
+    while let Some(chunks) = pair.server_stream(server_ch, si)?.read_sctp()? {
+        let n = chunks.len();
+        chunks.read(&mut buf)?;
+        lengths.push(n);
+    }
+
+    assert_eq!(
+        lengths,
+        vec![small.len(), tail.len()],
+        "the fragmented message must be abandoned whole, and the queue must keep working"
+    );
+    assert_eq!(
+        0,
+        pair.client_conn_mut(client_ch).buffered_amount(),
+        "abandoning a fragmented message must release every fragment's bytes"
     );
 
     close_association_pair(&mut pair, client_ch, server_ch, si);

--- a/rtc-sctp/src/endpoint/endpoint_test.rs
+++ b/rtc-sctp/src/endpoint/endpoint_test.rs
@@ -1408,6 +1408,94 @@ fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
     Ok(())
 }
 
+/// `ReliabilityType::Timed` is the policy `maxPacketLifeTime` maps onto, and it is
+/// supposed to bound how old a message can be when it reaches the peer.
+///
+/// It did not: the lifetime was measured from `c.since`, which is reassigned when
+/// the chunk leaves the pending queue and is given a TSN. Time the message spent
+/// waiting for a congestion window was therefore invisible to the policy, so the
+/// message went out however stale it was, with a freshly reset lifetime.
+#[test]
+fn test_assoc_timed_reliability_bounds_time_spent_in_pending_queue() -> Result<()> {
+    let si: u16 = 7;
+    // maxPacketLifeTime = 100 ms.
+    let lifetime_ms: u32 = 100;
+    let stall = Duration::from_secs(1);
+
+    let mut sbuf = vec![0u8; 1000];
+    for i in 0..sbuf.len() {
+        sbuf[i] = (i & 0xff) as u8;
+    }
+
+    let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+    establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+
+    pair.client_stream(client_ch, si)?.set_reliability_params(
+        true,
+        ReliabilityType::Timed,
+        lifetime_ms,
+    )?;
+    pair.server_stream(server_ch, si)?.set_reliability_params(
+        true,
+        ReliabilityType::Timed,
+        lifetime_ms,
+    )?;
+
+    // Shrink the congestion window so exactly one message fits in flight. The
+    // second write then has to wait in the pending queue behind the first.
+    pair.client_conn_mut(client_ch).cwnd = 1200;
+
+    // Message 0 leaves immediately and occupies the whole window.
+    sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
+
+    // Message 1 is blocked behind it.
+    sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &Bytes::from(sbuf.clone()),
+        PayloadProtocolIdentifier::Binary,
+    )?;
+
+    // Drive only the sender: message 0 goes on the wire, message 1 stays pending.
+    // The peer is deliberately not driven, so nothing is acknowledged and the
+    // window stays shut for as long as we like.
+    pair.drive_client();
+    assert!(
+        pair.client_conn_mut(client_ch).buffered_amount() >= sbuf.len(),
+        "message 1 should still be waiting in the pending queue"
+    );
+
+    // The stall lasts ten times the configured lifetime.
+    pair.time += stall;
+
+    // The stall clears and both sides run to completion.
+    pair.drive();
+
+    let mut buf = vec![0u8; 2000];
+    let mut received = vec![];
+    while let Some(chunks) = pair.server_stream(server_ch, si)?.read_sctp()? {
+        chunks.read(&mut buf)?;
+        received.push(u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]));
+    }
+
+    assert!(
+        !received.contains(&1),
+        "message 1 waited {stall:?} in the pending queue with maxPacketLifeTime={lifetime_ms}ms \
+         and must have been abandoned, but it was transmitted anyway (received={received:?})"
+    );
+
+    close_association_pair(&mut pair, client_ch, server_ch, si);
+
+    Ok(())
+}
+
 #[test]
 fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     //let _guard = subscribe();


### PR DESCRIPTION
Fixes #232. Rebased onto `v0.21.x` on top of b1905e4, so this is now just the fix.

## What was wrong

`ReliabilityType::Timed` — the PR-SCTP policy `maxPacketLifeTime` maps onto — measured a message's lifetime from `c.since`, which is reassigned every time a chunk is transmitted:

```rust
// rtc-sctp/src/association/mod.rs
c.since = Some(now); // use to calculate RTT and also for maxPacketLifeTime
```

Time a message spends waiting in `pending_queue` for cwnd or rwnd was therefore invisible to the policy. Draining a stall transmitted messages arbitrarily older than their configured lifetime, each with a freshly reset clock, so only the retransmission half of the option ever worked.

## What this changes

b1905e4 already brings the caller's instant as far as `write_source`. This carries it the last hop into `packetize` and puts it to work:

- `ChunkPayloadData` gains `created_at`, stamped in `packetize` from that instant and never reassigned. `since` keeps its existing role as the per-transmission RTT baseline — the two really are different clocks.
- `check_partial_reliability_status` measures the `Timed` policy against `created_at`, using `saturating_duration_since`.
- `pop_pending_data_chunks_to_send` abandons expired messages ahead of the cwnd/rwnd checks and before a TSN is allocated. Because nothing has been assigned a TSN, this creates no gap for the peer to reconcile and needs no ForwardTSN. Buffered bytes are released through the existing `BufferedAmountReleased` / `BufferedAmountLow` path.

No public API change of its own, and no new clock reads:

```
$ python3 scripts/check-sans-io-deterministic-time.py
Sans-I/O deterministic-time boundary holds: 8 allow-listed reads, no new ones.
```

## Scope

Deliberately conservative for a first change:

- **Unordered messages only.** An ordered message has already consumed a stream sequence number in `packetize`, so abandoning it before it is ever transmitted would leave an SSN gap that only a ForwardTSN carrying that SSN can close. Worth a follow-up; I did not want to smuggle it in here.
- **Whole messages only**, every fragment, and only at a message boundary — a partially drained message is never truncated mid-run.
- **DCEP exempt**, matching the existing exemption in `check_partial_reliability_status`.
- **A zero lifetime keeps its current meaning** (transmit once, never retransmit) rather than silently becoming "never transmit at all". Happy to change this if you would rather `maxPacketLifeTime: 0` expire at the pending stage too.

## Tests

`test_assoc_timed_reliability_bounds_time_spent_in_pending_queue` is the regression test. It runs on the existing `Pair` harness and its virtual clock — no sleeps. Reverting the three source files and keeping the test reproduces the original failure on b1905e4:

```
message 1 waited 1s in the pending queue with maxPacketLifeTime=100ms and must have been
abandoned, but it was transmitted anyway (received=[0, 1])
```

With the fix:

```
$ cargo test -p rtc-sctp
test result: ok. 136 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo clippy
$ cargo fmt --all -- --check
```

`cargo test --workspace` is otherwise green. `ice_restart_by_webrtc_interop` and `mdns_query_and_gather_interop` fail on my machine both with and without this change — this host cannot bind IPv6 link-local addresses or run mDNS multicast — so they are environmental and unrelated.
