### PR TITLE
add now: Instant for sctp write/outbound direction's public APIs

### DIFF
--- a/rtc-sctp/examples/sctp_e2e.rs
+++ b/rtc-sctp/examples/sctp_e2e.rs
@@ -198,7 +198,7 @@ fn main() {
             let mut stream = assoc.stream(0).unwrap();
             while sent < num_msgs && stream.buffered_amount().unwrap() < SEND_BUF_CAP {
                 stream
-                    .write_sctp(&msg, PayloadProtocolIdentifier::Binary)
+                    .write_sctp(now, &msg, PayloadProtocolIdentifier::Binary)
                     .unwrap();
                 sent += 1;
                 wrote = true;

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -491,7 +491,7 @@ fn test_assoc_max_message_size_default() -> Result<()> {
     if let Some(mut s) = stream {
         let p = Bytes::from(vec![0u8; 65537]);
 
-        if let Err(err) = s.write_sctp(&p.slice(..65536), ppi) {
+        if let Err(err) = s.write_sctp(Instant::now(), &p.slice(..65536), ppi) {
             assert_ne!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -501,7 +501,7 @@ fn test_assoc_max_message_size_default() -> Result<()> {
             assert!(false, "should be error");
         }
 
-        if let Err(err) = s.write_sctp(&p.slice(..65537), ppi) {
+        if let Err(err) = s.write_sctp(Instant::now(), &p.slice(..65537), ppi) {
             assert_eq!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -528,7 +528,7 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
     if let Some(mut s) = stream {
         let p = Bytes::from(vec![0u8; 30001]);
 
-        if let Err(err) = s.write_sctp(&p.slice(..30000), ppi) {
+        if let Err(err) = s.write_sctp(Instant::now(), &p.slice(..30000), ppi) {
             assert_ne!(
                 Error::ErrOutboundPacketTooLarge,
                 err,
@@ -538,7 +538,7 @@ fn test_assoc_max_message_size_explicit() -> Result<()> {
             assert!(false, "should be error");
         }
 
-        if let Err(err) = s.write_sctp(&p.slice(..30001), ppi) {
+        if let Err(err) = s.write_sctp(Instant::now(), &p.slice(..30001), ppi) {
             assert_eq!(
                 Error::ErrOutboundPacketTooLarge,
                 err,

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -2943,7 +2943,15 @@ impl Association {
         }
     }
 
-    pub(crate) fn send_reset_request(&mut self, stream_identifier: StreamId) -> Result<()> {
+    /// Queues the outgoing stream-reset chunk (RFC 6525).
+    ///
+    /// `now` is when the caller asked for the reset; threaded from `Stream::stop` for the same
+    /// reason `send_payload_data` takes one. Not yet consumed.
+    pub(crate) fn send_reset_request(
+        &mut self,
+        _now: Instant,
+        stream_identifier: StreamId,
+    ) -> Result<()> {
         let state = self.state();
         if state != AssociationState::Established {
             return Err(Error::ErrResetPacketInStateNotExist);
@@ -2966,7 +2974,15 @@ impl Association {
     }
 
     /// send_payload_data sends the data chunks.
-    pub(crate) fn send_payload_data(&mut self, chunks: Vec<ChunkPayloadData>) -> Result<()> {
+    ///
+    /// `now` is when the application handed the message to the stack. It is threaded from
+    /// `Stream::write*` rather than read here, so the queueing instant is the caller's own and
+    /// not "whenever the association was last driven". Not yet consumed.
+    pub(crate) fn send_payload_data(
+        &mut self,
+        _now: Instant,
+        chunks: Vec<ChunkPayloadData>,
+    ) -> Result<()> {
         let state = self.state();
         if state != AssociationState::Established {
             return Err(Error::ErrPayloadDataStateNotExist);

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -9,6 +9,7 @@ use crate::util::{ByteSlice, BytesArray, BytesChunk, BytesSource};
 use bytes::Bytes;
 use log::{debug, error, trace};
 use std::fmt;
+use std::time::Instant;
 
 /// Identifier for a stream within a particular association
 pub type StreamId = u16;
@@ -139,8 +140,16 @@ impl Stream<'_> {
     }
 
     /// write_sctp writes len(p) bytes from p to the DTLS connection
-    pub fn write_sctp(&mut self, p: &Bytes, ppi: PayloadProtocolIdentifier) -> Result<usize> {
-        self.write_source(&mut BytesChunk::new(p), ppi)
+    ///
+    /// `now` is the instant the message is handed to the stack. See the note on
+    /// [`Stream`] for why it is a parameter.
+    pub fn write_sctp(
+        &mut self,
+        now: Instant,
+        p: &Bytes,
+        ppi: PayloadProtocolIdentifier,
+    ) -> Result<usize> {
+        self.write_source(now, &mut BytesChunk::new(p), ppi)
     }
 
     /// Send data on the given stream.
@@ -148,20 +157,29 @@ impl Stream<'_> {
     /// Uses the deafult payload protocol (PPI).
     ///
     /// Returns the number of bytes successfully written.
-    pub fn write(&mut self, data: &[u8]) -> Result<usize> {
-        self.write_with_ppi(data, self.get_default_payload_type()?)
+    pub fn write(&mut self, now: Instant, data: &[u8]) -> Result<usize> {
+        self.write_with_ppi(now, data, self.get_default_payload_type()?)
     }
 
     /// Send data on the given stream, with a specific payload protocol.
     ///
     /// Returns the number of bytes successfully written.
-    pub fn write_with_ppi(&mut self, data: &[u8], ppi: PayloadProtocolIdentifier) -> Result<usize> {
-        self.write_source(&mut ByteSlice::from_slice(data), ppi)
+    pub fn write_with_ppi(
+        &mut self,
+        now: Instant,
+        data: &[u8],
+        ppi: PayloadProtocolIdentifier,
+    ) -> Result<usize> {
+        self.write_source(now, &mut ByteSlice::from_slice(data), ppi)
     }
 
     /// write writes len(p) bytes from p with the default Payload Protocol Identifier
-    pub fn write_chunk(&mut self, p: &Bytes) -> Result<usize> {
-        self.write_source(&mut BytesChunk::new(p), self.get_default_payload_type()?)
+    pub fn write_chunk(&mut self, now: Instant, p: &Bytes) -> Result<usize> {
+        self.write_source(
+            now,
+            &mut BytesChunk::new(p),
+            self.get_default_payload_type()?,
+        )
     }
 
     /// Send an owned [`Bytes`] on the stream with a specific payload protocol.
@@ -174,10 +192,11 @@ impl Stream<'_> {
     /// Returns the number of bytes successfully written.
     pub fn write_chunk_with_ppi(
         &mut self,
+        now: Instant,
         data: &Bytes,
         ppi: PayloadProtocolIdentifier,
     ) -> Result<usize> {
-        self.write_source(&mut BytesChunk::new(data), ppi)
+        self.write_source(now, &mut BytesChunk::new(data), ppi)
     }
 
     /// Send data on the given stream
@@ -186,8 +205,9 @@ impl Stream<'_> {
     /// Note that this method might also write a partial chunk. In this case
     /// it will not count this chunk as fully written. However
     /// the chunk will be advanced and contain only non-written data after the call.
-    pub fn write_chunks(&mut self, data: &mut [Bytes]) -> Result<usize> {
+    pub fn write_chunks(&mut self, now: Instant, data: &mut [Bytes]) -> Result<usize> {
         self.write_source(
+            now,
             &mut BytesArray::from_chunks(data),
             self.get_default_payload_type()?,
         )
@@ -196,6 +216,7 @@ impl Stream<'_> {
     /// write_source writes BytesSource to the DTLS connection
     fn write_source<B: BytesSource>(
         &mut self,
+        now: Instant,
         source: &mut B,
         ppi: PayloadProtocolIdentifier,
     ) -> Result<usize> {
@@ -230,7 +251,7 @@ impl Stream<'_> {
                     }))
             }
 
-            self.association.send_payload_data(chunks)?;
+            self.association.send_payload_data(now, chunks)?;
 
             Ok(p.len())
         } else {
@@ -258,7 +279,10 @@ impl Stream<'_> {
 
     /// stop closes the read-direction of the stream.
     /// Future calls to read are not permitted after calling stop.
-    pub fn stop(&mut self) -> Result<()> {
+    ///
+    /// `now` is the instant the caller is acting at: resetting the stream queues an outgoing
+    /// chunk, so it is on the same write path as [`write_sctp`](Self::write_sctp).
+    pub fn stop(&mut self, now: Instant) -> Result<()> {
         let mut reset = false;
         if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
             if s.state == RecvSendState::Readable || s.state == RecvSendState::ReadWritable {
@@ -271,7 +295,7 @@ impl Stream<'_> {
             // Reset the outgoing stream
             // https://tools.ietf.org/html/rfc6525
             self.association
-                .send_reset_request(self.stream_identifier)?;
+                .send_reset_request(now, self.stream_identifier)?;
         }
 
         Ok(())
@@ -292,9 +316,9 @@ impl Stream<'_> {
     /// immediately with an appropriate value (see the documentation of `Shutdown`).
     ///
     /// Resets the stream when both halves of this stream are shutdown.
-    pub fn close(&mut self) -> Result<()> {
+    pub fn close(&mut self, now: Instant) -> Result<()> {
         self.finish()?;
-        self.stop()
+        self.stop(now)
     }
 
     /// stream_identifier returns the Stream identifier associated to the stream.

--- a/rtc-sctp/src/endpoint/endpoint_test.rs
+++ b/rtc-sctp/src/endpoint/endpoint_test.rs
@@ -411,9 +411,12 @@ fn establish_session_pair(
     let _ = pair
         .client_conn_mut(client_ch)
         .open_stream(si, PayloadProtocolIdentifier::Binary)?;
-    let _ = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&hello_msg, PayloadProtocolIdentifier::Dcep)?;
+    let now = pair.time;
+    let _ = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &hello_msg,
+        PayloadProtocolIdentifier::Dcep,
+    )?;
     pair.drive();
 
     {
@@ -487,9 +490,12 @@ fn test_assoc_reliable_simple() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n, "unexpected length of received data");
     {
         let a = pair.client_conn_mut(client_ch);
@@ -535,9 +541,10 @@ fn test_assoc_reliable_write_chunk() -> Result<()> {
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
     {
+        let now = pair.time;
         let mut s = pair.client_stream(client_ch, si)?;
         s.set_default_payload_type(PayloadProtocolIdentifier::Binary)?;
-        let n = s.write_chunk(&msg)?;
+        let n = s.write_chunk(now, &msg)?;
         assert_eq!(msg.len(), n, "unexpected length of written data");
     }
 
@@ -583,7 +590,9 @@ fn test_assoc_reliable_ordered_reordered() -> Result<()> {
     }
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -592,7 +601,9 @@ fn test_assoc_reliable_ordered_reordered() -> Result<()> {
     pair.client.delay_outbound(); // Delay it
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -672,7 +683,9 @@ fn test_assoc_reliable_ordered_fragmented_then_defragmented() -> Result<()> {
         0,
     )?;
 
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbufl.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -734,7 +747,9 @@ fn test_assoc_reliable_unordered_fragmented_then_defragmented() -> Result<()> {
         0,
     )?;
 
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbufl.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -793,7 +808,9 @@ fn test_assoc_reliable_unordered_ordered() -> Result<()> {
     )?;
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -802,7 +819,9 @@ fn test_assoc_reliable_unordered_ordered() -> Result<()> {
     pair.client.delay_outbound(); // Delay it
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -870,17 +889,23 @@ fn test_assoc_reliable_retransmission() -> Result<()> {
 
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg1, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg1,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg1.len(), n, "unexpected length of received data");
     pair.drive_client(); // send data to server
     pair.server.inbound.clear(); // Lose it
     debug!("dropping packet");
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg2, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg2,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg2.len(), n, "unexpected length of received data");
 
     pair.drive();
@@ -934,9 +959,12 @@ fn test_assoc_reliable_short_buffer() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n, "unexpected length of received data");
     {
         let a = pair.client_conn_mut(client_ch);
@@ -1001,7 +1029,9 @@ fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
     //br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1011,7 +1041,9 @@ fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
     debug!("dropping packet");
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1079,8 +1111,12 @@ fn test_forward_tsn_stream_map_populated_then_cleared() -> Result<()> {
     // Send ordered ssn=0 and lose it in flight -> it becomes abandoned.
     let mut m0 = sbuf.clone();
     m0[0..4].copy_from_slice(&0u32.to_be_bytes());
-    pair.client_stream(client_ch, si)?
-        .write_sctp(&Bytes::from(m0), PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &Bytes::from(m0),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     pair.drive_client();
     pair.server.inbound.clear(); // drop ssn=0
 
@@ -1088,8 +1124,12 @@ fn test_forward_tsn_stream_map_populated_then_cleared() -> Result<()> {
     // must report the stream sequence so the receiver releases ssn=1.
     let mut m1 = sbuf.clone();
     m1[0..4].copy_from_slice(&1u32.to_be_bytes());
-    pair.client_stream(client_ch, si)?
-        .write_sctp(&Bytes::from(m1), PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &Bytes::from(m1),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     pair.drive();
 
     // (1) Population check: the receiver skipped ssn=0 and delivered ssn=1.
@@ -1150,7 +1190,9 @@ fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     //br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1159,7 +1201,9 @@ fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     pair.server.inbound.clear(); // Lose it
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1224,7 +1268,9 @@ fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
     //br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1233,7 +1279,9 @@ fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
     pair.server.inbound.clear(); // Lose it
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1296,7 +1344,9 @@ fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
         .set_reliability_params(true, ReliabilityType::Rexmit, 0)?; // doesn't matter
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1306,7 +1356,9 @@ fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
     //debug!("outbound len={}", pair.client.outbound.len());
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1380,7 +1432,9 @@ fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     //br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1389,7 +1443,9 @@ fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     pair.client.outbound.clear();
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1454,7 +1510,9 @@ fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
     //br.drop_next_nwrites(0, 1).await; // drop the first packet (second one should be sacked)
 
     sbuf[0..4].copy_from_slice(&0u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1463,7 +1521,9 @@ fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
     pair.client.outbound.clear();
 
     sbuf[0..4].copy_from_slice(&1u32.to_be_bytes());
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1541,7 +1601,9 @@ fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
 
     for i in 0..4u32 {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
+        let now = pair.time;
         let n = pair.client_stream(client_ch, si)?.write_sctp(
+            now,
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
         )?;
@@ -1636,7 +1698,9 @@ fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
 
     for i in 0..n_packets_to_send {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
+        let now = pair.time;
         let n = pair.client_stream(client_ch, si)?.write_sctp(
+            now,
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
         )?;
@@ -1759,7 +1823,9 @@ fn test_assoc_congestion_control_slow_reader() -> Result<()> {
 
     for i in 0..n_packets_to_send {
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
+        let now = pair.time;
         let n = pair.client_stream(client_ch, si)?.write_sctp(
+            now,
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
         )?;
@@ -1868,7 +1934,9 @@ fn test_assoc_delayed_ack() -> Result<()> {
         pair.server_conn_mut(server_ch).stats.reset();
     }
 
+    let now = pair.time;
     let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
         &Bytes::from(sbuf.clone()),
         PayloadProtocolIdentifier::Binary,
     )?;
@@ -1954,9 +2022,12 @@ fn test_assoc_reset_close_one_way() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n, "unexpected length of received data");
     {
         let a = pair.client_conn_mut(client_ch);
@@ -1979,7 +2050,8 @@ fn test_assoc_reset_close_one_way() -> Result<()> {
                 }
 
                 debug!("s0.close");
-                pair.client_stream(client_ch, si)?.stop()?; // send reset
+                let now = pair.time;
+                pair.client_stream(client_ch, si)?.stop(now)?; // send reset
 
                 pair.step();
             }
@@ -2013,9 +2085,12 @@ fn test_assoc_reset_close_both_ways() -> Result<()> {
         assert_eq!(0, a.buffered_amount(), "incorrect bufferedAmount");
     }
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n, "unexpected length of received data");
     {
         let a = pair.client_conn_mut(client_ch);
@@ -2065,10 +2140,12 @@ fn test_assoc_reset_close_both_ways() -> Result<()> {
         }
 
         if pair.client_stream(client_ch, si).is_ok() {
-            pair.client_stream(client_ch, si)?.stop()?; // send reset
+            let now = pair.time;
+            pair.client_stream(client_ch, si)?.stop(now)?; // send reset
         }
         if pair.server_stream(server_ch, si).is_ok() {
-            pair.server_stream(server_ch, si)?.stop()?; // send reset
+            let now = pair.time;
+            pair.server_stream(server_ch, si)?.stop(now)?; // send reset
         }
 
         pair.step();
@@ -2363,7 +2440,9 @@ fn test_old_rtx_on_regular_acks() -> Result<()> {
     for i in 0..20u32 {
         //println!("sending packet {}", i);
         sbuf[0..4].copy_from_slice(&i.to_be_bytes());
+        let now = pair.time;
         let n = pair.client_stream(client_ch, si)?.write_sctp(
+            now,
             &Bytes::from(sbuf.clone()),
             PayloadProtocolIdentifier::Binary,
         )?;
@@ -2826,12 +2905,16 @@ fn kps_816_write_then_reset_delivered_in_order_survives() -> Result<()> {
     let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
+    let now = pair.time;
     // Write and reset with no server read in between.
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg.clone().into(), PayloadProtocolIdentifier::Binary)?;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg.clone().into(),
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n);
-    pair.client_stream(client_ch, si)?.stop()?; // RFC 6525 outgoing reset
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.stop(now)?; // RFC 6525 outgoing reset
 
     // Flush the client's packets into the server's inbound queue, then feed
     // them to the server the way a real rtc application would consume them.
@@ -2979,11 +3062,15 @@ fn kps_repro_816_reordered_reset_before_data_must_not_lose_data() -> Result<()> 
     let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
-    let n = pair
-        .client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    let n = pair.client_stream(client_ch, si)?.write_sctp(
+        now,
+        &msg,
+        PayloadProtocolIdentifier::Binary,
+    )?;
     assert_eq!(msg.len(), n);
-    pair.client_stream(client_ch, si)?.stop()?;
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.stop(now)?;
 
     pair.drive_client();
     let n_packets = pair.server.inbound.len();
@@ -3039,8 +3126,9 @@ fn kps_816_close_unregisters_streams_holding_unread_data() -> Result<()> {
     let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
+    let now = pair.time;
     pair.client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
+        .write_sctp(now, &msg, PayloadProtocolIdentifier::Binary)?;
     pair.drive_client();
     let _ = deliver_to_server_rtc_style_no_read(&mut pair, server_ch);
 
@@ -3099,9 +3187,11 @@ fn kps_816_deferred_reset_completes_when_the_application_drains() -> Result<()> 
     let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
     establish_session_pair(&mut pair, client_ch, server_ch, si)?;
 
+    let now = pair.time;
     pair.client_stream(client_ch, si)?
-        .write_sctp(&msg, PayloadProtocolIdentifier::Binary)?;
-    pair.client_stream(client_ch, si)?.stop()?;
+        .write_sctp(now, &msg, PayloadProtocolIdentifier::Binary)?;
+    let now = pair.time;
+    pair.client_stream(client_ch, si)?.stop(now)?;
     pair.drive_client();
 
     // Reset ahead of the data, and the application does not read: the reset must

--- a/src/peer_connection/handler/sctp.rs
+++ b/src/peer_connection/handler/sctp.rs
@@ -593,7 +593,7 @@ impl<'a>
                                 message.stream_id
                             );
                             let mut stream = conn.stream(message.stream_id)?;
-                            stream.close()?;
+                            stream.close(now)?;
 
                             self.ctx.event_outs.push_back(TaggedRTCEventInternal {
                                 now,
@@ -631,7 +631,7 @@ impl<'a>
                     // `freeze()` is O(1) and the enqueued chunks are refcounted
                     // slices, eliminating a per-message alloc + full-payload memcpy.
                     let payload = std::mem::take(&mut message.payload).freeze();
-                    stream.write_chunk_with_ppi(&payload, message.ppi)?;
+                    stream.write_chunk_with_ppi(now, &payload, message.ppi)?;
                 }
 
                 // Transmit flush is deferred to poll_write (batch-drain).
@@ -1048,7 +1048,11 @@ mod tests {
                 .open_stream(1, PayloadProtocolIdentifier::Dcep)
                 .expect("open server stream");
             stream
-                .write_sctp(&Bytes::from(dcep_open), PayloadProtocolIdentifier::Dcep)
+                .write_sctp(
+                    now,
+                    &Bytes::from(dcep_open),
+                    PayloadProtocolIdentifier::Dcep,
+                )
                 .expect("server data");
         }
         let early_data = drain_transmits(&mut server_conn, now);
@@ -1301,6 +1305,7 @@ mod tests {
             for i in 0..count {
                 stream
                     .write_sctp(
+                        now,
                         &Bytes::from(vec![i as u8; 64]),
                         PayloadProtocolIdentifier::Binary,
                     )
@@ -1710,6 +1715,7 @@ mod tests {
             .open_stream(1, PayloadProtocolIdentifier::Binary)
             .and_then(|mut s| {
                 s.write_chunk_with_ppi(
+                    now,
                     &Bytes::from_static(b"pending payload on B"),
                     PayloadProtocolIdentifier::Binary,
                 )
@@ -1862,6 +1868,7 @@ mod tests {
         for i in 0..4u8 {
             stream
                 .write_chunk_with_ppi(
+                    base,
                     &Bytes::from(vec![i; 1024]),
                     PayloadProtocolIdentifier::Binary,
                 )


### PR DESCRIPTION
What changed

Public API — rtc_sctp::association::Stream<'a>. All six write_* methods now take now: Instant as the first parameter, matching the convention already used by Endpoint::write, Relay::send_to and RtpSender::write_rtp:
```
pub fn write_sctp(&mut self, now: Instant, p: &Bytes, ppi: PayloadProtocolIdentifier) -> Result<usize>
pub fn write(&mut self, now: Instant, data: &[u8]) -> Result<usize>
pub fn write_with_ppi(&mut self, now: Instant, data: &[u8], ppi: PayloadProtocolIdentifier) -> Result<usize>
pub fn write_chunk(&mut self, now: Instant, p: &Bytes) -> Result<usize>
pub fn write_chunk_with_ppi(&mut self, now: Instant, data: &Bytes, ppi: PayloadProtocolIdentifier) -> Result<usize>
pub fn write_chunks(&mut self, now: Instant, data: &mut [Bytes]) -> Result<usize>
```
Plus stop(now) and close(now) per your follow-up — stop queues an RFC 6525 reset chunk into pending_queue, so it's the same outbound path.

Private plumbing: write_source(now, …) → send_payload_data(_now, …), and send_reset_request(_now, …). Both accept the instant with a doc comment saying it's threaded from the caller and not yet consumed. No behaviour change — the parameter is unused today, which is why the test count is unchanged at 135.

The one production call site is handler/sctp.rs:634, inside handle_write, which already binds let now = msg.now. So the instant the peer connection receives from the application now reaches SCTP instead of being discarded at the boundary — which was the point.
