### PR TITLE
fix(sctp): enforce partial reliability across retransmission and reset

### DIFF
--- a/.github/workflows/sctp-interop.yml
+++ b/.github/workflows/sctp-interop.yml
@@ -1,0 +1,129 @@
+name: SCTP interoperability
+
+on:
+  push:
+    branches: [ master, v0.20.x, v0.21.x ]
+    paths:
+      - 'rtc-sctp/**'
+      - 'rtc-shared/**'
+      - 'rtc-datachannel/**'
+      - 'src/peer_connection/handler/mod.rs'
+      - 'src/peer_connection/handler/sctp.rs'
+      - 'src/peer_connection/handler/datachannel.rs'
+      - 'src/peer_connection/message/internal.rs'
+      - 'Cargo.toml'
+      - '.github/workflows/sctp-interop.yml'
+  pull_request:
+    branches: [ master, v0.20.x, v0.21.x ]
+    paths:
+      - 'rtc-sctp/**'
+      - 'rtc-shared/**'
+      - 'rtc-datachannel/**'
+      - 'src/peer_connection/handler/mod.rs'
+      - 'src/peer_connection/handler/sctp.rs'
+      - 'src/peer_connection/handler/datachannel.rs'
+      - 'src/peer_connection/message/internal.rs'
+      - 'Cargo.toml'
+      - '.github/workflows/sctp-interop.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  interop:
+    name: rtc with usrsctp and dcSCTP (both roles)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      SCTP_INTEROP_DIR: /tmp/sctp-interop
+      CARGO_TARGET_DIR: /tmp/sctp-interop-target
+      CARGO_TERM_COLOR: always
+      CC: clang
+      CXX: clang++
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Prepare artifacts
+        run: mkdir -p "$SCTP_INTEROP_DIR/artifacts/logs" "$SCTP_INTEROP_DIR/artifacts/manifests"
+
+      - name: Install test-only native build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake
+
+      - name: Check Python scripts
+        run: |
+          python3 -m py_compile rtc-sctp/interop/*.py
+          python3 rtc-sctp/interop/test_build_usrsctp.py -v
+
+      - name: Build pinned usrsctp and run its adapter self-test
+        run: |
+          python3 rtc-sctp/interop/build_usrsctp.py --build-dir "$SCTP_INTEROP_DIR/usrsctp" --self-test \
+            2>&1 | tee "$SCTP_INTEROP_DIR/artifacts/logs/usrsctp-build.log"
+
+      - name: Build pinned dcSCTP and run its adapter self-test
+        run: |
+          python3 rtc-sctp/interop/build_dcsctp.py --build-dir "$SCTP_INTEROP_DIR/dcsctp" --self-test \
+            2>&1 | tee "$SCTP_INTEROP_DIR/artifacts/logs/dcsctp-build.log"
+
+      - name: Build the rtc public API adapter
+        run: |
+          cargo build -p rtc-sctp --example sctp_interop --release \
+            2>&1 | tee "$SCTP_INTEROP_DIR/artifacts/logs/rtc-build.log"
+
+      - name: Run all 40 packet scenarios
+        run: |
+          python3 rtc-sctp/interop/run.py \
+            --rtc "$CARGO_TARGET_DIR/release/examples/sctp_interop" \
+            --usrsctp "$SCTP_INTEROP_DIR/usrsctp/build/usrsctp_peer" \
+            --dcsctp "$SCTP_INTEROP_DIR/dcsctp/build/dcsctp-peer" \
+            --output "$SCTP_INTEROP_DIR/artifacts/traces" \
+            2>&1 | tee "$SCTP_INTEROP_DIR/artifacts/logs/scenarios.log"
+
+      - name: Collect build inputs and manifests
+        if: always()
+        run: |
+          mkdir -p "$SCTP_INTEROP_DIR/artifacts/manifests"
+          git rev-parse HEAD > "$SCTP_INTEROP_DIR/artifacts/manifests/rtc-commit.txt"
+          rustc --version --verbose > "$SCTP_INTEROP_DIR/artifacts/manifests/rust-toolchain.txt" 2>&1 || true
+          python3 --version > "$SCTP_INTEROP_DIR/artifacts/manifests/python-version.txt" 2>&1 || true
+          clang --version > "$SCTP_INTEROP_DIR/artifacts/manifests/compiler.txt" 2>&1 || true
+          cmake --version > "$SCTP_INTEROP_DIR/artifacts/manifests/cmake-version.txt" 2>&1 || true
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          import shutil
+
+          root = Path(os.environ["SCTP_INTEROP_DIR"])
+          output = root / "artifacts/manifests"
+          files = {
+              Path("Cargo.lock"): "Cargo.lock",
+              root / "usrsctp/build/build.json": "usrsctp-build.json",
+              root / "dcsctp/project/CMakeLists.txt": "dcsctp-CMakeLists.txt",
+              root / "dcsctp/build/CMakeCache.txt": "dcsctp-CMakeCache.txt",
+              root / "dcsctp/self-test.jsonl": "dcsctp-self-test.jsonl",
+          }
+          for source, name in files.items():
+              if source.is_file():
+                  shutil.copyfile(source, output / name)
+          PY
+
+      - name: Upload traces and build manifests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sctp-interop-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.SCTP_INTEROP_DIR }}/artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/rtc-sctp/examples/sctp_e2e.rs
+++ b/rtc-sctp/examples/sctp_e2e.rs
@@ -85,6 +85,16 @@ impl Node {
             assoc.handle_timeout(now);
         }
 
+        while let Some(transmit) = assoc.poll_transmit(now) {
+            if let Payload::RawEncode(contents) = transmit.message {
+                for content in contents {
+                    outbound.push_back(content);
+                    did_work = true;
+                }
+            }
+        }
+
+        // poll_transmit can release buffered bytes and produce stream events.
         while let Some(event) = assoc.poll() {
             if matches!(event, Event::Connected) {
                 self.connected = true;
@@ -94,15 +104,6 @@ impl Node {
         while let Some(event) = assoc.poll_endpoint_event() {
             if let Some(ch) = self.handle {
                 self.endpoint.handle_event(ch, event);
-            }
-        }
-
-        while let Some(transmit) = assoc.poll_transmit(now) {
-            if let Payload::RawEncode(contents) = transmit.message {
-                for content in contents {
-                    outbound.push_back(content);
-                    did_work = true;
-                }
             }
         }
         self.timeout = assoc.poll_timeout();

--- a/rtc-sctp/examples/sctp_interop.rs
+++ b/rtc-sctp/examples/sctp_interop.rs
@@ -1,0 +1,307 @@
+//! Test-only line-protocol adapter for exchanges with independent SCTP stacks.
+//!
+//! Uses public rtc-sctp APIs, stdin/stdout and a caller-driven virtual clock.
+//! See `rtc-sctp/interop/README.md` for the protocol and scenario driver.
+
+use std::io::{self, BufRead, Write};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rtc_sctp::{
+    Association, AssociationHandle, ClientConfig, DatagramEvent, Endpoint, EndpointConfig, Event,
+    Payload, PayloadProtocolIdentifier, ReliabilityType, ServerConfig, TransportConfig,
+};
+use shared::TransportProtocol;
+
+const MAX_MESSAGE: usize = 1 << 20;
+const MAX_DRIVE: usize = 100_000;
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(DIGITS[(byte >> 4) as usize] as char);
+        out.push(DIGITS[(byte & 15) as usize] as char);
+    }
+    out
+}
+
+fn unhex(value: &str) -> Result<Bytes, String> {
+    if value == "-" {
+        return Ok(Bytes::new());
+    }
+    if !value.len().is_multiple_of(2) || value.len() > 2 * MAX_MESSAGE + 4096 {
+        return Err("invalid hex length".into());
+    }
+    let bytes: Result<Vec<_>, _> = value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let digit = |c: u8| (c as char).to_digit(16).ok_or("invalid hex digit");
+            Ok::<_, &str>((digit(pair[0])? * 16 + digit(pair[1])?) as u8)
+        })
+        .collect();
+    bytes.map(Bytes::from).map_err(String::from)
+}
+
+fn transport() -> TransportConfig {
+    TransportConfig::default()
+        .with_sctp_port(5000)
+        .with_max_message_size(MAX_MESSAGE as u32)
+        .with_max_receive_buffer_size(4 * MAX_MESSAGE as u32)
+        .with_max_num_inbound_streams(1024)
+        .with_max_num_outbound_streams(1024)
+}
+
+struct Peer {
+    endpoint: Endpoint,
+    peer_addr: SocketAddr,
+    handle: Option<AssociationHandle>,
+    association: Option<Association>,
+    now: Instant,
+    passive: bool,
+}
+
+impl Peer {
+    fn new(role: &str) -> Result<Self, String> {
+        let passive = match role {
+            "client" => false,
+            "server" => true,
+            _ => return Err("expected INIT client or server".into()),
+        };
+        let local_addr = "127.0.0.1:5000".parse().unwrap();
+        let peer_addr = "127.0.0.2:5000".parse().unwrap();
+        let mut config = EndpointConfig::default();
+        // The same packet budget as the external adapters. No IP socket is used.
+        config.max_payload_size(rtc_sctp::max_payload_size_for_mtu(1200));
+        Ok(Self {
+            endpoint: Endpoint::new(
+                local_addr,
+                TransportProtocol::UDP,
+                Arc::new(config),
+                passive.then(|| Arc::new(ServerConfig::new(transport()))),
+            ),
+            peer_addr,
+            handle: None,
+            association: None,
+            now: Instant::now(),
+            passive,
+        })
+    }
+
+    fn pump(&mut self) -> Result<(), String> {
+        let Some(association) = self.association.as_mut() else {
+            return Ok(());
+        };
+        // Reading can produce window updates or finish application close. Drain
+        // those outputs in the same command, with an explicit runaway bound.
+        for _ in 0..MAX_DRIVE {
+            let mut progress = false;
+            if let Some(transmit) = association.poll_transmit(self.now) {
+                if let Payload::RawEncode(packets) = transmit.message {
+                    for packet in packets {
+                        println!("PACKET {}", hex(&packet));
+                    }
+                }
+                progress = true;
+            }
+            while let Some(event) = association.poll() {
+                match event {
+                    Event::Connected => println!("EVENT ready"),
+                    Event::HandshakeFailed { reason } => {
+                        println!("EVENT error:handshake:{reason}")
+                    }
+                    Event::AssociationLost { reason, id } => {
+                        if association.is_closed() {
+                            println!("EVENT error:association:{reason}");
+                            println!("EVENT closed");
+                        } else {
+                            println!("EVENT stream_closed:{id}");
+                        }
+                    }
+                    _ => {}
+                }
+                progress = true;
+            }
+            for sid in association.stream_ids() {
+                // Reacquire the public handle: reading the final old message
+                // may retire the API object or make a later generation visible.
+                while let Ok(mut stream) = association.stream(sid) {
+                    match stream.read_sctp() {
+                        Ok(Some(message)) => {
+                            let payload = message
+                                .to_payload(MAX_MESSAGE)
+                                .map_err(|error| error.to_string())?;
+                            println!("MESSAGE {sid} {} {}", message.ppi as u32, hex(&payload));
+                            progress = true;
+                        }
+                        Ok(None) | Err(_) => break,
+                    }
+                }
+            }
+            while let Some(event) = association.poll_endpoint_event() {
+                if let Some(handle) = self.handle {
+                    self.endpoint.handle_event(handle, event);
+                }
+                progress = true;
+            }
+            if !progress {
+                return Ok(());
+            }
+        }
+        Err("drive iteration limit".into())
+    }
+
+    fn advance(&mut self, delta_ms: u64) -> Result<(), String> {
+        if delta_ms > 3_600_000 {
+            return Err("TICK exceeds one hour".into());
+        }
+        let target = self.now + Duration::from_millis(delta_ms);
+        for _ in 0..MAX_DRIVE {
+            let next = self
+                .association
+                .as_ref()
+                .and_then(Association::poll_timeout);
+            if let Some(deadline) = next
+                && deadline <= target
+            {
+                self.now = self.now.max(deadline);
+                self.association.as_mut().unwrap().handle_timeout(self.now);
+                self.pump()?;
+            } else {
+                self.now = target;
+                return self.pump();
+            }
+        }
+        Err("timeout iteration limit".into())
+    }
+
+    fn command(&mut self, words: &[&str]) -> Result<(), String> {
+        match words {
+            ["CONNECT"] if !self.passive && self.association.is_none() => {
+                let (handle, association) = self
+                    .endpoint
+                    .connect(self.now, ClientConfig::new(transport()), self.peer_addr)
+                    .map_err(|error| error.to_string())?;
+                self.handle = Some(handle);
+                self.association = Some(association);
+            }
+            ["INPUT", packet] => {
+                let packet = unhex(packet)?;
+                if let Some((handle, event)) =
+                    self.endpoint.handle(self.now, self.peer_addr, None, packet)
+                {
+                    match event {
+                        DatagramEvent::NewAssociation(association) => {
+                            self.handle = Some(handle);
+                            self.association = Some(association);
+                        }
+                        DatagramEvent::AssociationEvent(event) => {
+                            if let Some(association) = self.association.as_mut() {
+                                association.handle_event(event);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            ["SEND", sid, order, policy, ppid, payload] => {
+                let sid = sid.parse::<u16>().map_err(|e| e.to_string())?;
+                let ppid = ppid.parse::<u32>().map_err(|e| e.to_string())?;
+                let ppi = PayloadProtocolIdentifier::from(ppid);
+                if ppi == PayloadProtocolIdentifier::Unknown {
+                    return Err("rtc public API supports WebRTC PPIDs only".into());
+                }
+                let unordered = match *order {
+                    "ordered" => false,
+                    "unordered" => true,
+                    _ => return Err("invalid ordering".into()),
+                };
+                let (kind, value) = if *policy == "reliable" {
+                    (ReliabilityType::Reliable, 0)
+                } else if let Some(value) = policy.strip_prefix("timed:") {
+                    (
+                        ReliabilityType::Timed,
+                        value.parse::<u32>().map_err(|e| e.to_string())?,
+                    )
+                } else if let Some(value) = policy.strip_prefix("rexmit:") {
+                    (
+                        ReliabilityType::Rexmit,
+                        value.parse::<u32>().map_err(|e| e.to_string())?,
+                    )
+                } else {
+                    return Err("invalid policy".into());
+                };
+                let payload = unhex(payload)?;
+                if payload.is_empty() || payload.len() > MAX_MESSAGE {
+                    return Err("payload must contain 1..1048576 bytes".into());
+                }
+                let association = self.association.as_mut().ok_or("no association")?;
+                if !association.stream_ids().contains(&sid) {
+                    association
+                        .open_stream(sid, ppi)
+                        .map_err(|e| e.to_string())?;
+                }
+                let mut stream = association.stream(sid).map_err(|e| e.to_string())?;
+                stream
+                    .set_reliability_params(unordered, kind, value)
+                    .map_err(|e| e.to_string())?;
+                stream
+                    .write_sctp(self.now, &payload, ppi)
+                    .map_err(|e| e.to_string())?;
+            }
+            ["RESET", list] => {
+                let association = self.association.as_mut().ok_or("no association")?;
+                for sid in list.split(',') {
+                    let sid = sid.parse::<u16>().map_err(|e| e.to_string())?;
+                    if !association.stream_ids().contains(&sid) {
+                        association
+                            .open_stream(sid, PayloadProtocolIdentifier::Binary)
+                            .map_err(|e| e.to_string())?;
+                    }
+                    // stop() is the public API that initiates an outgoing reset
+                    // while allowing writes after the eventual reset result.
+                    association
+                        .stream(sid)
+                        .map_err(|e| e.to_string())?
+                        .stop(self.now)
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            ["TICK", elapsed] => {
+                return self.advance(elapsed.parse::<u64>().map_err(|e| e.to_string())?);
+            }
+            ["POLL"] => return self.advance(0),
+            _ => return Err("unknown command or invalid arguments".into()),
+        }
+        self.pump()
+    }
+}
+
+fn main() -> io::Result<()> {
+    let mut peer = None;
+    for line in io::stdin().lock().lines() {
+        let line = line?;
+        let words: Vec<_> = line.split_whitespace().collect();
+        let result = match words.as_slice() {
+            ["QUIT"] => {
+                println!("DONE");
+                io::stdout().flush()?;
+                break;
+            }
+            ["INIT", role] if peer.is_none() => Peer::new(role).map(|p| peer = Some(p)),
+            _ => match peer.as_mut() {
+                Some(peer) => peer.command(&words),
+                None => Err("INIT required".into()),
+            },
+        };
+        if let Err(error) = result {
+            println!("ERROR {}", error.replace(['\r', '\n'], " "));
+        }
+        println!("DONE");
+        io::stdout().flush()?;
+    }
+    Ok(())
+}

--- a/rtc-sctp/fuzz/Cargo.toml
+++ b/rtc-sctp/fuzz/Cargo.toml
@@ -24,6 +24,13 @@ default-features = false
 members = ["."]
 
 [[bin]]
+name = "association_state"
+path = "fuzz_targets/association_state.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "packet_unmarshal"
 path = "fuzz_targets/packet_unmarshal.rs"
 test = false

--- a/rtc-sctp/fuzz/README.md
+++ b/rtc-sctp/fuzz/README.md
@@ -1,0 +1,97 @@
+# Stateful SCTP scenarios
+
+`association_state` complements the packet/parameter parser targets. It establishes
+two real sans-I/O endpoints, completes a valid handshake, and then uses the public
+stream API. The network queue contains original packets emitted by the endpoints;
+loss, duplication, and reordering do not invent invalid RSNs, verification tags or
+checksums. The adapter interoperability suite is a separate test surface.
+
+The shared driver in `src/fuzzing_state.rs` checks:
+
+- Whole message contents and ownership, no duplicate application delivery, and
+  ordered delivery on each SID.
+- Timed policy at the instant `poll_transmit` emits DATA, including no Timed(0)
+  retransmission; Rexmit budgets are checked for each transmitted TSN.
+- Every accepted byte is counted on write, release events never exceed accepted
+  bytes, and live send buffers return to zero after the network becomes fair.
+  With no reset, release events must account for every accepted byte exactly.
+- A fair network and an application reading all available messages must reach
+  quiescence. Reliable messages must arrive unless the receiving application
+  stopped its read half or the association exhausted its allowed failures.
+
+Application and network choices are deterministic from the input. The driver is
+given an `Instant` origin and advances only virtual time. The endpoint's normal
+random handshake fields are not overridden; failure traces identify commands and
+relative time instead of assuming constant TSNs. The generated packet trace is
+protocol-valid for that particular association.
+
+Each action occupies four bytes `op, side_and_sid, flags, size`. At most 128
+actions are read; trailing incomplete actions are ignored. `side_and_sid & 1`
+chooses the side, `(side_and_sid >> 1) % 3` the SID, and `size % 3` chooses 32,
+1200 or 4000 payload bytes. `op % 12` selects:
+
+| Operation | Effect |
+| --- | --- |
+| 0 / 1 / 2 | Send Reliable / Timed(0,1,100) / Rexmit(0,1,2). |
+| 3 | Deliver a selected queued packet. |
+| 4 / 5 | Drop / duplicate a selected packet. |
+| 6 | Advance time by 0, 1, 100, 500 or 1100 ms. |
+| 7 | Read a side's available messages. |
+| 8 | Stop, finish or close the selected stream. |
+| 9 | Try to open/reuse the selected SID. |
+| 10 | Deliver the newest packet before older packets. |
+| 11 | Poll output and application events. |
+
+Command attempts rejected by the public API are not treated as successful writes.
+After the actions, all packet loss stops and both applications read. Explicit
+named regression tests additionally assert successful close/reopen and writable
+half behavior; these expectations are not conditional on API success.
+
+Run the critical matrix, short regressions, and 48 fixed seed scenarios without
+installing a fuzzer:
+
+```sh
+cargo test -p rtc-sctp --lib model_
+cargo test -p rtc-sctp --lib --release model_
+```
+
+With `cargo-fuzz` and a nightly toolchain available:
+
+```sh
+cd rtc-sctp
+cargo +nightly fuzz run association_state -- -seed=237 -max_len=512 -max_total_time=60
+```
+
+The ordinary library has no new dependency. The separate existing fuzz package
+uses `libfuzzer-sys`. A stable-toolchain smoke build is also possible, but does
+not enable coverage instrumentation or sanitizers:
+
+```sh
+cargo build --manifest-path rtc-sctp/fuzz/Cargo.toml \
+  --bin association_state --features rtc-sctp/bench
+rtc-sctp/fuzz/target/debug/association_state -runs=1000 -seed=237 -max_len=512
+```
+
+`model_replay_input` accepts a hex input through `RTC_SCTP_MODEL_INPUT`:
+
+```sh
+RTC_SCTP_MODEL_INPUT=6832487ee4db0a22 \
+  cargo test -p rtc-sctp --lib model_replay_input -- --nocapture
+```
+
+For a failure, `minimize_association_state.py` deletes whole commands and retains
+only a still-failing sequence. Pass the actual test executable printed by Cargo
+and an output path outside the source tree. It writes the minimized `.bin`, a
+`.log`, and metadata with a binary hash; `--contains` keeps a particular failure.
+
+```sh
+python3 rtc-sctp/fuzz/minimize_association_state.py \
+  --test-binary /path/to/debug/deps/rtc_sctp-HASH \
+  --input-hex HEX_FROM_FAILURE --contains 'protocol did not quiesce' \
+  --output /tmp/sctp-minimized
+```
+
+The bounded scenarios are a regression and fuzzing surface, not a proof of every
+SCTP event ordering. Packet corruption remains covered by the parser targets;
+peer cache size, external timers and interoperability are covered by the pinned
+usrsctp/dcSCTP suite.

--- a/rtc-sctp/fuzz/fuzz_targets/association_state.rs
+++ b/rtc-sctp/fuzz/fuzz_targets/association_state.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: &[u8]| {
+    rtc_sctp::fuzzing::association_state(input, std::time::Instant::now());
+});

--- a/rtc-sctp/fuzz/minimize_association_state.py
+++ b/rtc-sctp/fuzz/minimize_association_state.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Reduce a failing Association scenario by removing whole four-byte actions.
+
+Build the rtc-sctp library tests first and pass the executable Cargo prints after
+`Running unittests`. This runs the public model replay test in fresh subprocesses;
+it never changes the repository, production state, or a global Rust panic hook.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--test-binary", type=Path, required=True)
+    parser.add_argument("--input-hex", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--contains", default="", help="retain this failure text")
+    args = parser.parse_args()
+    data = bytes.fromhex(args.input_hex)
+    if len(data) % 4:
+        parser.error("input must contain whole four-byte actions")
+    binary = args.test_binary.resolve()
+    command = [str(binary), "--exact", "association::model_test::model_replay_input", "--nocapture"]
+    calls = 0
+
+    def fails(actions):
+        nonlocal calls
+        calls += 1
+        environment = os.environ.copy()
+        environment["RTC_SCTP_MODEL_INPUT"] = b"".join(actions).hex()
+        result = subprocess.run(command, env=environment, capture_output=True,
+                                text=True, timeout=30)
+        text = result.stdout + result.stderr
+        return result.returncode != 0 and args.contains in text, text
+
+    actions = [data[index:index + 4] for index in range(0, len(data), 4)]
+    if not fails(actions)[0]:
+        parser.error("the supplied input does not reproduce the requested failure")
+    size = max(1, len(actions) // 2)
+    while size:
+        index = 0
+        while index + size <= len(actions):
+            candidate = actions[:index] + actions[index + size:]
+            if fails(candidate)[0]:
+                actions = candidate
+            else:
+                index += size
+        size //= 2
+    failed, trace = fails(actions)
+    if not failed:
+        raise RuntimeError("reduced input did not replay consistently")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.with_suffix(".bin").write_bytes(b"".join(actions))
+    args.output.with_suffix(".log").write_text(trace)
+    metadata = {
+        "input_hex": b"".join(actions).hex(),
+        "actions": len(actions),
+        "subprocess_runs": calls,
+        "test_binary": str(binary),
+        "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+        "failure_filter": args.contains,
+    }
+    args.output.with_suffix(".json").write_text(json.dumps(metadata, indent=2) + "\n")
+    print(json.dumps(metadata, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/README-dcsctp.md
+++ b/rtc-sctp/interop/README-dcsctp.md
@@ -1,0 +1,111 @@
+# WebRTC dcSCTP packet adapter
+
+This test peer runs the actual C++ dcSCTP implementation from WebRTC. It is
+separate from the newer `webrtc/dcsctp` Rust project. It is never built or linked
+by an ordinary Cargo build of `rtc-sctp`.
+
+Pinned sources:
+
+| Dependency | Revision |
+| --- | --- |
+| [WebRTC](https://webrtc.googlesource.com/src/+/dab572fd15e3fb975ed14a9e9290f723bb6e3f30) | `dab572fd15e3fb975ed14a9e9290f723bb6e3f30` |
+| [Abseil](https://github.com/abseil/abseil-cpp/tree/c2336f9b5cb94b877ae3e38629e3b4530e60c89f) | `c2336f9b5cb94b877ae3e38629e3b4530e60c89f` |
+
+The Abseil revision is recorded by `third_party/abseil-cpp/README.chromium` at
+Chromium third_party `3c7ceaeb6bd16f270f6938b22db67b164a5b7b1d`, selected by
+the pinned WebRTC `DEPS`. Only `net/dcsctp`, `api`, and `rtc_base` are downloaded
+from WebRTC; its audio/video engine, depot_tools, and GN are not needed. Upstream
+sources are not patched. CMake builds dcSCTP, its small WebRTC support files,
+and the required Abseil targets. Upstream licenses are retained in the build
+directory. Downloaded sources and binaries stay outside the repository.
+
+## Build and check
+
+Requirements: Python 3.12 or newer, a C++20 compiler, CMake, and Make (or the
+generator selected through CMake's normal environment). This was checked with
+Apple Clang 16.0.0, CMake 3.31.6, and Make on arm64 macOS.
+
+```sh
+python3 rtc-sctp/interop/build_dcsctp.py \
+  --build-dir /tmp/rtc-237-dcsctp --self-test
+export RTC_DCSCTP_PEER=/tmp/rtc-237-dcsctp/build/dcsctp-peer
+```
+
+If CMake is unavailable, install only the test tool into the temporary build
+directory, then pass the native executable directly:
+
+```sh
+python3 -m pip install --target /tmp/rtc-237-dcsctp/tools cmake==3.31.6
+python3 rtc-sctp/interop/build_dcsctp.py \
+  --build-dir /tmp/rtc-237-dcsctp \
+  --cmake /tmp/rtc-237-dcsctp/tools/cmake/data/bin/cmake --self-test
+```
+
+`--self-test` starts two independent processes, establishes an association,
+delivers fragmented reliable messages in both directions, drops the first
+Timed DATA, drops a fragment of Rexmit(0), and loses a successful reset response.
+It verifies subsequent message delivery and reset completion using the real
+peer, and records commands, packets, events, and virtual timestamps in
+`self-test.jsonl`. Reads and event loops have explicit limits so a broken peer
+fails the check instead of hanging indefinitely.
+
+## Line protocol
+
+Each command ends with one `DONE` line. Packet and application callbacks occur
+before that line. Commands are processed synchronously; no output is generated
+between commands.
+
+| Input | Meaning |
+| --- | --- |
+| `INIT client` or `INIT server` | Construct one peer; local and remote SCTP ports are both 5000. |
+| `CONNECT` | Begin the ordinary SCTP handshake; a passive peer only needs `INIT server`. |
+| `SEND sid ordered\|unordered reliable\|timed:N\|rexmit:N ppid hex` | Enqueue a message with the native dcSCTP policy. |
+| `RESET sid[,sid...]` | Request an outgoing stream reset. |
+| `INPUT hex` | Deliver an entire raw SCTP packet, including its common header and checksum. |
+| `TICK delta_ms` | Advance virtual time by a nonnegative number of milliseconds. |
+| `POLL` | Process timeouts due at the current virtual time. |
+| `QUIT` | End the process after `DONE`. |
+
+Output lines are `PACKET hex`, `MESSAGE sid ppid hex`, `EVENT ready`,
+`EVENT closed`, `EVENT restarted`, `EVENT reset_in:SID`, `EVENT reset_out:SID`,
+or `EVENT reset_failed:SID:reason`. An incoming all-stream reset is reported as
+`EVENT reset_in:all`. Nonfatal native errors are `EVENT error:kind:reason`;
+aborts also emit `EVENT closed`. Command validation failures are `ERROR text`
+followed by `DONE`. A zero-length byte string is `-`; dcSCTP rejects zero-length
+user messages through its normal send result.
+
+Each outgoing packet is immediately preceded by `EVENT packet_time:MS`, carrying
+the peer's virtual time at the actual send callback. Preserve that value with
+the following packet: a timer may fire before the end of a large `TICK`, so the
+driver's time after the command alone is not the time of the transmission attempt.
+
+`RESET` represents the native outgoing SCTP operation. The adapter reports an
+incoming reset but does not silently initiate the other direction; the scenario
+driver controls both directions when modeling DataChannel close.
+
+## Time, randomness, and settings
+
+All dcSCTP time comes from `Now()`/`TimeMillis()` and callback-created timeouts.
+`TICK` fires due callbacks in deadline order, moving virtual time to each
+deadline before invoking the socket. Equal deadlines use timeout creation order.
+There are no worker threads or calls to a wall clock in the adapter. During a
+large tick, emitted packets can be held by the driver until it advances the
+other peer; this represents network delay. Scenarios needing finer ordering
+should use smaller ticks and record their delivery decisions.
+
+The deterministic random generator uses an explicitly defined 32-bit LCG and
+rejection sampling, with seeds `0x12345678` (client) and `0x87654321` (server).
+It is solely test input, not a security mechanism. The same commands produce
+the same raw handshake and DATA packets for the same pinned sources.
+
+PR-SCTP is enabled; message interleaving is disabled so comparisons use DATA and
+FORWARD-TSN. Heartbeats are disabled. The maximum message is 1 MiB and the send
+buffer is 2 MiB. Other dcSCTP defaults, including MTU 1191, initial RTO 500 ms,
+minimum RTO 400 ms, and maximum RTO 60 seconds, are retained. Checksum generation
+and validation use upstream Abseil CRC32C and are enabled.
+
+`timed:N` maps directly to `SendOptions.lifetime=N`. At this pinned revision,
+dcSCTP computes its deadline as `now + N + 1 ms` and expires messages at or beyond
+that deadline. In particular, `timed:0` can transmit during the enqueue
+millisecond. This native difference must be accounted for when comparing with
+the `rtc-sctp` API; the adapter does not alter peer policy to hide it.

--- a/rtc-sctp/interop/README-usrsctp.md
+++ b/rtc-sctp/interop/README-usrsctp.md
@@ -1,0 +1,115 @@
+# usrsctp test peer
+
+This is a real usrsctp association, using its `AF_CONN` interface to exchange raw
+SCTP packets over stdin/stdout. It does not open an IP socket or replace the
+stack's SCTP algorithms. It is a test executable and is not linked into `rtc-sctp`.
+
+The source is pinned to
+[`fd070e05a7474f38c7fecdf4d4b6005d2547ee00`](https://github.com/sctplab/usrsctp/tree/fd070e05a7474f38c7fecdf4d4b6005d2547ee00).
+The build script fetches it into a separate directory; no usrsctp source is
+vendored in this repository. Dependencies are Python 3.9+, git and a C11 compiler
+with POSIX threads (`clang` by default). The script supports macOS and Linux;
+macOS was exercised during implementation.
+
+From the repository root:
+
+```sh
+python3 rtc-sctp/interop/build_usrsctp.py --self-test
+```
+
+The default build directory is `/tmp/rtc-237-usrsctp`. The resulting executable
+is `/tmp/rtc-237-usrsctp/build/usrsctp_peer`. `build/build.json` records the exact
+source revision, adapter hash, compiler, flags and stack settings. A repeat build
+can prohibit network access:
+
+```sh
+python3 rtc-sctp/interop/build_usrsctp.py --offline --self-test
+```
+
+Use `--build-dir PATH`, `--cc PATH`, and `--jobs N` to change build locations or
+tools. No package installation, CMake, or change to the ordinary Cargo build is
+required. The external checkout must be clean; the script refuses to overwrite
+modified source.
+
+## Command protocol
+
+Each input line is one command. All output caused by that command precedes its
+`DONE` line. Input numbers use decimal and packet/message bytes use hexadecimal.
+`-` represents an empty byte string; SCTP send itself may reject an empty message.
+Start a separate process for each association.
+
+| Input | Meaning |
+| --- | --- |
+| `INIT client` / `INIT server` | Initialize once; server binds and listens immediately. |
+| `CONNECT` | Initiate the client handshake. The server is passive. |
+| `SEND sid ordered reliable ppid hex` | Queue an ordered reliable message. |
+| `SEND sid unordered timed:100 ppid hex` | Queue an unordered message with TTL 100 ms. |
+| `SEND sid ordered rexmit:0 ppid hex` | Queue a message with zero retransmissions. |
+| `RESET sid[,sid...]` | Request reset of the specified outgoing directions. |
+| `INPUT hex` | Deliver a complete SCTP packet, with its original checksum. |
+| `TICK milliseconds` | Advance the test clock by a relative interval (0–3,600,000 ms). |
+| `POLL` | Service nonblocking accept; callbacks otherwise run during commands. |
+| `QUIT` | Close sockets, perform bounded cleanup, report `DONE`, and exit. |
+
+The order and policy fields in `SEND` are independent: `ordered` or `unordered`
+can be paired with `reliable`, `timed:N`, or `rexmit:N`. The adapter maps these to
+`SCTP_PR_SCTP_NONE`, `SCTP_PR_SCTP_TTL`, and `SCTP_PR_SCTP_RTX` without normalizing
+zero TTL; differences from the `rtc` or dcSCTP API belong in scenario expectations.
+
+| Output | Meaning |
+| --- | --- |
+| `PACKET hex` | A complete packet emitted by the real stack; the harness chooses its delivery. |
+| `MESSAGE sid ppid hex` | One complete message delivered to the application. |
+| `EVENT ready` | Association established. |
+| `EVENT reset_in:SID` / `EVENT reset_out:SID` | That direction's reset completed. |
+| `EVENT send_failed:SID:code` | usrsctp send-failure notification, including PR abandonment. |
+| `EVENT closed` | Association closure notification. |
+| `EVENT error:text` | Asynchronous stack failure. |
+| `ERROR text` | The command was rejected; the following `DONE` still ends it. |
+| `DONE` | End of command output. |
+
+Both SCTP ports are 5000. The peer negotiates 1024 streams each way, enables
+PR-SCTP and stream reset, disables ECN, heartbeat and path-MTU discovery, uses a
+1200-byte path MTU and 4 MiB socket buffers, and enables `SCTP_NODELAY`. usrsctp's
+default RTO parameters remain in effect. `RESET` resets the outgoing direction;
+the harness must request the opposite direction when modelling a full data
+channel close. The peer does not automatically invent a reciprocal application
+close. A complete incoming message is read immediately by the callback. Therefore
+slow-reader/rwnd tests must put the slow reader on the `rtc` side; this adapter
+does not expose a paused application read queue.
+
+## Time and reproducibility
+
+`usrsctp_init_nothreads` disables background workers. `TICK` advances both the
+callout wheel (`usrsctp_handle_timers`) and the `gettimeofday` values used for
+PR-SCTP deadlines. The test build injects a header into library translation units
+which replaces `gettimeofday` with `rtc_usrsctp_gettimeofday`. It includes the
+platform time header before defining the macro, avoiding Darwin symbol aliases
+silently bypassing the hook. It makes no changes to upstream source files.
+
+Time starts at the fixed nonzero epoch 1,700,000,000,000 ms and only advances on
+`TICK`. Larger intervals are serviced in steps of at most 10 ms so a timer
+scheduled by a callback has a meaningful intermediate timestamp. Exact boundary
+tests can use 1 ms ticks. `POLL` and `INPUT` do not advance time. There is no
+wall-clock sleep in this peer. The self-test deliberately loses a Timed packet,
+advances virtual time, and checks that the stack emits FORWARD-TSN instead of
+retransmitting DATA; it would fail if only the callout wheel were virtualized.
+
+Randomness remains the stack's normal system entropy. The initial TSNs, tags and
+cookies consequently differ across processes. A scenario replay can reproduce
+application actions and loss choices by decoded chunk properties; byte-for-byte
+replay must retain the original packet trace. Record `build.json`, commands,
+virtual timestamps, network seed and original packet bytes with each run.
+
+`--self-test` starts two independent peer processes and checks the real handshake,
+reliable and timed messages in both directions, fragmented Rexmit(0), outgoing
+and reciprocal reset, SID reuse, and virtual TTL expiry after a lost DATA packet.
+It tests the adapter's plumbing; the shared Rust scenario suite supplies the
+`rtc ↔ usrsctp` protocol/regression checks.
+
+The limited reset-result cache used by interoperability scenarios is implemented
+in the pinned stack's
+[`sctp_handle_str_reset_request_out`](https://github.com/sctplab/usrsctp/blob/fd070e05a7474f38c7fecdf4d4b6005d2547ee00/usrsctplib/netinet/sctp_input.c):
+the preceding two RSNs can replay a stored result, while older requests receive
+`ErrorBadSequenceNumber`. This executable exercises that implementation directly;
+an individually synthesized response in a Rust unit test is a separate check.

--- a/rtc-sctp/interop/README.md
+++ b/rtc-sctp/interop/README.md
@@ -1,0 +1,241 @@
+SCTP packet interoperability tests
+
+These test adapters exchange raw SCTP packets between the public `rtc-sctp` API
+and two independent implementations. They open no UDP or DTLS sockets. C/C++ and
+the external sources are test dependencies only; the normal Cargo build does
+not compile or link them.
+
+**Build and run**
+
+Requirements: Rust/Cargo, Python 3.12+, git, a C11/C++20 compiler, and CMake 3.16+.
+The scripts support macOS and Linux. The initial external builds download pinned
+public sources; subsequent builds reuse them. Build artifacts stay outside the
+checkout.
+
+```sh
+python3 rtc-sctp/interop/build_usrsctp.py --build-dir /tmp/rtc-237-usrsctp --self-test
+python3 rtc-sctp/interop/build_dcsctp.py --build-dir /tmp/rtc-237-dcsctp --self-test
+CARGO_TARGET_DIR=/tmp/rtc-237-target-implementation cargo build -p rtc-sctp --example sctp_interop --release
+python3 rtc-sctp/interop/run.py \
+  --rtc /tmp/rtc-237-target-implementation/release/examples/sctp_interop \
+  --usrsctp /tmp/rtc-237-usrsctp/build/usrsctp_peer \
+  --dcsctp /tmp/rtc-237-dcsctp/build/dcsctp-peer \
+  --output /tmp/rtc-237-interop-traces
+```
+
+Use different `CARGO_TARGET_DIR` values when comparing source snapshots. Each
+trace records the exact adapter binary SHA-256. `--scenario` and `--role` may be
+repeated to select cases; role describes the rtc endpoint. For example:
+
+```sh
+python3 rtc-sctp/interop/run.py \
+  --rtc /tmp/rtc-237-target-implementation/release/examples/sctp_interop \
+  --usrsctp /tmp/rtc-237-usrsctp/build/usrsctp_peer \
+  --output /tmp/rtc-237-interop-reset \
+  --scenario forgotten_result_recovery --role client --seed 237
+```
+
+The default suite has 40 cases: two peers × both rtc handshake roles × ten
+scenarios. Application traffic runs in both directions. Each command has a
+5-second wall-clock limit; each case has a 45-second limit and bounded packet,
+command, and virtual-time loops. Failed cases produce nonzero exit status and
+retain their traces. `summary.json` records every result; `*.jsonl` contains
+application commands, original packet hex, decoded DATA/SACK/RE-CONFIG/FORWARD-TSN,
+network actions, virtual timestamps and application events. `*.stderr` retains
+adapter diagnostics.
+
+| Scenario | Checked property |
+|---|---|
+| `reliable` | Fragmented ordered and unordered messages arrive byte-for-byte once; a held DATA followed by a duplicate preserves ordered delivery. |
+| `timed_rtc`, `timed_peer` | Lose the first of two fragments; after Timed(100), no DATA is transmitted for that message, FORWARD-TSN completes abandonment, and the next reliable message is readable. Two fragments avoid legitimate fast recovery before the deadline. |
+| `rexmit_rtc`, `rexmit_peer` | Lose the first fragment of a 9000-byte Rexmit(0) message; no TSN is transmitted twice, the message is abandoned as a whole, and subsequent reliable traffic works. |
+| `lost_response_rtc`, `lost_response_peer` | Remove the first successful reset response parameter, preserving any bundled request/SACK. Reset recovers and ordered messages work on the reused SID. |
+| `simultaneous_reset` | Both endpoints issue outgoing reset before either request is delivered. Both can subsequently send on the reused SID. |
+| `sequential_resets` | Lose an explicit result, exchange an unrelated peer reset, complete two more resets, then deliver an actual delayed duplicate of the first request. Both real peers return BadSequence for the evicted result; the stale response must not rewind SSN. |
+| `forgotten_result_recovery` | Hold successful responses to N, supply an implicit ACK, queue two further resets and a write. A real retry must repeat the unchanged N; no newer request or queued DATA may escape before its result. Restore responses, verify N succeeds without cache eviction, and verify the two queued resets start and DATA uses the correct SSNs. |
+
+The last case has one explicitly logged compatibility adjustment: the pinned
+dcSCTP fills OutgoingResetRequest.response_sequence with its own request number,
+so it cannot naturally supply the intended E1 acknowledgement. The harness
+corrects that field to the last request actually received, retaining dcSCTP's
+request RSN, TSN boundary, SID list, and all other parameters, then recomputes
+CRC32C. Its actual receive/reset/result-cache implementation handles the replay.
+The correction is recorded as `normalize_peer_A4`. usrsctp already sends the
+proper field, and all other scenarios use unmodified peer fields. This case
+must not be described as an unmodified dcSCTP implicit-ACK trace.
+
+**Pinned implementations and clocks**
+
+| Peer | Sources | Clock and entropy |
+|---|---|---|
+| usrsctp | `fd070e05a7474f38c7fecdf4d4b6005d2547ee00`, [upstream](https://github.com/sctplab/usrsctp/tree/fd070e05a7474f38c7fecdf4d4b6005d2547ee00) | AF_CONN, `usrsctp_init_nothreads`, explicit `usrsctp_handle_timers`; a test-build `gettimeofday` hook advances TTL and callouts together. Original system entropy generates association IDs/cookies. Build configuration is in `build/build.json`. |
+| dcSCTP | WebRTC `dab572fd15e3fb975ed14a9e9290f723bb6e3f30`, [upstream](https://webrtc.googlesource.com/src/+/dab572fd15e3fb975ed14a9e9290f723bb6e3f30/net/dcsctp/); Abseil `c2336f9b5cb94b877ae3e38629e3b4530e60c89f` from pinned DEPS | Public packet API, virtual callbacks/timeouts, fixed per-role random seed, no task queue or real clock. |
+| rtc | Current Cargo snapshot, `examples/sctp_interop.rs` | Only public Endpoint/Association/Stream APIs. One startup Instant anchors elapsed virtual time; all subsequent time comes from TICK. Production random Initial TSN/vtag generation is preserved. |
+
+Ports are 5000 in both directions; message size is limited to 1 MiB. The rtc and
+usrsctp adapters use a 1200-byte SCTP packet budget. Message interleaving is
+disabled on dcSCTP so DATA/FORWARD-TSN properties are directly comparable.
+Incoming application messages are read immediately by each adapter; delayed
+application reads and DataChannel registry event ordering are tested at the
+Rust integration layer.
+
+The driver advances both peer clocks in steps of at most 10 ms before delivering
+new packets. An external callback may have run inside that interval; the JSONL
+timestamp is its end. dcSCTP additionally emits `EVENT packet_time:<ms>` before
+each packet; the driver records this callback time as `send_time_ms` and uses it
+for lifetime checks. Exact deadline equality belongs in the deterministic rtc
+unit tests. This suite uses Timed(100) and retransmission times well beyond that
+deadline. It does not equate rtc's compatibility mapping of Timed(0) with
+dcSCTP's one-millisecond lifetime quantization.
+
+`--seed` reproduces application payloads and network decisions. Cryptographic
+association numbers and cookies in rtc/usrsctp intentionally remain random;
+bit-for-bit packet equality across fresh processes is not promised. Captured
+bytes are preserved for diagnosis, while protocol comparisons should normalize
+TSNs/RSNs relative to each association's recorded initial values. No manually
+invented RSN is substituted for an emitted request.
+
+**Adapter protocol**
+
+Every command is a single line; its zero or more output lines end with `DONE`.
+The driver serializes commands, so the terminator unambiguously marks completion.
+
+| Input | Meaning |
+|---|---|
+| `INIT client` / `INIT server` | Create an active/passive endpoint. |
+| `CONNECT` | Active endpoint starts association establishment. |
+| `INPUT <hex>` | Receive one complete SCTP packet. |
+| `SEND <sid> ordered\|unordered reliable\|timed:N\|rexmit:N <ppid> <hex>` | Queue a complete application message with immutable policy. Use WebRTC PPID 53 for binary data. |
+| `RESET <sid[,sid...]>` | Request outgoing reset. rtc maps this to its existing `stop(now)` API, preserving writable behavior. |
+| `TICK <elapsed-ms>` | Advance virtual time and process due timers. |
+| `POLL` | Drain work at the current time. |
+| `QUIT` | End this test process. |
+
+Output is `PACKET <hex>`, `MESSAGE <sid> <ppid> <hex>`, `EVENT <description>` or
+`ERROR <description>`. Error output fails a scenario. RFC stream reset direction
+events are available from external peers; rtc exposes its existing public stream
+events. Assertions use actual messages and decoded request/response exchanges
+instead of inventing a private rtc state query.
+
+Packet faults inspect chunk/parameter contents and SID/RSN/TSN, not packet index
+or bundling shape. `rewrite()` can remove a selected DATA or RE-CONFIG parameter,
+preserve unrelated chunks, fix length/padding and recompute CRC32C. The decoder
+validates every emitted/reconstructed checksum. `held` and `release_held()` model
+delay, reordering and duplication; these preserve original packet bytes unless
+a recorded filter is applied. Built-in codec checks cover the CRC32C known
+vector, bundled chunks/parameters, filtering and corruption detection.
+
+These tests do not replace the workspace suites or claim that either external
+stack implements every RFC transition correctly.
+
+**Continuous integration**
+
+[SCTP interoperability](../../.github/workflows/sctp-interop.yml) runs the same
+40-case command on Ubuntu 24.04 for relevant pushes and pull requests targeting
+`master`, `v0.20.x`, or `v0.21.x`, matching the existing Cargo workflow. Paths are
+limited to SCTP, its shared/datachannel dependencies, the affected handlers,
+the root Cargo manifest, and the workflow itself. It can also be run manually
+from the Actions tab after the workflow is available on the default branch:
+
+```sh
+gh workflow run sctp-interop.yml --ref <branch>
+```
+
+The job installs native tools only for these external adapters; ordinary Cargo
+builds remain independent of them. Both peer adapter self-tests run before the
+packet suite. The `sctp-interop-<run-id>-<attempt>` artifact is uploaded even when
+a build or scenario fails, and contains available JSONL traces, scenario summary,
+compiler/toolchain versions, resolved Cargo.lock, build logs and external build
+manifests. Packet traces record binary hashes and pinned peer revisions. Artifacts
+are retained for 14 days; the job has a 25-minute limit in addition to the harness
+limits. The local build/run commands above reproduce the CI suite without GitHub
+services or credentials.
+
+**Identical public-API performance workloads**
+
+`perf_scenarios.rs` drives two real SCTP associations through public APIs with
+virtual time and no sockets. `build_perf.py` copies this same runner into an
+external Cargo project and points its dependencies at a chosen source checkout.
+It does not edit that checkout's source or Cargo manifests. The default target
+directory is inside the external build directory; `--target-dir` may reuse an
+existing cache. Use separate target directories for baseline and candidate.
+
+```sh
+python3 rtc-sctp/interop/build_perf.py \
+  --source /path/to/baseline --build-dir /tmp/sctp-perf-baseline
+python3 rtc-sctp/interop/build_perf.py \
+  --source /path/to/candidate --build-dir /tmp/sctp-perf-candidate
+/tmp/sctp-perf-candidate/perf-scenarios \
+  --scenario small-rwnd --messages 32768 --size 256 --streams 1 --rwnd 4096
+```
+
+Pass `--offline` when the selected snapshot's dependencies are already cached.
+Each build saves its compiler version, source revision, runner SHA-256 and binary
+SHA-256 in `perf-scenarios-build.json`. Both builds must use the same runner hash.
+Keep the generated Cargo.lock with the measurements.
+
+The fixed comparisons in `benchmark.py` use these additional workloads:
+
+| Case | Runner parameters | Required completed work |
+|---|---|---|
+| `small_rwnd` | `--scenario small-rwnd --messages 32768 --size 256 --streams 1 --rwnd 4096` | 65,536 complete messages, 16 MiB, across both directions. |
+| `multi_stream` | `--scenario multi-stream --messages 60000 --size 32 --streams 32 --rwnd 65536` | 120,000 complete messages across 32 simultaneous streams in each direction. |
+| `many_resets` | `--scenario reset-reuse --size 32 --streams 512 --cycles 1 --iterations 4 --rwnd 65536` | 8,192 complete messages and 4,096 close/reopen operations. |
+| `sid_reuse` | `--scenario reset-reuse --size 32 --streams 1 --cycles 512 --iterations 4 --rwnd 65536` | 4,104 complete messages and 4,096 close/reopen operations on the reused SID. |
+
+`--messages` counts messages per direction. Reset workloads send one message per
+direction/SID before each close and one more after the last reopen, verifying
+every reopened stream. `--seed` defaults to 237; each message carries a sequence
+number and checked payload. A short write, missing/duplicate message, failed
+close/reopen, wrong final count, association failure, or stalled timer fails the
+process. Loops also have explicit step, wall-time and virtual-time bounds.
+
+For `small-rwnd`, the application reads after each received datagram, keeping a
+receive burst below the 4096-byte window. This measures a constrained window with
+a responsive reader; it does not substitute for the separate zero-window and
+slow-reader correctness tests. `min_advertised_rwnd` records the actual SACK
+window. All workloads emit one JSON line with exact message/byte/stream counts,
+packet and timer counts, virtual time and `elapsed_ns`. `benchmark.py` accepts
+these binaries as `--baseline-workloads-bin` and `--candidate-workloads-bin`; it
+retains external wall time/RSS separately and uses the runner's timed interval
+for these cases, excluding process startup.
+
+For a separate allocation probe, repeat each build with `--allocation-probe`.
+The resulting `perf-scenarios-alloc` binary additionally counts allocations,
+reallocations and requested bytes during the workload. The normal latency binary
+contains no allocator instrumentation. Requested bytes include the full new size
+of reallocations; these counters describe allocation pressure, not physical
+payload copies or retained heap size. Peak RSS remains an external measurement.
+
+To measure cumulative SACK processing with substantial DATA still in flight,
+build the same normal and allocation runners against the clean PR base, the
+version before the optimization, and the candidate. For `git archive` snapshots,
+pass their full commit ID as `build_perf.py --source-revision`. Set
+`SCTP_MASTER_REV`, `SCTP_BEFORE_REV` and `SCTP_CANDIDATE_REV` to those commit IDs:
+
+```sh
+python3 rtc-sctp/interop/benchmark.py --samples 15 \
+  --matrix-variant master "$SCTP_MASTER_REV" \
+    /tmp/sctp-perf-master/perf-scenarios /tmp/sctp-perf-master/perf-scenarios-alloc \
+  --matrix-variant before "$SCTP_BEFORE_REV" \
+    /tmp/sctp-perf-before/perf-scenarios /tmp/sctp-perf-before/perf-scenarios-alloc \
+  --matrix-variant candidate "$SCTP_CANDIDATE_REV" \
+    /tmp/sctp-perf-candidate/perf-scenarios /tmp/sctp-perf-candidate/perf-scenarios-alloc \
+  --output /tmp/sctp-sack-comparison.json
+```
+
+The four fixed `sack_*` cases send 60,000 messages of 32 bytes per direction on
+one SID with a 1 MiB receive window: ordered Reliable or unordered `Rexmit(0)`,
+each with a receive budget of 1 or 32 datagrams per pump. They verify delivery,
+the absence of DATA retransmissions and Gap ACKs, and at least 1,024 DATA TSNs
+remaining after a SACK. Wire DATA/SACK/FORWARD-TSN counts are recorded to expose
+differences in protocol work between revisions. This is a public SCTP API
+workload, not a reproduction of the full Linux DataChannel benchmark in #111.
+
+Run measurements without concurrent builds or tests. Matrix mode verifies the
+runner, binary and Cargo.lock hashes, rotates revision order, and records all
+pairwise ratios with median/MAD/range and peak RSS. Five allocation probes run
+separately after the latency phase. The default 15% regression threshold is a
+gate, not a claim of zero overhead; comparisons with relative MAD above 5% are
+inconclusive. Matrix mode saves every comparison, including known slow versions,
+and does not turn the report into a pass/fail process exit code.

--- a/rtc-sctp/interop/benchmark.py
+++ b/rtc-sctp/interop/benchmark.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Compare prebuilt SCTP release binaries without sharing Cargo target state."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import statistics
+import subprocess
+import time
+
+
+WORKLOADS = {
+    "micro_small": ("sctp_micro", ["32", "1", "5000000"]),
+    "micro_bundled": ("sctp_micro", ["1200", "4", "1000000"]),
+    # Stay below one full SSN wrap: a86147a deadlocks at 16B x 131072.
+    # That correctness case is tracked separately, not treated as a timing run.
+    "e2e_small": ("sctp_e2e", ["16", "60000"]),
+    "e2e_fragmented": ("sctp_e2e", ["12000", "32768"]),
+}
+# Each public-API scenario is compiled from identical source for both snapshots.
+# The runner reports its own timed interval; process setup stays in wall_ns/RSS.
+EXTRA_WORKLOADS = {
+    "small_rwnd": ["--scenario", "small-rwnd", "--messages", "32768", "--size", "256",
+                   "--streams", "1", "--iterations", "1", "--seed", "237", "--rwnd", "4096"],
+    "multi_stream": ["--scenario", "multi-stream", "--messages", "60000", "--size", "32",
+                     "--streams", "32", "--iterations", "1", "--seed", "237", "--rwnd", "65536"],
+    "many_resets": ["--scenario", "reset-reuse", "--size", "32", "--streams", "512",
+                    "--cycles", "1", "--iterations", "4", "--seed", "237", "--rwnd", "65536"],
+    "sid_reuse": ["--scenario", "reset-reuse", "--size", "32", "--streams", "1",
+                  "--cycles", "512", "--iterations", "4", "--seed", "237", "--rwnd", "65536"],
+}
+QUEUE_TEST = "association::association_test::benchmark_pending_data_before_reset"
+SACK_WORKLOADS = {
+    f"sack_{policy}_{budget}": [
+        "--scenario", "multi-stream", "--messages", "60000", "--size", "32",
+        "--streams", "1", "--iterations", "1", "--seed", "237", "--rwnd", "1048576",
+        "--packet-budget", str(budget),
+        "--reliability", "reliable" if policy == "reliable" else "rexmit:0",
+        "--unordered", "0" if policy == "reliable" else "1",
+    ]
+    for policy in ("reliable", "rexmit0") for budget in (1, 32)
+}
+
+
+def describe(binary):
+    return {"path": str(binary), "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+            "bytes": binary.stat().st_size}
+
+
+def measure(command):
+    # Darwin reports bytes, GNU time reports KiB. Keep the raw stderr as well.
+    timer = Path("/usr/bin/time")
+    if timer.exists() and platform.system() == "Darwin":
+        invocation = [str(timer), "-l", *command]
+    elif timer.exists() and platform.system() == "Linux":
+        invocation = [str(timer), "-f", "RTC_BENCH_RSS_KB=%M", *command]
+    else:
+        invocation = command
+    started = time.perf_counter_ns()
+    result = subprocess.run(invocation, capture_output=True, text=True, timeout=120)
+    wall_ns = time.perf_counter_ns() - started
+    if result.returncode != 0:
+        raise RuntimeError(f"{command} failed ({result.returncode}):\n{result.stderr}")
+    rss = None
+    if platform.system() == "Darwin":
+        match = re.search(r"(\d+)\s+maximum resident set size", result.stderr)
+        if match:
+            rss = int(match[1])
+    elif platform.system() == "Linux":
+        match = re.search(r"RTC_BENCH_RSS_KB=(\d+)", result.stderr)
+        if match:
+            rss = int(match[1]) * 1024
+    queue = {int(count): int(micros) for count, micros in re.findall(
+        r"queued_messages=(\d+) payload_bytes=\d+ send_queue_us=(\d+)", result.stderr)}
+    scenario = None
+    for line in result.stdout.splitlines():
+        if line.startswith("{"):
+            value = json.loads(line)
+            if "elapsed_ns" in value:
+                scenario = value
+    return {"command": command, "wall_ns": wall_ns, "max_rss_bytes": rss,
+            "queue_us": queue, "scenario": scenario,
+            "stdout": result.stdout, "stderr": result.stderr}
+
+
+def summary(values):
+    median = statistics.median(values)
+    mad = statistics.median(abs(value - median) for value in values)
+    return {"median": median, "min": min(values), "max": max(values),
+            "mad": mad, "relative_mad": mad / median if median else 0}
+
+
+def sack_matrix(args, parser):
+    """Rotate three frozen source snapshots over the exact same public workload."""
+    names = [variant[0] for variant in args.matrix_variant]
+    if len(names) < 2 or len(set(names)) != len(names):
+        parser.error("matrix variants need at least two unique names")
+    cases = args.cases or list(SACK_WORKLOADS)
+    if any(case not in SACK_WORKLOADS for case in cases):
+        parser.error("matrix mode supports only the fixed sack_* workloads")
+    report = {
+        "format_version": 2, "host": platform.platform(), "cpu_count": os.cpu_count(),
+        "scope": "public SCTP associations; not the full Linux DataChannel benchmark from PR #111",
+        "policy": {"samples": args.samples, "warmups": 1, "allocation_samples": 5,
+                   "max_regression": args.max_regression,
+                   "max_relative_mad": args.max_relative_mad,
+                   "minimum_observed_remaining_inflight": 1024},
+        "workloads": {case: SACK_WORKLOADS[case] for case in cases},
+        "variants": {}, "comparisons": {}, "allocation_probes": {},
+    }
+    commands = {}
+    allocation_commands = {}
+    runner_hashes = set()
+    lock_hashes = set()
+    for name, revision, normal, allocation in args.matrix_variant:
+        binary = Path(normal).resolve()
+        alloc_binary = Path(allocation).resolve()
+        metadata = json.loads(binary.with_name(f"{binary.name}-build.json").read_text())
+        alloc_metadata = json.loads(alloc_binary.with_name(f"{alloc_binary.name}-build.json").read_text())
+        for artifact, details in ((binary, metadata), (alloc_binary, alloc_metadata)):
+            if details["source_revision"] != revision:
+                parser.error(f"{name}: source revision mismatch")
+            if details["binary_sha256"] != describe(artifact)["sha256"]:
+                parser.error(f"{name}: binary hash mismatch")
+            runner_hashes.add(details["runner_sha256"])
+        lock_hashes.add(hashlib.sha256(binary.with_name("Cargo.lock").read_bytes()).hexdigest())
+        commands[name] = {case: [str(binary), *SACK_WORKLOADS[case]] for case in cases}
+        allocation_commands[name] = {
+            case: [str(alloc_binary), *SACK_WORKLOADS[case]] for case in cases}
+        report["variants"][name] = {
+            "revision": revision, "binary": describe(binary), "build": metadata,
+            "measurements": {}, "summary": {},
+        }
+        report["allocation_probes"][name] = {
+            "binary": describe(alloc_binary), "build": alloc_metadata,
+            "measurements": {}, "summary": {},
+        }
+    if len(runner_hashes) != 1 or len(lock_hashes) != 1:
+        parser.error("all variants must use the same runner source and Cargo.lock")
+    report["runner_sha256"] = runner_hashes.pop()
+    report["cargo_lock_sha256"] = lock_hashes.pop()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def save():
+        args.output.write_text(json.dumps(report, indent=2) + "\n")
+
+    def validate(sample):
+        value = sample["scenario"]
+        if not value or value["sent_messages"] != 120_000 or value["delivered_messages"] != 120_000:
+            raise RuntimeError("fixed-work delivery count mismatch")
+        if value["retransmitted_data_chunks"] or value["gap_sack_chunks"]:
+            raise RuntimeError("no-loss workload unexpectedly entered DATA recovery")
+        if value["max_remaining_after_sack_chunks"] < 1024:
+            raise RuntimeError("SACK workload did not retain a substantial inflight window")
+
+    wire_metrics = ("data_chunks", "retransmitted_data_chunks", "sack_chunks", "gap_sack_chunks",
+                    "forward_tsn_chunks", "packets", "timer_firings", "max_wire_inflight_chunks",
+                    "sack_observations", "remaining_after_sack_sum", "max_remaining_after_sack_chunks")
+    for case in cases:
+        for name in names:
+            validate(measure(commands[name][case]))
+            report["variants"][name]["measurements"][case] = []
+        for iteration in range(args.samples):
+            pivot = iteration % len(names)
+            order = names[pivot:] + names[:pivot]
+            if iteration // len(names) % 2:
+                order.reverse()
+            for name in order:
+                sample = measure(commands[name][case])
+                validate(sample)
+                report["variants"][name]["measurements"][case].append(sample)
+        for name in names:
+            samples = report["variants"][name]["measurements"][case]
+            metrics = {key: summary([sample["scenario"][key] for sample in samples])
+                       for key in ("elapsed_ns", *wire_metrics)}
+            metrics["wall_ns"] = summary([sample["wall_ns"] for sample in samples])
+            if all(sample["max_rss_bytes"] is not None for sample in samples):
+                metrics["max_rss_bytes"] = summary([sample["max_rss_bytes"] for sample in samples])
+            report["variants"][name]["summary"][case] = metrics
+            elapsed = metrics["elapsed_ns"]
+            print(f"{name} {case}: {elapsed['median'] / 1e6:.3f} ms median; "
+                  f"MAD {elapsed['relative_mad']:.2%}", flush=True)
+        for index, name in enumerate(names):
+            for reference in names[:index]:
+                current = report["variants"][name]["summary"][case]["elapsed_ns"]
+                base = report["variants"][reference]["summary"][case]["elapsed_ns"]
+                ratio = current["median"] / base["median"]
+                noisy = max(current["relative_mad"], base["relative_mad"]) > args.max_relative_mad
+                verdict = "inconclusive" if noisy else (
+                    "regression" if ratio > 1 + args.max_regression else "pass")
+                report["comparisons"][f"{case}.{name}_over_{reference}"] = {
+                    "ratio": ratio, "verdict": verdict,
+                }
+                print(f"{case}: {name}/{reference} {ratio:.3f}x {verdict}", flush=True)
+        save()
+    print("latency phase complete; starting separate allocation probes", flush=True)
+    for name in names:
+        probe = report["allocation_probes"][name]
+        for case in cases:
+            samples = [measure(allocation_commands[name][case]) for _ in range(5)]
+            for sample in samples:
+                validate(sample)
+                if not sample["scenario"]["allocation_probe"]:
+                    raise RuntimeError("allocation binary has no instrumentation")
+            probe["measurements"][case] = samples
+            probe["summary"][case] = {
+                metric: summary([sample["scenario"][metric] for sample in samples])
+                for metric in ("allocations", "reallocations", "allocated_bytes")}
+        save()
+    print(f"raw measurements: {args.output}")
+    # Always retain all comparisons, including a known slow pre-fix snapshot.
+    # A matrix is evidence, not a gate that may select only favorable variants.
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-target", type=Path)
+    parser.add_argument("--baseline-test-bin", type=Path)
+    parser.add_argument("--baseline-rev")
+    parser.add_argument("--matrix-variant", action="append", nargs=4,
+                        metavar=("NAME", "REVISION", "BINARY", "ALLOCATION_BINARY"),
+                        help="compare frozen snapshots on the fixed SACK workloads")
+    parser.add_argument("--candidate-target", type=Path)
+    parser.add_argument("--candidate-test-bin", type=Path)
+    parser.add_argument("--candidate-rev")
+    parser.add_argument("--baseline-workloads-bin", type=Path)
+    parser.add_argument("--candidate-workloads-bin", type=Path)
+    parser.add_argument("--baseline-allocations-bin", type=Path)
+    parser.add_argument("--candidate-allocations-bin", type=Path)
+    parser.add_argument("--cases", nargs="+", choices=[*WORKLOADS, "pending_reset", *EXTRA_WORKLOADS, *SACK_WORKLOADS],
+                        help="run only these fixed workloads (default: all available)")
+    parser.add_argument("--samples", type=int, default=7)
+    parser.add_argument("--max-regression", type=float, default=0.15)
+    parser.add_argument("--max-relative-mad", type=float, default=0.05)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.samples < 5:
+        parser.error("at least five measured samples are required")
+    if args.matrix_variant:
+        sack_matrix(args, parser)
+        return
+    if not (args.baseline_target and args.baseline_test_bin and args.baseline_rev):
+        parser.error("the paired mode requires baseline target, test binary and revision")
+    if args.cases and any(case in SACK_WORKLOADS for case in args.cases):
+        parser.error("sack_* workloads require --matrix-variant")
+    if args.candidate_target and (not args.candidate_test_bin or not args.candidate_rev):
+        parser.error("a candidate needs both --candidate-test-bin and --candidate-rev")
+    if args.candidate_target and args.baseline_target.resolve() == args.candidate_target.resolve():
+        parser.error("baseline and candidate Cargo targets must be separate")
+
+    if args.candidate_target and bool(args.baseline_workloads_bin) != bool(args.candidate_workloads_bin):
+        parser.error("scenario comparisons need both workload binaries")
+    if args.candidate_target and bool(args.baseline_allocations_bin) != bool(args.candidate_allocations_bin):
+        parser.error("allocation comparisons need both instrumented binaries")
+    if args.baseline_allocations_bin and not args.baseline_workloads_bin:
+        parser.error("allocation probes also require the ordinary workload binaries")
+    allocation_binaries = {"baseline": args.baseline_allocations_bin,
+                           "candidate": args.candidate_allocations_bin}
+    cases = args.cases or [*WORKLOADS, "pending_reset", *(
+        EXTRA_WORKLOADS if args.baseline_workloads_bin else ())]
+    if any(case in EXTRA_WORKLOADS for case in cases) and not args.baseline_workloads_bin:
+        parser.error("scenario workloads require --baseline-workloads-bin")
+    workload_binaries = {"baseline": args.baseline_workloads_bin,
+                         "candidate": args.candidate_workloads_bin}
+    variants = {"baseline": (args.baseline_target, args.baseline_test_bin, args.baseline_rev)}
+    if args.candidate_target:
+        variants["candidate"] = (args.candidate_target, args.candidate_test_bin,
+                                 args.candidate_rev)
+    report = {
+        "format_version": 1,
+        "host": platform.platform(),
+        "cpu_count": os.cpu_count(),
+        "policy": {"samples": args.samples, "warmups": 1,
+                   "max_regression": args.max_regression,
+                   "max_relative_mad": args.max_relative_mad},
+        "variants": {}, "comparisons": {}, "allocation_probes": {},
+    }
+    commands = {}
+    for name, (target, test_binary, revision) in variants.items():
+        binaries = {bench: (target / "release/examples" / bench).resolve()
+                    for bench in ("sctp_micro", "sctp_e2e")}
+        commands[name] = {case: [str(binaries[bench]), *arguments]
+                          for case, (bench, arguments) in WORKLOADS.items()}
+        commands[name]["pending_reset"] = [str(test_binary.resolve()), QUEUE_TEST,
+                                             "--exact", "--ignored", "--nocapture"]
+        if workload_binaries[name]:
+            binaries["perf_scenarios"] = workload_binaries[name].resolve()
+            commands[name].update({case: [str(binaries["perf_scenarios"]), *arguments]
+                                   for case, arguments in EXTRA_WORKLOADS.items()})
+        report["variants"][name] = {
+            "revision": revision,
+            "binaries": {key: describe(binary) for key, binary in binaries.items()},
+            "test_binary": describe(test_binary.resolve()),
+            "measurements": {}, "summary": {},
+        }
+
+    # Warm each workload, then alternate A/B and B/A per round. Both versions
+    # perform exactly the same fixed work and run outside Cargo compilation.
+    for case in cases:
+        for name in variants:
+            measure(commands[name][case])
+            report["variants"][name]["measurements"][case] = []
+        for iteration in range(args.samples):
+            order = list(variants)
+            if iteration % 2:
+                order.reverse()
+            for name in order:
+                sample = measure(commands[name][case])
+                if case == "pending_reset" and set(sample["queue_us"]) != {2048, 4096, 8192, 16384}:
+                    raise RuntimeError("queue benchmark did not report all four workloads")
+                if case in EXTRA_WORKLOADS and sample["scenario"] is None:
+                    raise RuntimeError("public-API scenario did not report elapsed_ns JSON")
+                report["variants"][name]["measurements"][case].append(sample)
+        for name in variants:
+            samples = report["variants"][name]["measurements"][case]
+            metrics = {"wall_ns": summary([sample["wall_ns"] for sample in samples])}
+            if all(sample["max_rss_bytes"] is not None for sample in samples):
+                metrics["max_rss_bytes"] = summary([sample["max_rss_bytes"] for sample in samples])
+            if case in EXTRA_WORKLOADS:
+                metrics["elapsed_ns"] = summary([sample["scenario"]["elapsed_ns"] for sample in samples])
+            if case == "pending_reset":
+                for count in (2048, 4096, 8192, 16384):
+                    metrics[f"queue_{count}_us"] = summary([sample["queue_us"][count] for sample in samples])
+            report["variants"][name]["summary"][case] = metrics
+            wall = metrics["wall_ns"]
+            print(f"{name} {case}: {wall['median'] / 1e6:.3f} ms median, "
+                  f"{wall['min'] / 1e6:.3f}..{wall['max'] / 1e6:.3f} ms range", flush=True)
+
+    failed = False
+    inconclusive = False
+    if "candidate" in variants:
+        for case in cases:
+            # The queue's internal timer isolates queue processing from test
+            # setup and process launch. It is the performance gate for that case.
+            if case == "pending_reset":
+                metrics = [f"queue_{count}_us" for count in (2048, 4096, 8192, 16384)]
+            else:
+                metrics = ["elapsed_ns" if case in EXTRA_WORKLOADS else "wall_ns"]
+            for metric in metrics:
+                base = report["variants"]["baseline"]["summary"][case][metric]
+                candidate = report["variants"]["candidate"]["summary"][case][metric]
+                ratio = candidate["median"] / base["median"]
+                noisy = max(base["relative_mad"], candidate["relative_mad"]) > args.max_relative_mad
+                verdict = "inconclusive" if noisy else (
+                    "regression" if ratio > 1 + args.max_regression else "pass")
+                failed |= verdict == "regression"
+                inconclusive |= verdict == "inconclusive"
+                report["comparisons"][f"{case}.{metric}"] = {
+                    "candidate_over_baseline": ratio, "verdict": verdict}
+                print(f"{case}.{metric}: {ratio:.3f}x {verdict}")
+    # Allocation counting is a separate compilation feature. Never use these
+    # instrumented binaries for the latency acceptance gate above.
+    if args.baseline_allocations_bin:
+        for name in variants:
+            binary = allocation_binaries[name].resolve()
+            probe = {"binary": describe(binary), "samples": {}, "summary": {}}
+            for case in (case for case in cases if case in EXTRA_WORKLOADS):
+                command = [str(binary), *EXTRA_WORKLOADS[case]]
+                samples = [measure(command) for _ in range(5)]
+                if any(not sample["scenario"] or not sample["scenario"].get("allocation_probe")
+                       for sample in samples):
+                    raise RuntimeError("allocation probe did not report instrumented JSON")
+                probe["samples"][case] = samples
+                probe["summary"][case] = {
+                    metric: summary([sample["scenario"][metric] for sample in samples])
+                    for metric in ("allocations", "reallocations", "allocated_bytes")}
+                count = probe["summary"][case]["allocations"]["median"]
+                size = probe["summary"][case]["allocated_bytes"]["median"]
+                print(f"{name} {case}: {count:g} allocations, {size:g} allocated bytes")
+            report["allocation_probes"][name] = probe
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(f"raw measurements: {args.output}")
+    if failed:
+        raise SystemExit(1)
+    if inconclusive:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/build_dcsctp.py
+++ b/rtc-sctp/interop/build_dcsctp.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Fetch pinned dcSCTP sources and build the standalone test peer outside Cargo."""
+
+import argparse
+import base64
+import concurrent.futures
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import select
+import shutil
+import subprocess
+import tarfile
+import time
+import urllib.request
+
+
+WEBRTC_SHA = "dab572fd15e3fb975ed14a9e9290f723bb6e3f30"
+# Chromium third_party 3c7ceaeb6bd16f270f6938b22db67b164a5b7b1d,
+# selected by the WebRTC DEPS file above, records this Abseil revision.
+ABSEIL_SHA = "c2336f9b5cb94b877ae3e38629e3b4530e60c89f"
+
+
+def download(url):
+    print(f"fetch {url}", flush=True)
+    with urllib.request.urlopen(url, timeout=120) as response:
+        return response.read()
+
+
+def extract(data, destination):
+    destination.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
+        # Reject paths and links escaping the destination (Python >= 3.12).
+        archive.extractall(destination, filter="data")
+
+
+def fetch_webrtc(root, component):
+    target = root / "webrtc" / component
+    marker = target / ".rtc-interop-revision"
+    if marker.exists() and marker.read_text().strip() == WEBRTC_SHA:
+        return
+    url = f"https://webrtc.googlesource.com/src/+archive/{WEBRTC_SHA}/{component}.tar.gz"
+    extract(download(url), target)
+    marker.write_text(WEBRTC_SHA + "\n")
+
+
+def fetch_abseil(root):
+    target = root / f"abseil-cpp-{ABSEIL_SHA}"
+    marker = target / ".rtc-interop-revision"
+    if marker.exists() and marker.read_text().strip() == ABSEIL_SHA:
+        return
+    url = f"https://github.com/abseil/abseil-cpp/archive/{ABSEIL_SHA}.tar.gz"
+    extract(download(url), root)
+    marker.write_text(ABSEIL_SHA + "\n")
+
+
+def cmake_quote(path):
+    return '"' + str(path).replace("\\", "/").replace('"', '\\"') + '"'
+
+
+def self_test(binary, trace_path, other_binary=None):
+    """Exercise the actual packet API of two adapters, with bounded I/O waits."""
+    processes = [subprocess.Popen([str(executable)], stdin=subprocess.PIPE,
+                                  stdout=subprocess.PIPE, bufsize=0)
+                 for executable in (binary, other_binary or binary)]
+    buffers = [b"", b""]
+    observed = [[], []]
+    clocks = [0, 0]
+    trace = trace_path.open("w")
+    trace.write(json.dumps({
+        "format_version": 1,
+        "dcsctp_build": {"webrtc_sha": WEBRTC_SHA, "abseil_sha": ABSEIL_SHA,
+                         "client_seed": 0x12345678, "server_seed": 0x87654321,
+                         "clock": "virtual milliseconds", "ports": [5000, 5000],
+                         "mtu": 1191, "message_interleaving": False,
+                         "partial_reliability": True, "heartbeats": False},
+        "binaries": [{"path": str(path),
+                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+                     for path in (binary, other_binary or binary)],
+    }) + "\n")
+
+    def command(peer, value):
+        if value.startswith("TICK "):
+            clocks[peer] += int(value.split()[1])
+        trace.write(json.dumps({"peer": peer, "time_ms": clocks[peer],
+                                "command": value}) + "\n")
+        process = processes[peer]
+        process.stdin.write((value + "\n").encode())
+        result = []
+        deadline = time.monotonic() + 5
+        while True:
+            if b"\n" not in buffers[peer]:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not select.select([process.stdout], [], [], remaining)[0]:
+                    raise AssertionError(f"peer {peer} timed out after {value[:80]}")
+                chunk = os.read(process.stdout.fileno(), 65536)
+                if not chunk:
+                    raise AssertionError(f"peer {peer} exited after {value[:80]}")
+                buffers[peer] += chunk
+            if b"\n" not in buffers[peer]:
+                continue
+            line, buffers[peer] = buffers[peer].split(b"\n", 1)
+            line = line.decode()
+            trace.write(json.dumps({"peer": peer, "time_ms": clocks[peer],
+                                    "output": line}) + "\n")
+            if line == "DONE":
+                observed[peer].extend(result)
+                return result
+            if line.startswith("ERROR ") or line.startswith("EVENT error:"):
+                raise AssertionError(line)
+            result.append(line)
+
+    def pump(sender, output):
+        queue = [(1 - sender, line[7:]) for line in output if line.startswith("PACKET ")]
+        count = 0
+        while queue:
+            peer, packet = queue.pop(0)
+            count += 1
+            if count > 1000:
+                raise AssertionError("packet loop did not converge")
+            queue.extend((1 - peer, line[7:]) for line in command(peer, "INPUT " + packet)
+                         if line.startswith("PACKET "))
+
+    def advance(delta_ms):
+        output = [command(peer, f"TICK {delta_ms}") for peer in (0, 1)]
+        for peer in (0, 1):
+            pump(peer, output[peer])
+
+    try:
+        command(0, "INIT client")
+        command(1, "INIT server")
+        pump(0, command(0, "CONNECT"))
+        assert all("EVENT ready" in output for output in observed)
+        # Actual fragmentation and reliable delivery, in both directions.
+        for peer in (0, 1):
+            payload = bytes([peer + 1]) * 4000
+            pump(peer, command(peer, f"SEND 1 ordered reliable 53 {payload.hex()}"))
+            assert f"MESSAGE 1 53 {payload.hex()}" in observed[1 - peer]
+
+        # The first Timed DATA is deliberately dropped. T3 emits FORWARD-TSN,
+        # and a following ordered reliable message must still be deliverable.
+        dropped = command(0, "SEND 3 ordered timed:25 53 74696d6564")
+        assert any(line.startswith("PACKET ") for line in dropped)
+        advance(1000)
+        assert not any(line.startswith("MESSAGE 3 ") for line in observed[1])
+        pump(0, command(0, "SEND 3 ordered reliable 53 7375727669766f72"))
+        assert "MESSAGE 3 53 7375727669766f72" in observed[1]
+
+        # Drop the first fragment of a Rexmit(0) message, but deliver its tail.
+        output = command(0, "SEND 4 unordered rexmit:0 53 " + "ab" * 4000)
+        packets = [line for line in output if line.startswith("PACKET ")]
+        assert len(packets) > 1
+        pump(0, packets[1:])
+        advance(1000)
+        assert not any(line.startswith("MESSAGE 4 ") for line in observed[1])
+        pump(0, command(0, "SEND 4 unordered reliable 53 6166746572"))
+        assert "MESSAGE 4 53 6166746572" in observed[1]
+
+        # Lose an explicit successful reset response and recover through the
+        # real peer's result cache by repeating the original request.
+        output = command(0, "RESET 1")
+        requests = [line[7:] for line in output if line.startswith("PACKET ")]
+        assert requests
+        for packet in requests:
+            command(1, "INPUT " + packet)  # Intentionally drop the reply.
+        for _ in range(20):
+            advance(500)
+            if "EVENT reset_out:1" in observed[0]:
+                break
+        assert "EVENT reset_out:1" in observed[0]
+        assert "EVENT reset_in:1" in observed[1]
+        pump(0, command(0, "SEND 1 ordered reliable 53 7265757365"))
+        assert "MESSAGE 1 53 7265757365" in observed[1]
+        for peer in (0, 1):
+            command(peer, "QUIT")
+            assert processes[peer].wait(timeout=5) == 0
+        print(f"dcSCTP packet self-test passed; trace: {trace_path}")
+    finally:
+        trace.close()
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, default=Path("/tmp/rtc-237-dcsctp"))
+    parser.add_argument("--cmake", default=os.environ.get("CMAKE", "cmake"))
+    parser.add_argument("--jobs", type=int, default=min(os.cpu_count() or 2, 8))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    cmake = shutil.which(args.cmake)
+    if cmake is None:
+        parser.error("CMake is required; see README-dcsctp.md for a local installation")
+    if args.jobs < 1:
+        parser.error("--jobs must be positive")
+    root = args.build_dir.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        tasks = [pool.submit(fetch_webrtc, root, part)
+                 for part in ("net/dcsctp", "api", "rtc_base")]
+        tasks.append(pool.submit(fetch_abseil, root))
+        for task in tasks:
+            task.result()
+    for name in ("DEPS", "LICENSE", "PATENTS", "AUTHORS"):
+        target = root / "webrtc" / name
+        if not target.exists():
+            target.write_bytes(base64.b64decode(download(
+                f"https://webrtc.googlesource.com/src/+/{WEBRTC_SHA}/{name}?format=TEXT")))
+
+    webrtc = root / "webrtc"
+    excluded = {"task_queue_timeout.cc", "text_pcap_packet_observer.cc",
+                "dcsctp_socket_factory.cc"}
+    sources = [path for path in (webrtc / "net/dcsctp").rglob("*.cc")
+               if not any(part in ("testing", "fuzzers") for part in path.parts)
+               and not any(term in path.name for term in ("test", "mock", "fuzzer"))
+               and path.name not in excluded]
+    sources += [webrtc / path for path in (
+        "rtc_base/checks.cc", "rtc_base/strings/string_builder.cc",
+        "rtc_base/strings/string_format.cc", "api/units/time_delta.cc",
+        "api/units/timestamp.cc")]
+    sources.append(Path(__file__).resolve().with_name("dcsctp_peer.cc"))
+    source_list = "\n  ".join(cmake_quote(path) for path in sorted(sources))
+    project = root / "project"
+    project.mkdir(exist_ok=True)
+    (project / "CMakeLists.txt").write_text(f"""cmake_minimum_required(VERSION 3.16)
+project(rtc_dcsctp_interop LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
+set(ABSL_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+add_subdirectory({cmake_quote(root / ('abseil-cpp-' + ABSEIL_SHA))} abseil EXCLUDE_FROM_ALL)
+add_executable(dcsctp-peer
+  {source_list})
+target_include_directories(dcsctp-peer PRIVATE {cmake_quote(webrtc)})
+target_compile_definitions(dcsctp-peer PRIVATE WEBRTC_POSIX RTC_DISABLE_LOGGING)
+target_link_libraries(dcsctp-peer PRIVATE absl::crc32c absl::strings)
+""")
+    subprocess.run([cmake, "-S", str(project), "-B", str(root / "build"),
+                    "-DCMAKE_BUILD_TYPE=Release"], check=True)
+    subprocess.run([cmake, "--build", str(root / "build"), "--target", "dcsctp-peer",
+                    "--parallel", str(args.jobs)], check=True)
+    print(f"WEBRTC_SHA={WEBRTC_SHA}\nABSEIL_SHA={ABSEIL_SHA}")
+    print(f"RTC_DCSCTP_PEER={root / 'build/dcsctp-peer'}")
+    if args.self_test:
+        self_test(root / "build/dcsctp-peer", root / "self-test.jsonl")
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/build_perf.py
+++ b/rtc-sctp/interop/build_perf.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Build the same public-API runner against a selected rtc source snapshot."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tomllib
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True, help="rtc workspace snapshot")
+    parser.add_argument("--source-revision", help="exact revision for a git-archive source snapshot")
+    parser.add_argument("--build-dir", type=Path, required=True, help="external benchmark project")
+    parser.add_argument("--target-dir", type=Path, help="optional existing Cargo target cache")
+    parser.add_argument("--allocation-probe", action="store_true")
+    parser.add_argument("--offline", action="store_true")
+    args = parser.parse_args()
+    source = args.source.resolve()
+    output = args.build_dir.resolve()
+    if output.is_relative_to(source):
+        parser.error("--build-dir must be outside the selected source checkout")
+    runner = Path(__file__).with_name("perf_scenarios.rs")
+    workspace = tomllib.loads((source / "Cargo.toml").read_text())
+    bytes_version = workspace["workspace"]["dependencies"]["bytes"]
+    if not isinstance(bytes_version, str):
+        parser.error("expected a version string for the workspace bytes dependency")
+    (output / "src").mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(runner, output / "src/main.rs")
+    manifest = f'''[package]
+name = "rtc-sctp-perf-scenarios"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[features]
+allocation-probe = []
+
+[dependencies]
+rtc-sctp = {{ path = {json.dumps(str(source / "rtc-sctp"))} }}
+shared = {{ package = "rtc-shared", path = {json.dumps(str(source / "rtc-shared"))}, default-features = false }}
+bytes = {json.dumps(bytes_version)}
+'''
+    (output / "Cargo.toml").write_text(manifest)
+    target = args.target_dir.resolve() if args.target_dir else output / "target"
+    env = dict(os.environ, CARGO_TARGET_DIR=str(target), CARGO_INCREMENTAL="0")
+    command = ["cargo", "build", "--manifest-path", str(output / "Cargo.toml"), "--release"]
+    if args.offline:
+        command.append("--offline")
+    if args.allocation_probe:
+        command += ["--features", "allocation-probe"]
+    subprocess.run(command, env=env, check=True)
+    name = "perf-scenarios-alloc" if args.allocation_probe else "perf-scenarios"
+    binary = output / name
+    shutil.copy2(target / "release/rtc-sctp-perf-scenarios", binary)
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    metadata = {
+        "source": str(source),
+        "source_revision": args.source_revision or (revision.stdout.strip() if revision.returncode == 0 else None),
+        "runner_sha256": hashlib.sha256((output / "src/main.rs").read_bytes()).hexdigest(),
+        "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+        "allocation_probe": args.allocation_probe,
+        "command": command,
+        "target_dir": str(target),
+        "cargo_incremental": env["CARGO_INCREMENTAL"],
+        "rustc": subprocess.check_output(["rustc", "--version", "--verbose"], text=True),
+    }
+    (output / f"{name}-build.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    print(binary)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/build_usrsctp.py
+++ b/rtc-sctp/interop/build_usrsctp.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Build a pinned, test-only usrsctp AF_CONN peer without CMake or vendoring.
+
+Requires Python 3.9+, git, and a C11 compiler on macOS or Linux. Source, objects,
+and the executable live outside the repository unless --build-dir says otherwise.
+"""
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import selectors
+import subprocess
+
+REVISION = "fd070e05a7474f38c7fecdf4d4b6005d2547ee00"
+REPOSITORY = "https://github.com/sctplab/usrsctp.git"
+SOURCES = [
+    "netinet/sctp_asconf.c", "netinet/sctp_auth.c", "netinet/sctp_bsd_addr.c",
+    "netinet/sctp_callout.c", "netinet/sctp_cc_functions.c", "netinet/sctp_crc32.c",
+    "netinet/sctp_indata.c", "netinet/sctp_input.c", "netinet/sctp_output.c",
+    "netinet/sctp_pcb.c", "netinet/sctp_peeloff.c", "netinet/sctp_sha1.c",
+    "netinet/sctp_ss_functions.c", "netinet/sctp_sysctl.c", "netinet/sctp_timer.c",
+    "netinet/sctp_userspace.c", "netinet/sctp_usrreq.c", "netinet/sctputil.c",
+    "netinet6/sctp6_usrreq.c", "user_environment.c", "user_mbuf.c",
+    "user_recv_thread.c", "user_socket.c",
+]
+
+
+def run(command, **kwargs):
+    return subprocess.run(command, check=True, **kwargs)
+
+
+def checkout_source(source, offline):
+    """Select the pinned revision without replacing local source changes."""
+    if not (source / ".git").exists():
+        if offline:
+            raise RuntimeError(f"--offline requires an existing checkout at {source}")
+        # Populate the index/worktree before the dirty check: --no-checkout
+        # makes a fresh clone report every tracked path as deleted.
+        run(["git", "clone", REPOSITORY, str(source)])
+    exists = subprocess.run(
+        ["git", "-C", str(source), "cat-file", "-e", REVISION + "^{commit}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    if exists.returncode:
+        if offline:
+            raise RuntimeError(f"pinned revision {REVISION} is absent from {source}")
+        run(["git", "-C", str(source), "fetch", "origin", REVISION])
+    dirty = run(["git", "-C", str(source), "status", "--porcelain"],
+                capture_output=True, text=True).stdout
+    if dirty:
+        raise RuntimeError(f"refusing to replace modified source checkout: {source}")
+    run(["git", "-C", str(source), "checkout", "--detach", REVISION])
+
+
+def build(args):
+    root = args.build_dir.resolve()
+    source = root / "source"
+    root.mkdir(parents=True, exist_ok=True)
+    checkout_source(source, args.offline)
+
+    output = root / "build"
+    output.mkdir(exist_ok=True)
+    clock_header = output / "virtual_time.h"
+    # Include the system declaration before the macro so Darwin's symbol aliases
+    # cannot silently redirect the hook back to real gettimeofday.
+    clock_header.write_text(
+        "#include <sys/time.h>\n"
+        "int rtc_usrsctp_gettimeofday(struct timeval *, void *);\n"
+        "#define gettimeofday rtc_usrsctp_gettimeofday\n"
+    )
+    system = platform.system()
+    if system not in ("Darwin", "Linux"):
+        raise RuntimeError("this test build currently supports macOS and Linux")
+    common = [
+        args.cc, "-std=c11", "-O2", "-g", "-pthread", "-Wall", "-Wextra",
+        "-Wno-unused-parameter", "-Wno-unused-function",
+        "-Wno-address-of-packed-member", "-Wno-deprecated-declarations",
+        "-D__Userspace__", "-DSCTP_SIMPLE_ALLOCATOR", "-DSCTP_PROCESS_LEVEL_LOCKS",
+        "-DHAVE_STDATOMIC_H", "-DINET", "-DINET6", "-DINVARIANTS",
+        "-I", str(source / "usrsctplib"),
+    ]
+    if system == "Darwin":
+        common += [
+            "-D__APPLE_USE_RFC_2292", "-DHAVE_SA_LEN", "-DHAVE_SIN_LEN",
+            "-DHAVE_SIN6_LEN", "-DHAVE_SCONN_LEN", "-DHAVE_SYS_QUEUE_H",
+            "-DHAVE_NETINET_IP_ICMP_H", "-DHAVE_NET_ROUTE_H",
+        ]
+    else:
+        common += [
+            "-D_GNU_SOURCE", "-DHAVE_LINUX_IF_ADDR_H", "-DHAVE_LINUX_RTNETLINK_H",
+            "-DHAVE_NETINET_IP_ICMP_H", "-DHAVE_NET_ROUTE_H",
+        ]
+    jobs = []
+    objects = []
+    for relative in SOURCES:
+        obj = output / (relative.replace("/", "_") + ".o")
+        objects.append(str(obj))
+        jobs.append(common + ["-include", str(clock_header), "-c",
+                              str(source / "usrsctplib" / relative), "-o", str(obj)])
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        list(pool.map(run, jobs))
+    executable = output / "usrsctp_peer"
+    peer_source = Path(__file__).with_name("usrsctp_peer.c")
+    run(common + ["-Werror", str(peer_source)] + objects + ["-o", str(executable)])
+    metadata = {
+        "repository": REPOSITORY,
+        "revision": REVISION,
+        "adapter_sha256": hashlib.sha256(peer_source.read_bytes()).hexdigest(),
+        "compiler": run([args.cc, "--version"], capture_output=True, text=True).stdout,
+        "platform": platform.platform(),
+        "flags": common,
+        "clock": "virtual gettimeofday + usrsctp_handle_timers, 10ms maximum step",
+        "random": "system entropy; record initial TSN/vtag/cookie in packet traces",
+        "ports": [5000, 5000],
+        "streams": 1024,
+        "mtu": 1200,
+        "socket_buffers": 4 * 1024 * 1024,
+    }
+    (output / "build.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    print(executable, flush=True)
+    return executable
+
+
+class Peer:
+    """Bounded line reader for --self-test, not the scenario harness."""
+
+    def __init__(self, executable):
+        self.process = subprocess.Popen(
+            [str(executable)], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            bufsize=0,
+        )
+        self.pending = bytearray()
+        self.selector = selectors.DefaultSelector()
+        self.selector.register(self.process.stdout, selectors.EVENT_READ)
+        self.events = []
+        self.messages = []
+
+    def command(self, text):
+        self.process.stdin.write(text.encode() + b"\n")
+        packets = []
+        while True:
+            while b"\n" not in self.pending:
+                if not self.selector.select(timeout=5):
+                    raise RuntimeError(f"peer timeout after {text[:80]}")
+                data = os.read(self.process.stdout.fileno(), 65536)
+                if not data:
+                    raise RuntimeError(f"peer exited after {text[:80]}")
+                self.pending.extend(data)
+            line, _, rest = self.pending.partition(b"\n")
+            self.pending = bytearray(rest)
+            line = line.decode()
+            if line == "DONE":
+                return packets
+            if line.startswith("PACKET "):
+                packets.append(line.removeprefix("PACKET "))
+            elif line.startswith("MESSAGE "):
+                self.messages.append(line)
+            elif line.startswith("EVENT "):
+                self.events.append(line)
+            elif line.startswith("ERROR "):
+                raise RuntimeError(line)
+            else:
+                raise RuntimeError(f"unexpected adapter output: {line}")
+
+    def close(self):
+        if self.process.poll() is None:
+            try:
+                self.command("QUIT")
+                self.process.communicate(timeout=5)
+            except (RuntimeError, subprocess.TimeoutExpired, BrokenPipeError):
+                self.process.kill()
+                self.process.communicate()
+        self.selector.close()
+
+
+def self_test(executable):
+    peers = [Peer(executable), Peer(executable)]
+
+    def deliver(sender, packets):
+        queue = [(1 - sender, packet) for packet in packets]
+        for _ in range(10000):
+            if not queue:
+                return
+            receiver, packet = queue.pop(0)
+            queue.extend((1 - receiver, p)
+                         for p in peers[receiver].command("INPUT " + packet))
+        raise RuntimeError("self-test exceeded packet exchange bound")
+
+    try:
+        peers[0].command("INIT client")
+        peers[1].command("INIT server")
+        deliver(0, peers[0].command("CONNECT"))
+        assert all("EVENT ready" in peer.events for peer in peers), "handshake failed"
+        for sender, policy, ordering, data in [
+            (0, "reliable", "ordered", b"client to server"),
+            (1, "timed:100", "unordered", b"server to client"),
+            (0, "rexmit:0", "unordered", bytes(range(256)) * 20),
+        ]:
+            command = f"SEND 1 {ordering} {policy} 53 {data.hex()}"
+            deliver(sender, peers[sender].command(command))
+            for index, peer in enumerate(peers):
+                deliver(index, peer.command("TICK 200"))
+            expected = f"MESSAGE 1 53 {data.hex()}"
+            assert peers[1 - sender].messages.count(expected) == 1, "message not delivered exactly once"
+        deliver(0, peers[0].command("RESET 1"))
+        assert "EVENT reset_out:1" in peers[0].events, "outgoing reset not completed"
+        assert "EVENT reset_in:1" in peers[1].events, "incoming reset not completed"
+        deliver(1, peers[1].command("RESET 1"))
+        assert "EVENT reset_out:1" in peers[1].events, "reciprocal outgoing reset not completed"
+        assert "EVENT reset_in:1" in peers[0].events, "reciprocal incoming reset not completed"
+        deliver(0, peers[0].command("SEND 1 ordered reliable 53 7265757365"))
+        assert peers[1].messages[-1] == "MESSAGE 1 53 7265757365", "SID reuse failed"
+        deliver(1, peers[1].command("TICK 200"))
+        # Drop every packet from the first timed send. The virtual clock must
+        # expire TTL as well as advance callouts; otherwise T3 emits DATA again.
+        peers[0].command("SEND 2 ordered timed:100 53 657870697265")
+        timed_out = peers[0].command("TICK 4000")
+        kinds = []
+        for packet in timed_out:
+            raw = bytes.fromhex(packet)
+            pos = 12
+            while pos + 4 <= len(raw):
+                kinds.append(raw[pos])
+                length = int.from_bytes(raw[pos + 2:pos + 4], "big")
+                if length < 4:
+                    raise RuntimeError("invalid emitted SCTP chunk")
+                pos += (length + 3) & ~3
+        assert 192 in kinds, "expired timed DATA did not produce FORWARD-TSN"
+        assert 0 not in kinds, "expired timed DATA was retransmitted"
+        deliver(0, timed_out)
+        print("usrsctp self-test: handshake, policies, fragmentation, reset, SID reuse, virtual TTL passed")
+    finally:
+        for peer in peers:
+            peer.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, default=Path("/tmp/rtc-237-usrsctp"))
+    parser.add_argument("--cc", default=os.environ.get("CC", "clang"))
+    parser.add_argument("--jobs", type=int, default=min(os.cpu_count() or 1, 8))
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.jobs < 1:
+        parser.error("--jobs must be positive")
+    executable = build(args)
+    if args.self_test:
+        self_test(executable)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/dcsctp_peer.cc
+++ b/rtc-sctp/interop/dcsctp_peer.cc
@@ -1,0 +1,281 @@
+// Standalone, deterministic packet adapter for upstream WebRTC dcSCTP.
+// Test-only: no UDP, DTLS, wall clock, or threads are used by this adapter.
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "net/dcsctp/public/dcsctp_message.h"
+#include "net/dcsctp/public/dcsctp_options.h"
+#include "net/dcsctp/public/timeout.h"
+#include "net/dcsctp/socket/dcsctp_socket.h"
+
+namespace {
+
+uint64_t Number(std::string_view value, uint64_t maximum) {
+  uint64_t result = 0;
+  auto [end, error] =
+      std::from_chars(value.data(), value.data() + value.size(), result);
+  if (error != std::errc() || end != value.data() + value.size() ||
+      result > maximum) {
+    throw std::runtime_error("invalid unsigned integer");
+  }
+  return result;
+}
+
+std::vector<uint8_t> Unhex(std::string_view value) {
+  if (value == "-") return {};
+  if (value.size() % 2 != 0 || value.size() > 4 * 1024 * 1024) {
+    throw std::runtime_error("invalid hex length");
+  }
+  std::vector<uint8_t> bytes(value.size() / 2);
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    unsigned int byte = 0;
+    auto [end, error] = std::from_chars(value.data() + 2 * i,
+                                      value.data() + 2 * i + 2, byte, 16);
+    if (error != std::errc() || end != value.data() + 2 * i + 2) {
+      throw std::runtime_error("invalid hex digit");
+    }
+    bytes[i] = static_cast<uint8_t>(byte);
+  }
+  return bytes;
+}
+
+std::string Hex(std::span<const uint8_t> bytes) {
+  if (bytes.empty()) return "-";
+  static constexpr char digits[] = "0123456789abcdef";
+  std::string result(bytes.size() * 2, '0');
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    result[2 * i] = digits[bytes[i] >> 4];
+    result[2 * i + 1] = digits[bytes[i] & 15];
+  }
+  return result;
+}
+
+std::string OneLine(absl::string_view value) {
+  std::string result(value);
+  std::replace(result.begin(), result.end(), '\n', ' ');
+  std::replace(result.begin(), result.end(), '\r', ' ');
+  return result;
+}
+
+class Peer final : public dcsctp::DcSctpSocketCallbacks {
+ public:
+  void Init(std::string_view role) {
+    if (socket_ || (role != "client" && role != "server")) {
+      throw std::runtime_error("INIT requires an uninitialized client or server");
+    }
+    random_ = role == "client" ? 0x12345678u : 0x87654321u;
+    dcsctp::DcSctpOptions options;
+    options.local_port = 5000;
+    options.remote_port = 5000;
+    options.enable_message_interleaving = false;
+    options.enable_partial_reliability = true;
+    options.heartbeat_interval = dcsctp::DurationMs(0);
+    options.max_message_size = 1024 * 1024;
+    options.max_send_buffer_size = 2 * 1024 * 1024;
+    socket_ = std::make_unique<dcsctp::DcSctpSocket>(
+        "interop", *this, nullptr, options);
+  }
+
+  bool Command(const std::vector<std::string>& words) {
+    if (words.empty()) throw std::runtime_error("empty command");
+    const auto& command = words[0];
+    if (command == "QUIT" && words.size() == 1) return false;
+    if (command == "INIT" && words.size() == 2) {
+      Init(words[1]);
+      return true;
+    }
+    if (!socket_) throw std::runtime_error("INIT required");
+    if (command == "CONNECT" && words.size() == 1) {
+      socket_->Connect();
+    } else if (command == "SEND" && words.size() == 6) {
+      auto sid = dcsctp::StreamID(Number(words[1], UINT16_MAX));
+      dcsctp::SendOptions options;
+      if (words[2] != "ordered" && words[2] != "unordered") {
+        throw std::runtime_error("expected ordered or unordered");
+      }
+      options.unordered = dcsctp::IsUnordered(words[2] == "unordered");
+      if (words[3].starts_with("timed:")) {
+        options.lifetime = dcsctp::DurationMs(
+            Number(std::string_view(words[3]).substr(6), INT32_MAX));
+      } else if (words[3].starts_with("rexmit:")) {
+        options.max_retransmissions =
+            Number(std::string_view(words[3]).substr(7), UINT32_MAX);
+      } else if (words[3] != "reliable") {
+        throw std::runtime_error("unknown reliability policy");
+      }
+      auto ppid = dcsctp::PPID(Number(words[4], UINT32_MAX));
+      auto result = socket_->Send(
+          dcsctp::DcSctpMessage(sid, ppid, Unhex(words[5])), options);
+      if (result != dcsctp::SendStatus::kSuccess) {
+        throw std::runtime_error(std::string(dcsctp::ToString(result)));
+      }
+    } else if (command == "RESET" && words.size() == 2) {
+      std::vector<dcsctp::StreamID> streams;
+      std::istringstream list(words[1]);
+      for (std::string sid; std::getline(list, sid, ',');) {
+        streams.emplace_back(Number(sid, UINT16_MAX));
+      }
+      if (streams.empty() || words[1].back() == ',') {
+        throw std::runtime_error("expected a comma-separated stream list");
+      }
+      auto result = socket_->ResetStreams(streams);
+      if (result != dcsctp::ResetStreamsStatus::kPerformed) {
+        throw std::runtime_error(std::string(dcsctp::ToString(result)));
+      }
+    } else if (command == "INPUT" && words.size() == 2) {
+      socket_->ReceivePacket(Unhex(words[1]));
+    } else if (command == "TICK" && words.size() == 2) {
+      // WebRTC Timestamp internally stores microseconds; leave room for its
+      // conversion and for the largest millisecond timeout.
+      Advance(Number(words[1], INT64_MAX / 1000 - INT32_MAX - now_ms_));
+    } else if (command == "POLL" && words.size() == 1) {
+      Advance(0);
+    } else {
+      throw std::runtime_error("unknown command or argument count");
+    }
+    return true;
+  }
+
+  void SendPacket(std::span<const uint8_t> data) override {
+    std::cout << "EVENT packet_time:" << now_ms_ << '\n';
+    std::cout << "PACKET " << Hex(data) << '\n';
+  }
+
+  std::unique_ptr<dcsctp::Timeout> CreateTimeout(
+      webrtc::TaskQueueBase::DelayPrecision) override {
+    return std::make_unique<VirtualTimeout>(*this, next_timer_++);
+  }
+
+  dcsctp::TimeMs TimeMillis() override { return dcsctp::TimeMs(now_ms_); }
+  webrtc::Timestamp Now() override {
+    return webrtc::Timestamp::Millis(now_ms_);
+  }
+
+  uint32_t GetRandomInt(uint32_t low, uint32_t high) override {
+    // Rejection sampling avoids implementation-defined distribution behavior.
+    // The seed is fixed per role; this generator is not used for security.
+    if (high <= low) throw std::runtime_error("invalid dcSCTP random range");
+    const uint32_t width = high - low;
+    const uint32_t threshold = -width % width;
+    do {
+      random_ = random_ * 1664525u + 1013904223u;
+    } while (random_ < threshold);
+    return low + random_ % width;
+  }
+
+  void OnMessageReceived(dcsctp::DcSctpMessage message) override {
+    std::cout << "MESSAGE " << *message.stream_id() << ' ' << *message.ppid()
+              << ' ' << Hex(message.payload()) << '\n';
+  }
+  void OnError(dcsctp::ErrorKind error, absl::string_view message) override {
+    std::cout << "EVENT error:" << dcsctp::ToString(error) << ':'
+              << OneLine(message) << '\n';
+  }
+  void OnAborted(dcsctp::ErrorKind error, absl::string_view message) override {
+    OnError(error, message);
+    OnClosed();
+  }
+  void OnConnected() override { std::cout << "EVENT ready\n"; }
+  void OnClosed() override { std::cout << "EVENT closed\n"; }
+  void OnConnectionRestarted() override { std::cout << "EVENT restarted\n"; }
+  void OnStreamsResetFailed(std::span<const dcsctp::StreamID> streams,
+                           absl::string_view reason) override {
+    for (auto sid : streams) {
+      std::cout << "EVENT reset_failed:" << *sid << ':' << OneLine(reason)
+                << '\n';
+    }
+  }
+  void OnStreamsResetPerformed(
+      std::span<const dcsctp::StreamID> streams) override {
+    for (auto sid : streams) std::cout << "EVENT reset_out:" << *sid << '\n';
+  }
+  void OnIncomingStreamsReset(
+      std::span<const dcsctp::StreamID> streams) override {
+    if (streams.empty()) std::cout << "EVENT reset_in:all\n";
+    for (auto sid : streams) std::cout << "EVENT reset_in:" << *sid << '\n';
+  }
+
+ private:
+  struct Timer {
+    std::optional<int64_t> deadline;
+    dcsctp::TimeoutID timeout_id = dcsctp::TimeoutID(0);
+  };
+
+  class VirtualTimeout final : public dcsctp::Timeout {
+   public:
+    VirtualTimeout(Peer& owner, uint64_t key) : owner_(owner), key_(key) {
+      owner_.timers_.emplace(key_, Timer());
+    }
+    ~VirtualTimeout() override { owner_.timers_.erase(key_); }
+    void Start(dcsctp::DurationMs duration,
+               dcsctp::TimeoutID timeout_id) override {
+      auto& timer = owner_.timers_.at(key_);
+      timer.deadline = owner_.now_ms_ + *duration;
+      timer.timeout_id = timeout_id;
+    }
+    void Stop() override { owner_.timers_.at(key_).deadline.reset(); }
+
+   private:
+    Peer& owner_;
+    uint64_t key_;
+  };
+
+  void Advance(int64_t delta_ms) {
+    const int64_t target = now_ms_ + delta_ms;
+    for (size_t fired = 0;; ++fired) {
+      auto next = timers_.end();
+      for (auto it = timers_.begin(); it != timers_.end(); ++it) {
+        if (it->second.deadline && *it->second.deadline <= target &&
+            (next == timers_.end() ||
+             *it->second.deadline < *next->second.deadline)) {
+          next = it;
+        }
+      }
+      if (next == timers_.end()) break;
+      if (fired == 100000) throw std::runtime_error("timeout iteration limit");
+      now_ms_ = *next->second.deadline;
+      const auto timeout_id = next->second.timeout_id;
+      next->second.deadline.reset();
+      socket_->HandleTimeout(timeout_id);
+    }
+    now_ms_ = target;
+  }
+
+  int64_t now_ms_ = 0;
+  uint32_t random_ = 1;
+  uint64_t next_timer_ = 0;
+  // Keep these alive until the socket destroys its Timeout instances.
+  std::map<uint64_t, Timer> timers_;
+  std::unique_ptr<dcsctp::DcSctpSocket> socket_;
+};
+
+}  // namespace
+
+int main() {
+  Peer peer;
+  for (std::string line; std::getline(std::cin, line);) {
+    bool keep_running = true;
+    try {
+      std::istringstream input(line);
+      std::vector<std::string> words;
+      for (std::string word; input >> word;) words.push_back(std::move(word));
+      keep_running = peer.Command(words);
+    } catch (const std::exception& error) {
+      std::cout << "ERROR " << OneLine(error.what()) << '\n';
+    }
+    std::cout << "DONE\n" << std::flush;
+    if (!keep_running) break;
+  }
+}

--- a/rtc-sctp/interop/perf_scenarios.rs
+++ b/rtc-sctp/interop/perf_scenarios.rs
@@ -1,0 +1,739 @@
+//! Identical, public-API fixed-work workloads for two rtc-sctp source snapshots.
+//! Build with build_perf.py; this file is not part of the library or its API.
+
+use bytes::Bytes;
+use rtc_sctp::{
+    Association, AssociationError, AssociationHandle, ClientConfig, DatagramEvent, Endpoint,
+    EndpointConfig, Event, Payload, PayloadProtocolIdentifier, ReliabilityType, ServerConfig,
+    TransportConfig,
+};
+use shared::TransportProtocol;
+use std::collections::VecDeque;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+type Result<T> = std::result::Result<T, String>;
+const PPI: PayloadProtocolIdentifier = PayloadProtocolIdentifier::Binary;
+const SEND_CAP: usize = 1 << 20;
+
+#[cfg(feature = "allocation-probe")]
+mod allocation {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
+
+    static ENABLED: AtomicBool = AtomicBool::new(false);
+    static CALLS: AtomicU64 = AtomicU64::new(0);
+    static REALLOCS: AtomicU64 = AtomicU64::new(0);
+    static BYTES: AtomicU64 = AtomicU64::new(0);
+    struct Probe;
+    #[global_allocator]
+    static ALLOCATOR: Probe = Probe;
+
+    fn record(size: usize, realloc: bool, succeeded: bool) {
+        if succeeded && ENABLED.load(Relaxed) {
+            if realloc { &REALLOCS } else { &CALLS }.fetch_add(1, Relaxed);
+            BYTES.fetch_add(size as u64, Relaxed);
+        }
+    }
+    unsafe impl GlobalAlloc for Probe {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let result = unsafe { System.alloc(layout) };
+            record(layout.size(), false, !result.is_null());
+            result
+        }
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            let result = unsafe { System.alloc_zeroed(layout) };
+            record(layout.size(), false, !result.is_null());
+            result
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+            let result = unsafe { System.realloc(ptr, layout, size) };
+            record(size, true, !result.is_null());
+            result
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) };
+        }
+    }
+    pub fn start() {
+        ENABLED.store(true, Relaxed);
+    }
+    pub fn finish() -> String {
+        ENABLED.store(false, Relaxed);
+        format!(
+            "\"allocation_probe\":true,\"allocations\":{},\"reallocations\":{},\"allocated_bytes\":{}",
+            CALLS.load(Relaxed),
+            REALLOCS.load(Relaxed),
+            BYTES.load(Relaxed)
+        )
+    }
+}
+
+struct Config {
+    scenario: String,
+    messages: u64,
+    size: usize,
+    streams: usize,
+    cycles: u64,
+    iterations: u64,
+    seed: u64,
+    rwnd: u32,
+    reliability: String,
+    unordered: bool,
+    packet_budget: usize,
+}
+
+impl Config {
+    fn parse() -> Result<Self> {
+        let mut value = Self {
+            scenario: "multi-stream".into(),
+            messages: 60_000,
+            size: 32,
+            streams: 32,
+            cycles: 512,
+            iterations: 1,
+            seed: 237,
+            rwnd: 1 << 20,
+            reliability: "reliable".into(),
+            unordered: false,
+            packet_budget: usize::MAX,
+        };
+        let mut args = std::env::args().skip(1);
+        while let Some(name) = args.next() {
+            let arg = args
+                .next()
+                .ok_or_else(|| format!("missing value for {name}"))?;
+            if name == "--scenario" {
+                value.scenario = arg;
+                continue;
+            }
+            if name == "--reliability" {
+                value.reliability = arg;
+                continue;
+            }
+            let number = arg.parse::<u64>().map_err(|e| format!("{name}: {e}"))?;
+            match name.as_str() {
+                "--messages" => value.messages = number,
+                "--size" => value.size = usize::try_from(number).map_err(|e| e.to_string())?,
+                "--streams" => {
+                    value.streams = usize::try_from(number).map_err(|e| e.to_string())?
+                }
+                "--cycles" => value.cycles = number,
+                "--iterations" => value.iterations = number,
+                "--seed" => value.seed = number,
+                "--rwnd" => value.rwnd = u32::try_from(number).map_err(|e| e.to_string())?,
+                "--unordered" if number <= 1 => value.unordered = number != 0,
+                "--packet-budget" => {
+                    value.packet_budget = usize::try_from(number).map_err(|e| e.to_string())?
+                }
+                _ => return Err(format!("unknown argument {name}")),
+            }
+        }
+        if !matches!(
+            value.scenario.as_str(),
+            "small-rwnd" | "multi-stream" | "reset-reuse"
+        ) {
+            return Err("--scenario must be small-rwnd, multi-stream or reset-reuse".into());
+        }
+        if !(1..=1_000_000).contains(&value.messages)
+            || !(16..=65_536).contains(&value.size)
+            || !(1..=4096).contains(&value.streams)
+            || !(1..=10_000).contains(&value.cycles)
+            || !(1..=100).contains(&value.iterations)
+            || value.rwnd < value.size as u32
+            || value.packet_budget == 0
+            || !matches!(value.reliability.as_str(), "reliable" | "rexmit:0")
+        {
+            return Err("invalid workload bounds (messages 1..1M, size 16..64KiB, streams 1..4096, cycles 1..10000, iterations 1..100, rwnd >= size, packet-budget >= 1, reliability reliable|rexmit:0)".into());
+        }
+        Ok(value)
+    }
+
+    fn messages_per_direction(&self) -> u64 {
+        if self.scenario == "reset-reuse" {
+            (self.cycles + 1) * self.streams as u64
+        } else {
+            self.messages
+        }
+    }
+}
+
+#[derive(Default)]
+struct Totals {
+    sent: u64,
+    received: u64,
+    bytes: u64,
+    opened: u64,
+    closed: u64,
+    reopened: u64,
+    packets: u64,
+    timers: u64,
+    virtual_ms: u128,
+    data_chunks: u64,
+    retransmitted_data_chunks: u64,
+    sack_chunks: u64,
+    gap_sack_chunks: u64,
+    forward_tsn_chunks: u64,
+    max_wire_inflight: u32,
+    sack_observations: u64,
+    remaining_after_sack: u64,
+    max_remaining_after_sack: u32,
+}
+
+struct Node {
+    endpoint: Endpoint,
+    peer_addr: SocketAddr,
+    handle: Option<AssociationHandle>,
+    assoc: Option<Association>,
+    connected: bool,
+    sent: u64,
+    received: u64,
+    received_per_stream: Vec<u64>,
+    closed_per_stream: Vec<u64>,
+    packets: u64,
+    timers: u64,
+    min_rwnd: u32,
+    wire: WireStats,
+}
+
+/// Observe the actual cumulative-ACK window through public wire bytes. This
+/// is not cwnd or private outstanding-byte accounting. On the no-loss transfer
+/// workloads it measures precisely how many DATA TSNs remain after each SACK.
+#[derive(Default)]
+struct WireStats {
+    last_data_tsn: Option<u32>,
+    cumulative_ack: Option<u32>,
+    data_chunks: u64,
+    retransmitted_data_chunks: u64,
+    sack_chunks: u64,
+    gap_sack_chunks: u64,
+    forward_tsn_chunks: u64,
+    max_inflight: u32,
+    sack_observations: u64,
+    remaining_after_sack: u64,
+    max_remaining_after_sack: u32,
+}
+
+impl WireStats {
+    fn observe(&mut self, packet: &[u8], outgoing: bool) -> Result<()> {
+        let mut offset = 12;
+        while offset + 4 <= packet.len() {
+            let length = u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]) as usize;
+            if length < 4 || offset + length > packet.len() {
+                return Err("invalid observed chunk".into());
+            }
+            let kind = packet[offset];
+            if outgoing && kind == 0 && length >= 16 {
+                self.data_chunks += 1;
+                let tsn = u32::from_be_bytes(packet[offset + 4..offset + 8].try_into().unwrap());
+                if self
+                    .last_data_tsn
+                    .is_some_and(|last| tsn.wrapping_sub(last) >= 1 << 31 || tsn == last)
+                {
+                    self.retransmitted_data_chunks += 1;
+                } else {
+                    self.last_data_tsn = Some(tsn);
+                    let acknowledged = *self.cumulative_ack.get_or_insert(tsn.wrapping_sub(1));
+                    self.max_inflight = self.max_inflight.max(tsn.wrapping_sub(acknowledged));
+                }
+            } else if outgoing && kind == 3 {
+                self.sack_chunks += 1;
+                if length >= 16 && packet[offset + 12..offset + 14] != [0, 0] {
+                    self.gap_sack_chunks += 1;
+                }
+            } else if outgoing && kind == 192 {
+                self.forward_tsn_chunks += 1;
+            } else if !outgoing && kind == 3 && length >= 16 {
+                let tsn = u32::from_be_bytes(packet[offset + 4..offset + 8].try_into().unwrap());
+                if let Some(last) = self.last_data_tsn {
+                    let remaining = last.wrapping_sub(tsn);
+                    if remaining >= 1 << 31 {
+                        return Err("SACK acknowledges unobserved DATA".into());
+                    }
+                    self.cumulative_ack = Some(tsn);
+                    self.sack_observations += 1;
+                    self.remaining_after_sack += remaining as u64;
+                    self.max_remaining_after_sack = self.max_remaining_after_sack.max(remaining);
+                }
+            }
+            offset += (length + 3) & !3;
+        }
+        Ok(())
+    }
+}
+
+impl Node {
+    fn new(endpoint: Endpoint, peer_addr: SocketAddr, streams: usize) -> Self {
+        Self {
+            endpoint,
+            peer_addr,
+            handle: None,
+            assoc: None,
+            connected: false,
+            sent: 0,
+            received: 0,
+            received_per_stream: vec![0; streams],
+            closed_per_stream: vec![0; streams],
+            packets: 0,
+            timers: 0,
+            min_rwnd: u32::MAX,
+            wire: WireStats::default(),
+        }
+    }
+
+    fn drive(
+        &mut self,
+        now: Instant,
+        inbound: &mut VecDeque<Bytes>,
+        outbound: &mut VecDeque<Bytes>,
+        packet_budget: usize,
+    ) -> Result<bool> {
+        let mut worked = false;
+        for _ in 0..packet_budget.min(inbound.len()) {
+            let data = inbound.pop_front().unwrap();
+            self.wire.observe(&data, false)?;
+            worked = true;
+            if let Some((handle, event)) = self.endpoint.handle(now, self.peer_addr, None, data) {
+                match event {
+                    DatagramEvent::NewAssociation(assoc) => {
+                        if self.assoc.is_some() {
+                            return Err("unexpected second association".into());
+                        }
+                        self.handle = Some(handle);
+                        self.assoc = Some(assoc);
+                    }
+                    DatagramEvent::AssociationEvent(event) => self
+                        .assoc
+                        .as_mut()
+                        .ok_or("packet without association")?
+                        .handle_event(event),
+                    _ => return Err("unsupported endpoint event".into()),
+                }
+            }
+        }
+        let Some(assoc) = &mut self.assoc else {
+            return Ok(worked);
+        };
+        if assoc.poll_timeout().is_some_and(|deadline| deadline <= now) {
+            assoc.handle_timeout(now);
+            self.timers += 1;
+            worked = true;
+        }
+        while let Some(transmit) = assoc.poll_transmit(now) {
+            let Payload::RawEncode(packets) = transmit.message else {
+                return Err("unexpected encoded payload type".into());
+            };
+            for packet in packets {
+                self.packets += 1;
+                self.wire.observe(&packet, true)?;
+                // Observe only public wire bytes; no benchmark-only SCTP hooks.
+                let mut offset = 12;
+                while offset + 4 <= packet.len() {
+                    let length =
+                        u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]) as usize;
+                    if length < 4 || offset + length > packet.len() {
+                        return Err("invalid emitted chunk".into());
+                    }
+                    if packet[offset] == 3 && length >= 16 {
+                        self.min_rwnd = self.min_rwnd.min(u32::from_be_bytes(
+                            packet[offset + 8..offset + 12].try_into().unwrap(),
+                        ));
+                    }
+                    offset += (length + 3) & !3;
+                }
+                outbound.push_back(packet);
+            }
+            worked = true;
+        }
+        while let Some(event) = assoc.poll() {
+            match event {
+                Event::Connected => self.connected = true,
+                Event::HandshakeFailed { reason } => {
+                    return Err(format!("handshake failed: {reason}"));
+                }
+                Event::AssociationLost { reason, id } => {
+                    if assoc.is_closed() || reason != AssociationError::Reset {
+                        return Err(format!("association lost: {reason}"));
+                    }
+                    *self
+                        .closed_per_stream
+                        .get_mut(id as usize)
+                        .ok_or("close for unexpected SID")? += 1;
+                }
+                _ => {}
+            }
+            worked = true;
+        }
+        if let Some(event) = assoc.poll_endpoint_event() {
+            self.endpoint
+                .handle_event(self.handle.ok_or("missing endpoint handle")?, event);
+            return Err("association unexpectedly drained".into());
+        }
+        if outbound.len() > 100_000 {
+            return Err("wire queue bound exceeded".into());
+        }
+        Ok(worked)
+    }
+
+    fn buffered(&mut self, streams: usize) -> Result<usize> {
+        let assoc = self.assoc.as_mut().ok_or("missing association")?;
+        (0..streams).try_fold(0, |sum, sid| {
+            let amount = assoc
+                .stream(sid as u16)
+                .map_err(|e| e.to_string())?
+                .buffered_amount()
+                .map_err(|e| e.to_string())?;
+            Ok(sum + amount)
+        })
+    }
+
+    fn write_to(&mut self, target: u64, source: usize, cfg: &Config, now: Instant) -> Result<bool> {
+        let mut buffered = self.buffered(cfg.streams)?;
+        let before = self.sent;
+        while self.sent < target && buffered < SEND_CAP {
+            let mut data = vec![payload_byte(cfg.seed, source, self.sent); cfg.size];
+            data[..8].copy_from_slice(&self.sent.to_le_bytes());
+            let sid = (self.sent % cfg.streams as u64) as u16;
+            let count = self
+                .assoc
+                .as_mut()
+                .unwrap()
+                .stream(sid)
+                .map_err(|e| e.to_string())?
+                .write_sctp(now, &Bytes::from(data), PPI)
+                .map_err(|e| e.to_string())?;
+            if count != cfg.size {
+                return Err(format!("short write: {count}/{}", cfg.size));
+            }
+            buffered += count;
+            self.sent += 1;
+        }
+        Ok(self.sent != before)
+    }
+
+    fn read_all(&mut self, source: usize, cfg: &Config, buffer: &mut [u8]) -> Result<bool> {
+        let before = self.received;
+        let assoc = self.assoc.as_mut().ok_or("missing association")?;
+        for sid in 0..cfg.streams {
+            let mut stream = assoc.stream(sid as u16).map_err(|e| e.to_string())?;
+            while let Some(chunks) = stream.read_sctp().map_err(|e| e.to_string())? {
+                let size = chunks.read(buffer).map_err(|e| e.to_string())?;
+                if size != cfg.size || chunks.ppi != PPI {
+                    return Err("invalid complete message".into());
+                }
+                let expected = self.received_per_stream[sid] * cfg.streams as u64 + sid as u64;
+                let sequence = u64::from_le_bytes(buffer[..8].try_into().unwrap());
+                let fill = payload_byte(cfg.seed, source, expected);
+                if sequence != expected || buffer[8..size].iter().any(|byte| *byte != fill) {
+                    return Err(format!(
+                        "wrong/duplicate message on SID {sid}: {sequence}, expected {expected}"
+                    ));
+                }
+                std::hint::black_box(&buffer[..size]);
+                self.received_per_stream[sid] += 1;
+                self.received += 1;
+            }
+        }
+        Ok(self.received != before)
+    }
+}
+
+fn payload_byte(seed: u64, source: usize, sequence: u64) -> u8 {
+    (seed ^ sequence.rotate_left(7) ^ (source as u64 + 1).wrapping_mul(0x9e37_79b9)) as u8
+}
+
+struct Pair {
+    nodes: [Node; 2],
+    c2s: VecDeque<Bytes>,
+    s2c: VecDeque<Bytes>,
+    now: Instant,
+    started: Instant,
+    steps: u64,
+    buffer: Vec<u8>,
+}
+
+impl Pair {
+    fn new(cfg: &Config) -> Result<Self> {
+        let started = Instant::now();
+        let addresses: [SocketAddr; 2] = [
+            "127.0.0.1:5000".parse().unwrap(),
+            "127.0.0.1:5001".parse().unwrap(),
+        ];
+        let endpoint = Arc::new(EndpointConfig::default());
+        let transport = || {
+            TransportConfig::default()
+                .with_max_message_size(cfg.size as u32)
+                .with_max_receive_buffer_size(cfg.rwnd)
+                .with_max_num_inbound_streams(cfg.streams as u16)
+                .with_max_num_outbound_streams(cfg.streams as u16)
+        };
+        let mut client = Node::new(
+            Endpoint::new(addresses[0], TransportProtocol::UDP, endpoint.clone(), None),
+            addresses[1],
+            cfg.streams,
+        );
+        let server = Node::new(
+            Endpoint::new(
+                addresses[1],
+                TransportProtocol::UDP,
+                endpoint,
+                Some(Arc::new(ServerConfig::new(transport()))),
+            ),
+            addresses[0],
+            cfg.streams,
+        );
+        let (handle, assoc) = client
+            .endpoint
+            .connect(started, ClientConfig::new(transport()), addresses[1])
+            .map_err(|e| e.to_string())?;
+        client.handle = Some(handle);
+        client.assoc = Some(assoc);
+        let mut pair = Self {
+            nodes: [client, server],
+            c2s: VecDeque::new(),
+            s2c: VecDeque::new(),
+            now: started,
+            started,
+            steps: 0,
+            buffer: vec![0; cfg.size],
+        };
+        while !pair.nodes.iter().all(|node| node.connected) {
+            if !pair.step(cfg, false)? {
+                pair.advance()?;
+            }
+        }
+        Ok(pair)
+    }
+
+    fn step(&mut self, cfg: &Config, read: bool) -> Result<bool> {
+        self.steps += 1;
+        if self.steps > 20_000_000
+            || (self.steps % 1024 == 0 && self.started.elapsed() > Duration::from_secs(90))
+        {
+            return Err("workload exceeded its step/wall-clock bound".into());
+        }
+        // A small-window workload handles one datagram per application read
+        // turn. This bounds each receive burst below rwnd, instead of making a
+        // throughput comparison depend on a pre-existing zero-window deadlock.
+        let budget = if cfg.scenario == "small-rwnd" {
+            1
+        } else {
+            cfg.packet_budget
+        };
+        let mut worked = self.nodes[0].drive(self.now, &mut self.s2c, &mut self.c2s, budget)?;
+        worked |= self.nodes[1].drive(self.now, &mut self.c2s, &mut self.s2c, budget)?;
+        if read {
+            worked |= self.nodes[0].read_all(1, cfg, &mut self.buffer)?;
+            worked |= self.nodes[1].read_all(0, cfg, &mut self.buffer)?;
+        }
+        Ok(worked)
+    }
+
+    fn advance(&mut self) -> Result<()> {
+        let deadline = self
+            .nodes
+            .iter()
+            .filter_map(|node| node.assoc.as_ref().and_then(Association::poll_timeout))
+            .min()
+            .ok_or_else(|| {
+                format!(
+                    "deadlock without timer: sent={:?}, received={:?}",
+                    self.nodes.each_ref().map(|n| n.sent),
+                    self.nodes.each_ref().map(|n| n.received)
+                )
+            })?;
+        if deadline <= self.now
+            || deadline.duration_since(self.started) > Duration::from_secs(86_400)
+        {
+            return Err("timer did not advance or exceeded the virtual-time bound".into());
+        }
+        self.now = deadline;
+        Ok(())
+    }
+
+    fn open(&mut self, cfg: &Config) -> Result<()> {
+        for node in &mut self.nodes {
+            for sid in 0..cfg.streams {
+                node.assoc
+                    .as_mut()
+                    .unwrap()
+                    .open_stream(sid as u16, PPI)
+                    .map_err(|e| format!("open/reopen SID {sid}: {e}"))?
+                    .set_reliability_params(
+                        cfg.unordered,
+                        if cfg.reliability == "rexmit:0" {
+                            ReliabilityType::Rexmit
+                        } else {
+                            ReliabilityType::Reliable
+                        },
+                        0,
+                    )
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn transfer(&mut self, cfg: &Config, target: u64) -> Result<()> {
+        loop {
+            let mut worked = false;
+            for (source, node) in self.nodes.iter_mut().enumerate() {
+                worked |= node.write_to(target, source, cfg, self.now)?;
+            }
+            worked |= self.step(cfg, true)?;
+            if self.nodes.iter().any(|node| node.received > target) {
+                return Err("extra delivery".into());
+            }
+            if self
+                .nodes
+                .iter()
+                .all(|node| node.sent == target && node.received == target)
+                && self.nodes[0].buffered(cfg.streams)? == 0
+                && self.nodes[1].buffered(cfg.streams)? == 0
+                && self.c2s.is_empty()
+                && self.s2c.is_empty()
+            {
+                return Ok(());
+            }
+            if !worked {
+                self.advance()?;
+            }
+        }
+    }
+
+    fn reset(&mut self, cfg: &Config, cycle: u64) -> Result<()> {
+        for sid in 0..cfg.streams {
+            self.nodes[0]
+                .assoc
+                .as_mut()
+                .unwrap()
+                .stream(sid as u16)
+                .map_err(|e| e.to_string())?
+                .close(self.now)
+                .map_err(|e| e.to_string())?;
+        }
+        loop {
+            let worked = self.step(cfg, false)?;
+            if self
+                .nodes
+                .iter()
+                .any(|node| node.closed_per_stream.iter().any(|count| *count > cycle))
+            {
+                return Err("duplicate close notification".into());
+            }
+            if self.nodes.iter().all(|node| {
+                node.closed_per_stream.iter().all(|count| *count == cycle)
+                    && node.assoc.as_ref().unwrap().stream_ids().is_empty()
+            }) && self.c2s.is_empty()
+                && self.s2c.is_empty()
+            {
+                return Ok(());
+            }
+            if !worked {
+                self.advance()?;
+            }
+        }
+    }
+}
+
+fn run(cfg: &Config) -> Result<(Totals, u32)> {
+    let mut total = Totals::default();
+    let mut min_rwnd = u32::MAX;
+    for _ in 0..cfg.iterations {
+        let mut pair = Pair::new(cfg)?;
+        pair.open(cfg)?;
+        total.opened += 2 * cfg.streams as u64;
+        if cfg.scenario == "reset-reuse" {
+            for cycle in 1..=cfg.cycles {
+                pair.transfer(cfg, cycle * cfg.streams as u64)?;
+                pair.reset(cfg, cycle)?;
+                pair.open(cfg)?;
+                total.reopened += 2 * cfg.streams as u64;
+                total.opened += 2 * cfg.streams as u64;
+            }
+        }
+        pair.transfer(cfg, cfg.messages_per_direction())?;
+        total.virtual_ms += pair.now.duration_since(pair.started).as_millis();
+        for node in &pair.nodes {
+            total.sent += node.sent;
+            total.received += node.received;
+            total.bytes += node.received * cfg.size as u64;
+            total.closed += node.closed_per_stream.iter().sum::<u64>();
+            total.packets += node.packets;
+            total.timers += node.timers;
+            total.data_chunks += node.wire.data_chunks;
+            total.retransmitted_data_chunks += node.wire.retransmitted_data_chunks;
+            total.sack_chunks += node.wire.sack_chunks;
+            total.gap_sack_chunks += node.wire.gap_sack_chunks;
+            total.forward_tsn_chunks += node.wire.forward_tsn_chunks;
+            total.max_wire_inflight = total.max_wire_inflight.max(node.wire.max_inflight);
+            total.sack_observations += node.wire.sack_observations;
+            total.remaining_after_sack += node.wire.remaining_after_sack;
+            total.max_remaining_after_sack = total
+                .max_remaining_after_sack
+                .max(node.wire.max_remaining_after_sack);
+            min_rwnd = min_rwnd.min(node.min_rwnd);
+        }
+    }
+    let expected = 2 * cfg.iterations * cfg.messages_per_direction();
+    if total.sent != expected || total.received != expected || total.closed != total.reopened {
+        return Err("final workload count mismatch".into());
+    }
+    Ok((total, min_rwnd))
+}
+
+fn main() {
+    let cfg = Config::parse().unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(2)
+    });
+    #[cfg(feature = "allocation-probe")]
+    allocation::start();
+    let started = Instant::now();
+    let result = run(&cfg);
+    let elapsed_ns = started.elapsed().as_nanos();
+    #[cfg(feature = "allocation-probe")]
+    let allocation = allocation::finish();
+    #[cfg(not(feature = "allocation-probe"))]
+    let allocation = "\"allocation_probe\":false,\"allocations\":null,\"reallocations\":null,\"allocated_bytes\":null";
+    let (total, min_rwnd) = result.unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1)
+    });
+    println!(
+        "{{\"scenario\":\"{}\",\"iterations\":{},\"messages_per_direction\":{},\"streams\":{},\"message_size\":{},\"cycles\":{},\"seed\":{},\"rwnd\":{},\"sent_messages\":{},\"delivered_messages\":{},\"delivered_bytes\":{},\"opened_streams\":{},\"closed_streams\":{},\"reopened_streams\":{},\"packets\":{},\"timer_firings\":{},\"virtual_elapsed_ms\":{},\"elapsed_ns\":{},\"min_advertised_rwnd\":{},\"reliability\":\"{}\",\"unordered\":{},\"packet_budget\":{},\"data_chunks\":{},\"retransmitted_data_chunks\":{},\"sack_chunks\":{},\"gap_sack_chunks\":{},\"forward_tsn_chunks\":{},\"max_wire_inflight_chunks\":{},\"sack_observations\":{},\"remaining_after_sack_sum\":{},\"max_remaining_after_sack_chunks\":{},{}}}",
+        cfg.scenario,
+        cfg.iterations,
+        cfg.messages_per_direction(),
+        cfg.streams,
+        cfg.size,
+        cfg.cycles,
+        cfg.seed,
+        cfg.rwnd,
+        total.sent,
+        total.received,
+        total.bytes,
+        total.opened,
+        total.closed,
+        total.reopened,
+        total.packets,
+        total.timers,
+        total.virtual_ms,
+        elapsed_ns,
+        min_rwnd,
+        cfg.reliability,
+        cfg.unordered,
+        cfg.packet_budget,
+        total.data_chunks,
+        total.retransmitted_data_chunks,
+        total.sack_chunks,
+        total.gap_sack_chunks,
+        total.forward_tsn_chunks,
+        total.max_wire_inflight,
+        total.sack_observations,
+        total.remaining_after_sack,
+        total.max_remaining_after_sack,
+        allocation
+    );
+}

--- a/rtc-sctp/interop/run.py
+++ b/rtc-sctp/interop/run.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Bounded, packet-aware SCTP interop scenarios. Requires only Python stdlib."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+from pathlib import Path
+import random
+import selectors
+import struct
+import subprocess
+import time
+
+
+PINS = {
+    "usrsctp": "fd070e05a7474f38c7fecdf4d4b6005d2547ee00",
+    "dcsctp": "dab572fd15e3fb975ed14a9e9290f723bb6e3f30",
+}
+CHUNK_NAMES = {0: "DATA", 1: "INIT", 2: "INIT_ACK", 3: "SACK", 4: "HEARTBEAT",
+               5: "HEARTBEAT_ACK", 6: "ABORT", 7: "SHUTDOWN", 8: "SHUTDOWN_ACK",
+               9: "ERROR", 10: "COOKIE_ECHO", 11: "COOKIE_ACK", 14: "SHUTDOWN_COMPLETE",
+               64: "I_DATA", 130: "RE_CONFIG", 192: "FORWARD_TSN", 194: "I_FORWARD_TSN"}
+
+
+def crc32c(data: bytes) -> int:
+    value = 0xFFFFFFFF
+    for byte in data:
+        value ^= byte
+        for _ in range(8):
+            value = (value >> 1) ^ (0x82F63B78 if value & 1 else 0)
+    return value ^ 0xFFFFFFFF
+
+
+def pad(data: bytes) -> bytes:
+    return data + bytes((-len(data)) % 4)
+
+
+def tlvs(data: bytes, offset: int = 0):
+    while offset < len(data):
+        if len(data) - offset < 4:
+            raise AssertionError("truncated TLV header")
+        kind, size = struct.unpack_from("!HH", data, offset)
+        if size < 4 or offset + size > len(data):
+            raise AssertionError("invalid TLV length")
+        raw = data[offset:offset + size]
+        yield kind, raw
+        # Padding after the last parameter may belong to the enclosing chunk
+        # padding, outside its declared length (e.g. Supported Extensions).
+        offset = len(data) if offset + size == len(data) else offset + ((size + 3) & ~3)
+    if offset != len(data):
+        raise AssertionError("truncated TLV padding")
+
+
+def chunks(packet: bytes):
+    if len(packet) < 12:
+        raise AssertionError("short SCTP header")
+    offset = 12
+    while offset < len(packet):
+        if len(packet) - offset < 4:
+            raise AssertionError("truncated chunk header")
+        kind, flags, size = struct.unpack_from("!BBH", packet, offset)
+        if size < 4 or offset + size > len(packet):
+            raise AssertionError("invalid chunk length")
+        raw = packet[offset:offset + size]
+        yield kind, flags, raw
+        offset += (size + 3) & ~3
+    if offset != len(packet):
+        raise AssertionError("truncated chunk padding")
+
+
+def decode_parameter(kind: int, raw: bytes) -> dict:
+    result = {"type": kind, "length": len(raw)}
+    body = raw[4:]
+    if kind == 13:
+        if len(body) < 12 or len(body) % 2:
+            raise AssertionError("invalid outgoing reset length")
+        seq, response, last = struct.unpack_from("!III", body)
+        result.update(request=seq, response=response, last_tsn=last,
+                      sids=list(struct.unpack(f"!{(len(body)-12)//2}H", body[12:])))
+    elif kind == 16:
+        if len(body) not in (8, 16):
+            raise AssertionError("invalid reconfig response length")
+        seq, status = struct.unpack_from("!II", body)
+        result.update(response=seq, result=status)
+    return result
+
+
+def decode_chunk(kind: int, flags: int, raw: bytes) -> dict:
+    result = {"type": kind, "name": CHUNK_NAMES.get(kind, "UNKNOWN"),
+              "flags": flags, "length": len(raw)}
+    body = raw[4:]
+    if kind == 0:
+        if len(body) < 13:
+            raise AssertionError("empty or truncated DATA")
+        tsn, sid, ssn, ppid = struct.unpack_from("!IHHI", body)
+        result.update(tsn=tsn, sid=sid, ssn=ssn, ppid=ppid, beginning=bool(flags & 2),
+                      end=bool(flags & 1), unordered=bool(flags & 4),
+                      payload_length=len(body)-12,
+                      payload_sha256=hashlib.sha256(body[12:]).hexdigest())
+    elif kind in (1, 2):
+        tag, rwnd, outbound, inbound, tsn = struct.unpack_from("!IIHHI", body)
+        result.update(tag=tag, rwnd=rwnd, outbound=outbound, inbound=inbound,
+                      initial_tsn=tsn,
+                      parameters=[{"type": k, "hex": p.hex()} for k, p in tlvs(body, 16)])
+    elif kind == 3:
+        cumulative, rwnd, gaps, duplicates = struct.unpack_from("!IIHH", body)
+        if len(body) != 12 + gaps * 4 + duplicates * 4:
+            raise AssertionError("invalid SACK length")
+        result.update(cumulative=cumulative, rwnd=rwnd,
+                      gaps=[list(struct.unpack_from("!HH", body, 12+4*i)) for i in range(gaps)],
+                      duplicates=[struct.unpack_from("!I", body, 12+4*gaps+4*i)[0]
+                                  for i in range(duplicates)])
+    elif kind == 130:
+        result["parameters"] = [decode_parameter(k, p) for k, p in tlvs(body)]
+    elif kind == 192:
+        if len(body) < 4 or len(body) % 4:
+            raise AssertionError("invalid FORWARD-TSN length")
+        result.update(cumulative=struct.unpack_from("!I", body)[0],
+                      streams=[list(struct.unpack_from("!HH", body, i))
+                               for i in range(4, len(body), 4)])
+    return result
+
+
+def decode(packet: bytes) -> dict:
+    if len(packet) < 12:
+        raise AssertionError("short SCTP packet")
+    checksum = int.from_bytes(packet[8:12], "little")
+    expected = crc32c(packet[:8] + bytes(4) + packet[12:])
+    if checksum != expected:
+        raise AssertionError(f"invalid CRC32C {checksum:08x}, expected {expected:08x}")
+    source, destination, tag = struct.unpack_from("!HHI", packet)
+    return {"source_port": source, "destination_port": destination, "vtag": tag,
+            "checksum": checksum,
+            "chunks": [decode_chunk(k, f, raw) for k, f, raw in chunks(packet)]}
+
+
+def rewrite(packet: bytes, keep_chunk=lambda chunk: True,
+            keep_parameter=lambda parameter: True) -> bytes | None:
+    """Remove selected chunks/parameters, retaining association fields and CRC."""
+    retained = []
+    for kind, flags, raw in chunks(packet):
+        if not keep_chunk(decode_chunk(kind, flags, raw)):
+            continue
+        if kind == 130:
+            params = [pad(p) for k, p in tlvs(raw[4:])
+                      if keep_parameter(decode_parameter(k, p))]
+            if not params:
+                continue
+            body = b"".join(params)
+            raw = struct.pack("!BBH", kind, flags, 4+len(body)) + body
+        retained.append(pad(raw))
+    if not retained:
+        return None
+    result = packet[:8] + bytes(4) + b"".join(retained)
+    result = result[:8] + crc32c(result).to_bytes(4, "little") + result[12:]
+    decode(result)
+    return result
+
+
+def correct_response_sequence(packet: bytes, sequence: int) -> bytes:
+    """Normalize a peer's A4 field, keeping its actual request/TSN/SIDs intact."""
+    result = bytearray(packet)
+    chunk_offset = 12
+    for kind, _, raw in chunks(packet):
+        if kind == 130:
+            parameter_offset = chunk_offset + 4
+            for parameter_kind, parameter in tlvs(raw[4:]):
+                if parameter_kind == 13:
+                    struct.pack_into("!I", result, parameter_offset + 8, sequence)
+                parameter_offset += (len(parameter) + 3) & ~3
+        chunk_offset += (len(raw) + 3) & ~3
+    result[8:12] = bytes(4)
+    result[8:12] = crc32c(result).to_bytes(4, "little")
+    decode(bytes(result))
+    return bytes(result)
+
+
+class Peer:
+    def __init__(self, name: str, binary: Path, artifact: Path, command_timeout: float):
+        self.name = name
+        self.stderr = artifact.with_suffix(f".{name}.stderr").open("wb")
+        self.process = subprocess.Popen([str(binary)], stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE, stderr=self.stderr)
+        self.selector = selectors.DefaultSelector()
+        self.selector.register(self.process.stdout, selectors.EVENT_READ)
+        self.buffer = b""
+        self.timeout = command_timeout
+
+    def command(self, command: str) -> list[str]:
+        self.process.stdin.write((command + "\n").encode())
+        self.process.stdin.flush()
+        until = time.monotonic() + self.timeout
+        result = []
+        while True:
+            while b"\n" in self.buffer:
+                raw, self.buffer = self.buffer.split(b"\n", 1)
+                line = raw.decode().rstrip("\r")
+                if line == "DONE":
+                    return result
+                result.append(line)
+            remaining = until - time.monotonic()
+            if remaining <= 0 or not self.selector.select(remaining):
+                raise AssertionError(f"{self.name}: command timed out: {command[:80]}")
+            data = os.read(self.process.stdout.fileno(), 65536)
+            if not data:
+                raise AssertionError(f"{self.name}: exited {self.process.poll()}: {result[-5:]}")
+            self.buffer += data
+            if len(self.buffer) > 16 * 1024 * 1024:
+                raise AssertionError("adapter response exceeds limit")
+
+    def close(self):
+        try:
+            if self.process.poll() is None:
+                self.command("QUIT")
+                self.process.wait(timeout=2)
+        except (AssertionError, BrokenPipeError, subprocess.TimeoutExpired):
+            self.process.kill()
+            self.process.wait()
+        self.selector.close()
+        self.process.stdin.close()
+        self.process.stdout.close()
+        self.stderr.close()
+
+
+class Link:
+    def __init__(self, rtc: Path, external: Path, rtc_client: bool,
+                 artifact: Path, seed: int, command_timeout: float):
+        self.trace = artifact.open("w", encoding="utf8")
+        self.now = 0
+        self.random = random.Random(seed)
+        self.peers = {"rtc": Peer("rtc", rtc, artifact, command_timeout),
+                      "peer": Peer("peer", external, artifact, command_timeout)}
+        self.pending = collections.deque()
+        self.held = []
+        self.messages = {"rtc": [], "peer": []}
+        self.events = {"rtc": [], "peer": []}
+        self.next_packet_time = {"rtc": None, "peer": None}
+        self.wire = []
+        self.rules = []
+        self.operations = 0
+        self.wall_deadline = time.monotonic() + 45
+        self.log("settings", seed=seed, rtc_client=rtc_client, mtu=1200,
+                 ppid=53, step_ms=10, command_timeout=command_timeout,
+                 rtc_binary_sha256=hashlib.sha256(rtc.read_bytes()).hexdigest(),
+                 peer_binary_sha256=hashlib.sha256(external.read_bytes()).hexdigest())
+        try:
+            self.command("rtc", "INIT client" if rtc_client else "INIT server")
+            self.command("peer", "INIT server" if rtc_client else "INIT client")
+            self.command("rtc" if rtc_client else "peer", "CONNECT")
+            self.until(lambda: all("ready" in events for events in self.events.values()), 8000)
+        except Exception as error:
+            self.log("failed_handshake", error=str(error))
+            self.close()
+            raise
+
+    @staticmethod
+    def other(name):
+        return "peer" if name == "rtc" else "rtc"
+
+    def log(self, kind, **data):
+        self.trace.write(json.dumps({"time_ms": self.now, "kind": kind, **data},
+                                    sort_keys=True) + "\n")
+
+    def command(self, name: str, command: str):
+        self.operations += 1
+        if self.operations > 100_000 or time.monotonic() > self.wall_deadline:
+            raise AssertionError("scenario execution bound exceeded")
+        self.log("command", node=name, command=command)
+        for line in self.peers[name].command(command):
+            if line.startswith("PACKET "):
+                packet = bytes.fromhex(line[7:])
+                sent_at = self.next_packet_time[name]
+                self.next_packet_time[name] = None
+                if sent_at is None:
+                    sent_at = self.now
+                try:
+                    parsed = decode(packet)
+                except (AssertionError, struct.error) as error:
+                    self.log("invalid_packet", source=name, hex=packet.hex(), error=str(error))
+                    raise
+                self.log("emit", source=name, hex=packet.hex(), packet=parsed,
+                         send_time_ms=sent_at)
+                self.wire.append((sent_at, name, packet, parsed))
+                self.pending.append((name, packet))
+            elif line.startswith("MESSAGE "):
+                _, sid, ppid, payload = line.split(maxsplit=3)
+                value = {"sid": int(sid), "ppid": int(ppid), "hex": payload}
+                self.messages[name].append(value)
+                self.log("message", node=name, **value)
+            elif line.startswith("EVENT "):
+                event = line[6:]
+                if event.startswith("packet_time:"):
+                    self.next_packet_time[name] = int(event.split(":", 1)[1])
+                    self.log("packet_clock", node=name, send_time_ms=self.next_packet_time[name])
+                    continue
+                self.events[name].append(event)
+                self.log("event", node=name, event=event)
+                if event == "closed" or event.startswith("error:"):
+                    raise AssertionError(f"unexpected peer error: {name}: {event}")
+            elif line.startswith("ERROR "):
+                self.log("adapter_error", node=name, error=line[6:])
+                raise AssertionError(f"{name}: {line}; command={command[:80]}")
+            else:
+                raise AssertionError(f"unknown adapter output {name}: {line[:200]}")
+
+    def pump(self):
+        deliveries = 0
+        while self.pending:
+            source, packet = self.pending.popleft()
+            original = packet
+            for rule in self.rules:
+                if packet is None:
+                    break
+                packet = rule(self, source, packet)
+            if packet is not None:
+                self.log("deliver", source=source, destination=self.other(source),
+                         hex=packet.hex(), changed=packet != original, packet=decode(packet))
+                self.command(self.other(source), "INPUT " + packet.hex())
+            deliveries += 1
+            if deliveries > 10_000:
+                raise AssertionError("packet feedback loop")
+
+    def advance(self, milliseconds=10):
+        # Both clocks advance before newly generated packets are delivered.
+        # Trace time is the end of the command's <=10ms interval, not a claim
+        # that every internal callback in an external peer ran at that instant.
+        self.now += milliseconds
+        self.command("rtc", f"TICK {milliseconds}")
+        self.command("peer", f"TICK {milliseconds}")
+        self.pump()
+
+    def until(self, predicate, timeout=12_000):
+        limit = self.now + timeout
+        self.pump()
+        while not predicate():
+            if self.now >= limit:
+                raise AssertionError(f"condition not reached by virtual time {limit}ms")
+            self.advance(min(10, limit-self.now))
+
+    def settle(self, milliseconds=250):
+        self.pump()
+        limit = self.now + milliseconds
+        while self.now < limit:
+            self.advance(min(10, limit-self.now))
+
+    def send(self, name, sid, data, policy="reliable", order="ordered", pump=True):
+        self.command(name, f"SEND {sid} {order} {policy} 53 {data.hex()}")
+        if pump:
+            self.pump()
+
+    def received(self, name, sid, data):
+        return self.messages[name].count({"sid": sid, "ppid": 53, "hex": data.hex()})
+
+    def expect_message(self, source, sid, data):
+        target = self.other(source)
+        self.until(lambda: self.received(target, sid, data) == 1)
+        assert self.received(target, sid, data) == 1, "duplicate application delivery"
+
+    def release_held(self, reverse=False, duplicate=False):
+        held, self.held = self.held, []
+        if reverse:
+            held.reverse()
+        for source, packet in held:
+            self.log("release_held", source=source, hex=packet.hex(), duplicate=duplicate)
+            self.pending.append((source, packet))
+            if duplicate:
+                self.pending.append((source, packet))
+        self.pump()
+
+    def close(self):
+        for peer in self.peers.values():
+            peer.close()
+        self.trace.close()
+
+
+class DropFirstData:
+    def __init__(self, source, sid):
+        self.source, self.sid = source, sid
+        self.dropped = None
+
+    def __call__(self, link, source, packet):
+        if source != self.source or self.dropped is not None:
+            return packet
+
+        def keep(chunk):
+            if (self.dropped is None and chunk["type"] == 0 and
+                    chunk["sid"] == self.sid and chunk["beginning"]):
+                self.dropped = chunk["tsn"]
+                link.log("drop_DATA", source=source, tsn=self.dropped,
+                         original_hex=packet.hex())
+                return False
+            return True
+        return rewrite(packet, keep_chunk=keep)
+
+
+class DropResetResult:
+    def __init__(self, requester, sid, limit=1):
+        self.requester, self.sid = requester, sid
+        self.limit = limit
+        self.request = None
+        self.request_packet = None
+        self.dropped = 0
+
+    def __call__(self, link, source, packet):
+        if source == self.requester and self.request is None:
+            for chunk in decode(packet)["chunks"]:
+                for param in chunk.get("parameters", []):
+                    if param["type"] == 13 and self.sid in param["sids"]:
+                        self.request = param["request"]
+                        # Retain only this request for a genuinely delayed duplicate.
+                        self.request_packet = rewrite(
+                            packet, keep_chunk=lambda c: c["type"] == 130,
+                            keep_parameter=lambda p: p.get("request") == self.request)
+        if (source == self.requester or self.request is None or
+                (self.limit is not None and self.dropped >= self.limit)):
+            return packet
+
+        def keep(param):
+            if ((self.limit is None or self.dropped < self.limit) and param["type"] == 16 and
+                    param["response"] == self.request and param["result"] in (0, 1)):
+                self.dropped += 1
+                link.log("drop_reset_result", source=source, sequence=self.request,
+                         original_hex=packet.hex())
+                return False
+            return True
+        return rewrite(packet, keep_parameter=keep)
+
+
+def reliable(link):
+    for source, sid, size, order in [("rtc", 1, 16_384, "ordered"),
+                                      ("peer", 2, 4000, "unordered")]:
+        payload = link.random.randbytes(size)
+        link.send(source, sid, payload, order=order)
+        link.expect_message(source, sid, payload)
+    # Ordered delivery under delayed/duplicated DATA, chosen by content/SID.
+    held_once = False
+
+    def hold(link, source, packet):
+        nonlocal held_once
+        if not held_once and source == "rtc" and any(
+                c["type"] == 0 and c["sid"] == 3 for c in decode(packet)["chunks"]):
+            held_once = True
+            link.held.append((source, packet))
+            link.log("hold", source=source, hex=packet.hex())
+            return None
+        return packet
+    link.rules.append(hold)
+    link.send("rtc", 3, b"ordered first")
+    link.send("rtc", 3, b"ordered second")
+    assert not link.received("peer", 3, b"ordered second")
+    link.release_held(reverse=True, duplicate=True)
+    link.expect_message("rtc", 3, b"ordered first")
+    link.expect_message("rtc", 3, b"ordered second")
+    sequence = [m["hex"] for m in link.messages["peer"] if m["sid"] == 3]
+    assert sequence == [b"ordered first".hex(), b"ordered second".hex()]
+
+
+def partial_reliability(link, source, policy):
+    sid = 5
+    # Two timed fragments cannot trigger three immediate Gap ACK reports before
+    # the 100ms deadline. A large message can legitimately recover via fast
+    # retransmit at virtual time zero, so that is a different test scenario.
+    payload = link.random.randbytes(9000 if policy == "rexmit:0" else 2000)
+    rule = DropFirstData(source, sid)
+    link.rules.append(rule)
+    begin, start = link.now, len(link.wire)
+    link.send(source, sid, payload, policy, "unordered")
+    assert rule.dropped is not None, "did not observe first DATA"
+    link.until(lambda: any(origin == source and any(c["type"] == 192 for c in p["chunks"])
+                           for _, origin, _, p in link.wire[start:]))
+    link.settle(500)
+    relevant = [(at, c) for at, origin, _, p in link.wire[start:] if origin == source
+                for c in p["chunks"] if c["type"] == 0 and c["sid"] == sid]
+    if policy == "rexmit:0":
+        tsns = [c["tsn"] for _, c in relevant]
+        assert len(tsns) == len(set(tsns)), "Rexmit(0) retransmitted DATA"
+    else:
+        assert all(at < begin+100 for at, _ in relevant), "DATA sent after Timed(100) deadline"
+    assert not link.received(link.other(source), sid, payload), "lost unreliable message delivered"
+    sentinel = b"reliable message after abandonment"
+    link.send(source, sid, sentinel)
+    link.expect_message(source, sid, sentinel)
+    assert not link.received(link.other(source), sid, payload)
+
+
+def prime_stream(link, sid):
+    for source in ["rtc", "peer"]:
+        payload = f"before reset {source} {sid}".encode()
+        link.send(source, sid, payload)
+        link.expect_message(source, sid, payload)
+    link.settle()
+
+
+def lost_reset_response(link, requester):
+    sid = 7
+    prime_stream(link, sid)
+    rule = DropResetResult(requester, sid)
+    link.rules.append(rule)
+    link.command(requester, f"RESET {sid}")
+    link.pump()
+    assert rule.dropped == 1, "no successful reset response was dropped"
+    link.settle(6500)
+    payload = b"after lost reset response"
+    link.send(requester, sid, payload)
+    link.expect_message(requester, sid, payload)
+
+
+def simultaneous_reset(link):
+    sid = 8
+    prime_stream(link, sid)
+    link.command("rtc", f"RESET {sid}")
+    link.command("peer", f"RESET {sid}")
+    link.pump()
+    link.settle(3500)
+    for source in ["rtc", "peer"]:
+        payload = f"new incarnation {source}".encode()
+        link.send(source, sid, payload)
+        link.expect_message(source, sid, payload)
+
+
+def sequential_resets(link):
+    sid = 9
+    prime_stream(link, sid)
+    rule = DropResetResult("rtc", sid)
+    link.rules.append(rule)
+    link.command("rtc", f"RESET {sid}")
+    link.pump()
+    assert rule.dropped == 1
+    # A real peer-generated request supplies a correctly sequenced implicit ACK.
+    link.command("peer", "RESET 10")
+    link.pump()
+    link.settle(6500)
+    for other_sid in [11, 12]:
+        link.command("rtc", f"RESET {other_sid}")
+        link.pump()
+        link.settle(500)
+    # A held network duplicate can arrive after either peer's bounded result
+    # cache evicts N. Its response must not change a finished/newer procedure.
+    link.pending.append(("rtc", rule.request_packet))
+    link.log("delayed_duplicate_request", hex=rule.request_packet.hex(), sequence=rule.request)
+    link.pump()
+    for suffix in [b"zero", b"one"]:
+        payload = b"after sequential resets " + suffix
+        link.send("rtc", sid, payload)
+        link.expect_message("rtc", sid, payload)
+
+
+def forgotten_result_recovery(link):
+    sid = 20
+    prime_stream(link, sid)
+    start = len(link.wire)
+    rule = DropResetResult("rtc", sid, limit=None)
+    link.rules.append(rule)
+    link.command("rtc", f"RESET {sid}")
+    queued = b"queued behind a lost result"
+    link.send("rtc", sid, queued, pump=False)
+    link.pump()
+    assert rule.dropped > 0
+
+    def normalize_a4(link, source, packet):
+        # usrsctp already emits the expected A4 value. The pinned dcSCTP emits
+        # its own request sequence instead; keep this explicit fault-normalized
+        # case separate from the unmodified sequential_resets scenario.
+        if source == "peer" and any(p["type"] == 13 and 21 in p["sids"]
+                                     for c in decode(packet)["chunks"]
+                                     for p in c.get("parameters", [])):
+            changed = correct_response_sequence(packet, rule.request)
+            if changed != packet:
+                link.log("normalize_peer_A4", original_hex=packet.hex(),
+                         replacement_hex=changed.hex(), response_sequence=rule.request)
+            return changed
+        return packet
+
+    link.rules.append(normalize_a4)
+    link.command("peer", "RESET 21")
+    link.pump()
+    for other_sid in [22, 23]:
+        link.command("rtc", f"RESET {other_sid}")
+        link.pump()
+    assert not link.received("peer", sid, queued), "implicit ACK prematurely released DATA"
+
+    def requests():
+        return [p for _, source, _, packet in link.wire[start:] if source == "rtc"
+                for c in packet["chunks"] for p in c.get("parameters", []) if p["type"] == 13]
+
+    # Keep dropping N's result through a real retry. Other requests must remain
+    # queued, so neither peer's bounded result cache can evict the unknown N.
+    dropped_before_retry = rule.dropped
+    link.until(lambda: rule.dropped > dropped_before_retry)
+    outstanding = requests()
+    assert len(outstanding) >= 2, "the unknown result was not queried again"
+    assert all(p == outstanding[0] for p in outstanding), "a newer or changed reset escaped before N's result"
+    assert outstanding[0]["request"] == rule.request
+    assert not link.received("peer", sid, queued), "a query prematurely released DATA"
+
+    # Restore responses; Success for the same immutable N establishes the SSN
+    # boundary, releases DATA, and permits the queued requests to start.
+    rule.limit = rule.dropped
+    link.expect_message("rtc", sid, queued)
+    link.until(lambda: {22, 23}.issubset({sid for p in requests() for sid in p["sids"]}))
+    link.settle(1000)
+    sentinel = b"next SSN after result recovery"
+    link.send("rtc", sid, sentinel)
+    link.expect_message("rtc", sid, sentinel)
+    bad_sequence = [p for _, source, _, packet in link.wire if source == "peer"
+                    for c in packet["chunks"] for p in c.get("parameters", [])
+                    if p["type"] == 16 and p.get("response") == rule.request and p.get("result") == 5]
+    assert not bad_sequence, "new reset requests evicted the unresolved result"
+    link.log("recovery_path", first_request=rule.request,
+             repeated_request_count=len(outstanding), subsequent_sids=[22, 23],
+             forgotten_result=False, a4_normalization="only if peer field differed")
+
+
+SCENARIOS = {
+    "reliable": reliable,
+    "timed_rtc": lambda link: partial_reliability(link, "rtc", "timed:100"),
+    "timed_peer": lambda link: partial_reliability(link, "peer", "timed:100"),
+    "rexmit_rtc": lambda link: partial_reliability(link, "rtc", "rexmit:0"),
+    "rexmit_peer": lambda link: partial_reliability(link, "peer", "rexmit:0"),
+    "lost_response_rtc": lambda link: lost_reset_response(link, "rtc"),
+    "lost_response_peer": lambda link: lost_reset_response(link, "peer"),
+    "simultaneous_reset": simultaneous_reset,
+    "sequential_resets": sequential_resets,
+    "forgotten_result_recovery": forgotten_result_recovery,
+}
+
+
+def self_test():
+    assert crc32c(b"123456789") == 0xE3069283
+    header = struct.pack("!HHII", 5000, 5000, 123, 0)
+    data = struct.pack("!BBHIHHI", 0, 3, 19, 7, 1, 0, 53) + b"abc"
+    response = struct.pack("!HHII", 16, 12, 9, 1)
+    request = struct.pack("!HHIIIH", 13, 18, 10, 9, 7, 1)
+    reconfig = struct.pack("!BBH", 130, 0, 36) + response + pad(request)
+    packet = header + pad(data) + reconfig
+    packet = packet[:8] + crc32c(packet).to_bytes(4, "little") + packet[12:]
+    assert len(decode(packet)["chunks"]) == 2
+    filtered = rewrite(packet, keep_parameter=lambda p: p["type"] != 16)
+    assert decode(filtered)["chunks"][1]["parameters"][0]["request"] == 10
+    assert rewrite(packet, keep_chunk=lambda c: False) is None
+    assert decode(rewrite(packet, keep_chunk=lambda c: c["type"] != 0))["chunks"][0]["type"] == 130
+    try:
+        decode(packet[:-1] + bytes([packet[-1] ^ 1]))
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("corrupted packet passed CRC")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rtc", type=Path, required=True)
+    parser.add_argument("--usrsctp", type=Path)
+    parser.add_argument("--dcsctp", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--scenario", action="append", choices=SCENARIOS)
+    parser.add_argument("--role", action="append", choices=["client", "server"])
+    parser.add_argument("--seed", type=int, default=237)
+    parser.add_argument("--command-timeout", type=float, default=5)
+    args = parser.parse_args()
+    self_test()
+    peers = {name: getattr(args, name) for name in PINS if getattr(args, name)}
+    if not peers:
+        parser.error("provide --usrsctp and/or --dcsctp")
+    for binary in [args.rtc, *peers.values()]:
+        if not binary.is_file():
+            parser.error(f"missing adapter binary: {binary}")
+    args.output.mkdir(parents=True, exist_ok=True)
+    results = []
+    for peer_name, binary in peers.items():
+        for role in args.role or ["client", "server"]:
+            for scenario in args.scenario or SCENARIOS:
+                name = f"{peer_name}-rtc-{role}-{scenario}"
+                artifact = args.output / (name + ".jsonl")
+                link = None
+                started = time.monotonic()
+                try:
+                    link = Link(args.rtc.resolve(), binary.resolve(), role == "client",
+                                artifact, args.seed, args.command_timeout)
+                    SCENARIOS[scenario](link)
+                    link.log("passed", scenario=scenario)
+                    result = {"case": name, "status": "passed", "virtual_ms": link.now}
+                except Exception as error:
+                    if link:
+                        link.log("failed", error=str(error))
+                    result = {"case": name, "status": "failed", "error": str(error)}
+                finally:
+                    if link:
+                        link.close()
+                result.update(peer_revision=PINS[peer_name], seed=args.seed,
+                              seconds=round(time.monotonic()-started, 3), trace=str(artifact))
+                results.append(result)
+                print(json.dumps(result, sort_keys=True), flush=True)
+                (args.output / "summary.json").write_text(json.dumps(results, indent=2) + "\n")
+    if any(result["status"] != "passed" for result in results):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtc-sctp/interop/test_build_usrsctp.py
+++ b/rtc-sctp/interop/test_build_usrsctp.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Offline Git fixtures for the pinned usrsctp source checkout helper."""
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+spec = importlib.util.spec_from_file_location(
+    "build_usrsctp", Path(__file__).with_name("build_usrsctp.py"))
+builder = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(builder)
+
+
+def git(*args):
+    return subprocess.run(
+        ["git", *map(str, args)], check=True,
+        capture_output=True, text=True).stdout.strip()
+
+
+class SourceCheckoutTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="usrsctp-checkout-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.upstream = self.root / "upstream"
+        git("init", self.upstream)
+        git("-C", self.upstream, "config", "user.name", "Checkout Test")
+        git("-C", self.upstream, "config", "user.email", "test@example.invalid")
+        git("-C", self.upstream, "config", "commit.gpgsign", "false")
+        (self.upstream / "tracked").write_text("pinned content\n")
+        git("-C", self.upstream, "add", "tracked")
+        git("-C", self.upstream, "commit", "-m", "pinned revision")
+        self.pinned = git("-C", self.upstream, "rev-parse", "HEAD")
+        (self.upstream / "tracked").write_text("later content\n")
+        git("-C", self.upstream, "commit", "-am", "later revision")
+        for name, value in (("REPOSITORY", str(self.upstream)),
+                            ("REVISION", self.pinned)):
+            replacement = patch.object(builder, name, value)
+            replacement.start()
+            self.addCleanup(replacement.stop)
+
+    def assert_pinned_clean(self, source):
+        self.assertEqual(git("-C", source, "rev-parse", "HEAD"), self.pinned)
+        self.assertEqual(git("-C", source, "status", "--porcelain"), "")
+        self.assertEqual((source / "tracked").read_text(), "pinned content\n")
+
+    def test_fresh_clone_checks_out_pinned_revision(self):
+        source = self.root / "fresh"
+        builder.checkout_source(source, offline=False)
+        self.assert_pinned_clean(source)
+
+    def test_existing_clean_checkout_can_select_pin_offline(self):
+        source = self.root / "existing"
+        git("clone", self.upstream, source)
+        builder.checkout_source(source, offline=True)
+        self.assert_pinned_clean(source)
+
+    def test_existing_modified_checkout_is_preserved(self):
+        for kind in ("tracked", "staged", "untracked"):
+            with self.subTest(kind=kind):
+                source = self.root / kind
+                git("clone", self.upstream, source)
+                path = source / ("untracked" if kind == "untracked" else "tracked")
+                path.write_text("user changes\n")
+                if kind == "staged":
+                    git("-C", source, "add", "tracked")
+                before = git("-C", source, "rev-parse", "HEAD")
+                status = git("-C", source, "status", "--porcelain")
+                with self.assertRaisesRegex(RuntimeError, "modified source checkout"):
+                    builder.checkout_source(source, offline=True)
+                self.assertEqual(git("-C", source, "rev-parse", "HEAD"), before)
+                self.assertEqual(git("-C", source, "status", "--porcelain"), status)
+                self.assertEqual(path.read_text(), "user changes\n")
+
+    def test_offline_missing_checkout_is_rejected(self):
+        source = self.root / "missing"
+        with self.assertRaisesRegex(RuntimeError, "requires an existing checkout"):
+            builder.checkout_source(source, offline=True)
+        self.assertFalse(source.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtc-sctp/interop/usrsctp_peer.c
+++ b/rtc-sctp/interop/usrsctp_peer.c
@@ -1,0 +1,483 @@
+/* Test-only AF_CONN peer for the pinned usrsctp build. No IP socket is opened. */
+#include <arpa/inet.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+
+#include "usrsctp.h"
+
+#define PORT 5000
+#define STREAMS 1024
+#define MAX_PACKET_HEX (32U * 1024U * 1024U)
+
+static struct socket *endpoint;
+static struct socket *listener;
+static bool initialized;
+static bool passive;
+static int address_token;
+/* Nonzero epoch avoids the stack's zero-time sentinel. TICK is the only clock. */
+static uint64_t now_ms = UINT64_C(1700000000000);
+
+/* Injected into library translation units by build_usrsctp.py. */
+int rtc_usrsctp_gettimeofday(struct timeval *tv, void *timezone_unused) {
+    (void)timezone_unused;
+    tv->tv_sec = (time_t)(now_ms / 1000);
+    tv->tv_usec = (suseconds_t)((now_ms % 1000) * 1000);
+    return 0;
+}
+
+struct partial_message {
+    uint16_t sid;
+    uint16_t ssn;
+    uint32_t ppid;
+    uint8_t *bytes;
+    size_t length;
+    struct partial_message *next;
+};
+static struct partial_message *partials;
+
+static void hex_print(const void *buffer, size_t length) {
+    const uint8_t *bytes = buffer;
+    if (!length) {
+        putchar('-');
+    }
+    for (size_t i = 0; i < length; ++i) {
+        printf("%02x", bytes[i]);
+    }
+}
+
+static int output_packet(void *addr, void *buffer, size_t length,
+                         uint8_t tos, uint8_t set_df) {
+    (void)addr;
+    (void)tos;
+    (void)set_df;
+    fputs("PACKET ", stdout);
+    hex_print(buffer, length);
+    putchar('\n');
+    return 0;
+}
+
+static void discard_partial(uint16_t sid) {
+    struct partial_message **slot = &partials;
+    while (*slot) {
+        struct partial_message *p = *slot;
+        if (p->sid == sid) {
+            *slot = p->next;
+            free(p->bytes);
+            free(p);
+        } else {
+            slot = &p->next;
+        }
+    }
+}
+
+static void notification(const union sctp_notification *note, size_t length) {
+    if (length < sizeof(note->sn_header) || note->sn_header.sn_length != length) {
+        puts("EVENT error:invalid_notification");
+        return;
+    }
+    switch (note->sn_header.sn_type) {
+    case SCTP_ASSOC_CHANGE:
+        if (note->sn_assoc_change.sac_state == SCTP_COMM_UP) {
+            puts("EVENT ready");
+        } else if (note->sn_assoc_change.sac_state == SCTP_SHUTDOWN_COMP) {
+            puts("EVENT closed");
+        } else if (note->sn_assoc_change.sac_state == SCTP_COMM_LOST ||
+                   note->sn_assoc_change.sac_state == SCTP_CANT_STR_ASSOC) {
+            printf("EVENT error:association:%u\n", note->sn_assoc_change.sac_error);
+            puts("EVENT closed");
+        }
+        break;
+    case SCTP_STREAM_RESET_EVENT: {
+        const struct sctp_stream_reset_event *e = &note->sn_strreset_event;
+        if (length < sizeof(*e)) {
+            puts("EVENT error:invalid_reset_notification");
+            break;
+        }
+        if (e->strreset_flags & (SCTP_STREAM_RESET_DENIED | SCTP_STREAM_RESET_FAILED)) {
+            printf("EVENT error:reset:%u\n", e->strreset_flags);
+            break;
+        }
+        size_t count = (length - sizeof(*e)) / sizeof(uint16_t);
+        for (size_t i = 0; i < count; ++i) {
+            uint16_t sid = e->strreset_stream_list[i];
+            if (e->strreset_flags & SCTP_STREAM_RESET_INCOMING_SSN) {
+                discard_partial(sid);
+                printf("EVENT reset_in:%u\n", sid);
+            }
+            if (e->strreset_flags & SCTP_STREAM_RESET_OUTGOING_SSN) {
+                printf("EVENT reset_out:%u\n", sid);
+            }
+        }
+        break;
+    }
+    case SCTP_PARTIAL_DELIVERY_EVENT:
+        if (note->sn_pdapi_event.pdapi_indication == SCTP_PARTIAL_DELIVERY_ABORTED) {
+            discard_partial((uint16_t)note->sn_pdapi_event.pdapi_stream);
+        }
+        break;
+    case SCTP_SEND_FAILED_EVENT:
+        printf("EVENT send_failed:%u:%u\n", note->sn_send_failed_event.ssfe_info.snd_sid,
+               note->sn_send_failed_event.ssfe_error);
+        break;
+    default:
+        break;
+    }
+}
+
+static int receive_data(struct socket *sock, union sctp_sockstore addr, void *data,
+                        size_t length, struct sctp_rcvinfo info, int flags,
+                        void *ulp_info) {
+    (void)sock;
+    (void)addr;
+    (void)ulp_info;
+    if (!data) {
+        puts("EVENT closed");
+        return 1;
+    }
+    if (flags & MSG_NOTIFICATION) {
+        notification(data, length);
+    } else {
+        /* Default fragment-interleave=0 keeps a partial delivery contiguous.
+         * Still retain the message identity so no partial callback is exposed as
+         * a complete application message. */
+        struct partial_message **slot = &partials;
+        while (*slot && ((*slot)->sid != info.rcv_sid || (*slot)->ssn != info.rcv_ssn)) {
+            slot = &(*slot)->next;
+        }
+        if (!*slot) {
+            *slot = calloc(1, sizeof(**slot));
+            if (!*slot) {
+                fputs("out of memory\n", stderr);
+                exit(2);
+            }
+            (*slot)->sid = info.rcv_sid;
+            (*slot)->ssn = info.rcv_ssn;
+            (*slot)->ppid = ntohl(info.rcv_ppid);
+        }
+        struct partial_message *p = *slot;
+        uint8_t *bytes = realloc(p->bytes, p->length + length);
+        if (!bytes && length) {
+            fputs("out of memory\n", stderr);
+            exit(2);
+        }
+        p->bytes = bytes;
+        if (length) {
+            memcpy(bytes + p->length, data, length);
+        }
+        p->length += length;
+        if (flags & MSG_EOR) {
+            printf("MESSAGE %u %" PRIu32 " ", p->sid, p->ppid);
+            hex_print(p->bytes, p->length);
+            putchar('\n');
+            *slot = p->next;
+            free(p->bytes);
+            free(p);
+        }
+    }
+    free(data);
+    return 1;
+}
+
+static int set_option(struct socket *sock, int level, int name,
+                      const void *value, socklen_t length) {
+    if (usrsctp_setsockopt(sock, level, name, value, length) < 0) {
+        printf("ERROR setsockopt:%d:%s\n", name, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static struct sockaddr_conn conn_address(void) {
+    struct sockaddr_conn addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sconn_family = AF_CONN;
+#ifdef __APPLE__
+    addr.sconn_len = sizeof(addr);
+#endif
+    addr.sconn_port = htons(PORT);
+    addr.sconn_addr = &address_token;
+    return addr;
+}
+
+static int init_peer(const char *role) {
+    if (initialized || !role || (strcmp(role, "client") && strcmp(role, "server"))) {
+        puts("ERROR expected_one_INIT_client_or_server");
+        return -1;
+    }
+    passive = !strcmp(role, "server");
+    usrsctp_init_nothreads(0, output_packet, NULL);
+    initialized = true;
+    usrsctp_sysctl_set_sctp_ecn_enable(0);
+    usrsctp_sysctl_set_sctp_pr_enable(1);
+    usrsctp_sysctl_set_sctp_reconfig_enable(1);
+    usrsctp_register_address(&address_token);
+    endpoint = usrsctp_socket(AF_CONN, SOCK_STREAM, IPPROTO_SCTP,
+                              receive_data, NULL, 0, &address_token);
+    if (!endpoint) {
+        printf("ERROR socket:%s\n", strerror(errno));
+        return -1;
+    }
+    usrsctp_set_non_blocking(endpoint, 1);
+    const int on = 1;
+    const int buffer_size = 4 * 1024 * 1024;
+    struct sctp_initmsg init = {STREAMS, STREAMS, 8, 0};
+    struct sctp_assoc_value reset = {SCTP_ALL_ASSOC, SCTP_ENABLE_RESET_STREAM_REQ};
+    struct sctp_paddrparams path;
+    memset(&path, 0, sizeof(path));
+    path.spp_address.ss_family = AF_CONN;
+#ifdef __APPLE__
+    path.spp_address.ss_len = sizeof(struct sockaddr_conn);
+#endif
+    path.spp_flags = SPP_PMTUD_DISABLE | SPP_HB_DISABLE;
+    path.spp_pathmtu = 1200;
+    if (set_option(endpoint, IPPROTO_SCTP, SCTP_NODELAY, &on, sizeof(on)) ||
+        set_option(endpoint, SOL_SOCKET, SO_SNDBUF, &buffer_size, sizeof(buffer_size)) ||
+        set_option(endpoint, SOL_SOCKET, SO_RCVBUF, &buffer_size, sizeof(buffer_size)) ||
+        set_option(endpoint, IPPROTO_SCTP, SCTP_INITMSG, &init, sizeof(init)) ||
+        set_option(endpoint, IPPROTO_SCTP, SCTP_ENABLE_STREAM_RESET, &reset, sizeof(reset)) ||
+        set_option(endpoint, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, &path, sizeof(path))) {
+        return -1;
+    }
+    uint16_t types[] = {SCTP_ASSOC_CHANGE, SCTP_STREAM_RESET_EVENT,
+                        SCTP_PARTIAL_DELIVERY_EVENT, SCTP_SEND_FAILED_EVENT};
+    for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); ++i) {
+        struct sctp_event event = {SCTP_ALL_ASSOC, types[i], 1};
+        if (set_option(endpoint, IPPROTO_SCTP, SCTP_EVENT, &event, sizeof(event))) {
+            return -1;
+        }
+    }
+    struct sockaddr_conn addr = conn_address();
+    if (usrsctp_bind(endpoint, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        printf("ERROR bind:%s\n", strerror(errno));
+        return -1;
+    }
+    if (passive) {
+        if (usrsctp_listen(endpoint, 1) < 0) {
+            printf("ERROR listen:%s\n", strerror(errno));
+            return -1;
+        }
+        listener = endpoint;
+        endpoint = NULL;
+    }
+    return 0;
+}
+
+static void accept_peer(void) {
+    if (listener && !endpoint) {
+        endpoint = usrsctp_accept(listener, NULL, NULL);
+        if (endpoint) {
+            usrsctp_set_non_blocking(endpoint, 1);
+            usrsctp_close(listener);
+            listener = NULL;
+        } else if (errno != EWOULDBLOCK && errno != EAGAIN) {
+            printf("ERROR accept:%s\n", strerror(errno));
+        }
+    }
+}
+
+static bool number(const char *text, uint32_t maximum, uint32_t *out) {
+    if (!text || !*text || *text == '-') {
+        return false;
+    }
+    char *end;
+    errno = 0;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno || *end || value > maximum) {
+        return false;
+    }
+    *out = (uint32_t)value;
+    return true;
+}
+
+static int nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+static uint8_t *unhex(const char *text, size_t *length) {
+    if (!text) return NULL;
+    size_t count = strcmp(text, "-") ? strlen(text) : 0;
+    if (count > MAX_PACKET_HEX || count % 2) return NULL;
+    uint8_t *bytes = malloc(count / 2 + 1);
+    if (!bytes) return NULL;
+    for (size_t i = 0; i < count; i += 2) {
+        int a = nibble(text[i]), b = nibble(text[i + 1]);
+        if (a < 0 || b < 0) {
+            free(bytes);
+            return NULL;
+        }
+        bytes[i / 2] = (uint8_t)((a << 4) | b);
+    }
+    *length = count / 2;
+    return bytes;
+}
+
+static void send_message(char **args, size_t count) {
+    uint32_t sid, ppid;
+    if (count != 5 || !number(args[0], UINT16_MAX, &sid) ||
+        !number(args[3], UINT32_MAX, &ppid) ||
+        (strcmp(args[1], "ordered") && strcmp(args[1], "unordered"))) {
+        puts("ERROR expected_SEND_sid_order_policy_ppid_hex");
+        return;
+    }
+    struct sctp_sendv_spa spa;
+    memset(&spa, 0, sizeof(spa));
+    spa.sendv_flags = SCTP_SEND_SNDINFO_VALID | SCTP_SEND_PRINFO_VALID;
+    spa.sendv_sndinfo.snd_sid = (uint16_t)sid;
+    spa.sendv_sndinfo.snd_ppid = htonl(ppid);
+    if (!strcmp(args[1], "unordered")) spa.sendv_sndinfo.snd_flags = SCTP_UNORDERED;
+    if (!strcmp(args[2], "reliable")) {
+        spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_NONE;
+    } else {
+        uint32_t value;
+        const char *colon = strchr(args[2], ':');
+        if (!colon || !number(colon + 1, UINT32_MAX, &value)) {
+            puts("ERROR invalid_reliability_policy");
+            return;
+        }
+        if (!strncmp(args[2], "timed:", 6)) {
+            spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_TTL;
+        } else if (!strncmp(args[2], "rexmit:", 7)) {
+            spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_RTX;
+        } else {
+            puts("ERROR invalid_reliability_policy");
+            return;
+        }
+        spa.sendv_prinfo.pr_value = value;
+    }
+    size_t length;
+    uint8_t *data = unhex(args[4], &length);
+    if (!data) {
+        puts("ERROR invalid_hex");
+        return;
+    }
+    ssize_t sent = usrsctp_sendv(endpoint, data, length, NULL, 0, &spa,
+                                sizeof(spa), SCTP_SENDV_SPA, 0);
+    if (sent < 0) printf("ERROR send:%s\n", strerror(errno));
+    else if ((size_t)sent != length) puts("ERROR partial_send");
+    free(data);
+}
+
+static void reset_streams(char *text) {
+    size_t count = 1;
+    for (const char *p = text; *p; ++p) if (*p == ',') ++count;
+    if (count > STREAMS) {
+        puts("ERROR too_many_streams");
+        return;
+    }
+    size_t length = sizeof(struct sctp_reset_streams) + count * sizeof(uint16_t);
+    struct sctp_reset_streams *reset = calloc(1, length);
+    if (!reset) exit(2);
+    reset->srs_flags = SCTP_STREAM_RESET_OUTGOING;
+    reset->srs_number_streams = (uint16_t)count;
+    char *state;
+    char *sid_text = strtok_r(text, ",", &state);
+    size_t i = 0;
+    while (sid_text) {
+        uint32_t sid;
+        if (!number(sid_text, UINT16_MAX, &sid)) break;
+        reset->srs_stream_list[i++] = (uint16_t)sid;
+        sid_text = strtok_r(NULL, ",", &state);
+    }
+    if (i != count) puts("ERROR invalid_reset_streams");
+    else set_option(endpoint, IPPROTO_SCTP, SCTP_RESET_STREAMS, reset, (socklen_t)length);
+    free(reset);
+}
+
+static void cleanup(void) {
+    if (endpoint) usrsctp_close(endpoint);
+    if (listener) usrsctp_close(listener);
+    endpoint = NULL;
+    listener = NULL;
+    if (initialized) {
+        usrsctp_deregister_address(&address_token);
+        /* No peer is expected to answer after QUIT. Drain the bounded closing
+         * timers, then release the process even if graceful shutdown is pending. */
+        for (int i = 0; i < 20 && usrsctp_finish() != 0; ++i) {
+            now_ms += 1000;
+            usrsctp_handle_timers(1000);
+        }
+        initialized = false;
+    }
+    while (partials) discard_partial(partials->sid);
+}
+
+int main(void) {
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    char *line = NULL;
+    size_t capacity = 0;
+    bool quit = false;
+    while (!quit && getline(&line, &capacity, stdin) >= 0) {
+        char *tokens[8];
+        size_t count = 0;
+        char *state;
+        char *token = strtok_r(line, " \t\r\n", &state);
+        while (token && count < sizeof(tokens) / sizeof(tokens[0])) {
+            tokens[count++] = token;
+            token = strtok_r(NULL, " \t\r\n", &state);
+        }
+        if (!count) {
+            puts("ERROR empty_command");
+        } else if (!strcmp(tokens[0], "QUIT") && count == 1) {
+            cleanup();
+            quit = true;
+        } else if (!strcmp(tokens[0], "INIT") && count == 2) {
+            init_peer(tokens[1]);
+        } else if (!initialized) {
+            puts("ERROR INIT_required");
+        } else if (!strcmp(tokens[0], "CONNECT") && count == 1) {
+            if (passive) {
+                puts("ERROR server_is_passive");
+            } else {
+                struct sockaddr_conn addr = conn_address();
+                if (usrsctp_connect(endpoint, (struct sockaddr *)&addr, sizeof(addr)) < 0 &&
+                    errno != EINPROGRESS) printf("ERROR connect:%s\n", strerror(errno));
+            }
+        } else if (!strcmp(tokens[0], "INPUT") && count == 2) {
+            size_t length;
+            uint8_t *packet = unhex(tokens[1], &length);
+            if (!packet || length < 12) puts("ERROR invalid_packet_hex");
+            else usrsctp_conninput(&address_token, packet, length, 0);
+            free(packet);
+            accept_peer();
+        } else if (!strcmp(tokens[0], "TICK") && count == 2) {
+            uint32_t elapsed;
+            if (!number(tokens[1], 3600000, &elapsed)) puts("ERROR invalid_elapsed_ms");
+            else {
+                /* Stepping callouts together with wall-clock time preserves the
+                 * interval scheduled by a callback during a larger TICK. */
+                while (elapsed) {
+                    uint32_t step = elapsed > 10 ? 10 : elapsed;
+                    now_ms += step;
+                    usrsctp_handle_timers(step);
+                    elapsed -= step;
+                }
+                accept_peer();
+            }
+        } else if (!strcmp(tokens[0], "POLL") && count == 1) {
+            accept_peer();
+        } else if (!endpoint) {
+            puts("ERROR association_not_ready");
+        } else if (!strcmp(tokens[0], "SEND")) {
+            send_message(tokens + 1, count - 1);
+        } else if (!strcmp(tokens[0], "RESET") && count == 2) {
+            reset_streams(tokens[1]);
+        } else {
+            puts("ERROR unknown_command");
+        }
+        puts("DONE");
+    }
+    free(line);
+    cleanup();
+    return 0;
+}

--- a/rtc-sctp/src/association/ack_optimization_test.rs
+++ b/rtc-sctp/src/association/ack_optimization_test.rs
@@ -1,0 +1,472 @@
+use super::*;
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn release_events(a: &mut Association, sid: u16) -> (usize, usize) {
+    let (mut released, mut low) = (0, 0);
+    while let Some(event) = a.poll() {
+        match event {
+            Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) if id == sid => {
+                released += n_bytes;
+            }
+            Event::Stream(StreamEvent::BufferedAmountLow { id }) if id == sid => low += 1,
+            _ => {}
+        }
+    }
+    (released, low)
+}
+
+fn t3_errors(a: &mut Association, before_expiry: Instant) -> usize {
+    let (expired, failed, errors) = a.timers.is_expired(Timer::T3RTX, before_expiry);
+    assert!(
+        !expired && !failed,
+        "reading the counter must not expire T3"
+    );
+    errors
+}
+
+#[test]
+fn duplicate_gap_ack_preserves_t3_and_does_not_repeat_credit() -> Result<()> {
+    let mut a = timed_test_association();
+    a.rto_mgr.set_rto(1000, false);
+    let now = Instant::now();
+    let first = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"lost"), ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"received"), ppi)?;
+    assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 2);
+    let sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: first.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now + Duration::from_millis(50))?;
+    assert_eq!(release_events(&mut a, 1), (8, 0));
+
+    let timeout = a.poll_timeout().unwrap();
+    a.handle_timeout(timeout);
+    let retried = transmitted_data(&a.gather_outbound(timeout).0);
+    assert_eq!(retried.len(), 1);
+    assert_eq!(retried[0].tsn, first);
+    assert_eq!(retried[0].user_data, Bytes::from_static(b"lost"));
+    assert_eq!(t3_errors(&mut a, timeout), 1);
+    let deadline = a.poll_timeout();
+    let rto = a.rto_mgr.get_rto();
+    let cwnd = a.cwnd;
+    let srtt = a.rto_mgr.srtt;
+
+    // RFC 9260 6.3.2 R3 and 8.1-8.2: repeated evidence for the second TSN
+    // is neither acknowledgment of the earliest outstanding DATA nor progress.
+    for delay in [10, 20, 30] {
+        let at = timeout + Duration::from_millis(delay);
+        a.handle_sack(&sack, at)?;
+        assert_eq!(t3_errors(&mut a, at), 1);
+        assert_eq!(a.poll_timeout(), deadline);
+        assert_eq!(a.rto_mgr.get_rto(), rto);
+        assert_eq!(a.rto_mgr.srtt, srtt);
+        assert_eq!(a.cwnd, cwnd);
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 4);
+        assert_eq!(a.stream(1)?.buffered_amount()?, 4);
+        assert_eq!(release_events(&mut a, 1), (0, 0));
+        assert!(transmitted_data(&a.gather_outbound(at).0).is_empty());
+    }
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: first.wrapping_add(1),
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        timeout + Duration::from_millis(40),
+    )?;
+    assert_eq!(release_events(&mut a, 1), (4, 1));
+    assert!(a.inflight_queue.is_empty());
+    assert!(a.poll_timeout().is_none());
+    Ok(())
+}
+
+#[test]
+fn reack_after_gap_revocation_resets_t3_without_second_delivery_credit() -> Result<()> {
+    let mut a = timed_test_association();
+    a.rto_mgr.set_rto(1000, false);
+    let now = Instant::now();
+    let first = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let payload = Bytes::from(vec![42; 64]);
+    let mut stream = a.open_stream(1, ppi)?;
+    for _ in 0..3 {
+        stream.write_sctp(now, &payload, ppi)?;
+    }
+    assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 3);
+    let mut sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: first.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now + Duration::from_millis(50))?;
+    assert_eq!(release_events(&mut a, 1), (64, 0));
+    sack.gap_ack_blocks.clear();
+    a.handle_sack(&sack, now + Duration::from_millis(60))?;
+    assert_eq!(a.inflight_queue.outstanding_bytes(), 192);
+
+    // RFC 9260 6.2.1 D(iii): advisory ACK revocation restores recovery, while
+    // the original application credit remains released.
+    let timeout = a.poll_timeout().unwrap();
+    a.handle_timeout(timeout);
+    let retried = transmitted_data(&a.gather_outbound(timeout).0);
+    assert_eq!(retried.len(), 3);
+    assert!(retried.iter().all(|c| c.user_data == payload));
+    assert_eq!(t3_errors(&mut a, timeout), 1);
+    let deadline = a.poll_timeout();
+    let rto = a.rto_mgr.get_rto();
+    sack.gap_ack_blocks.push(GapAckBlock { start: 2, end: 2 });
+    let reack = timeout + Duration::from_millis(10);
+    a.handle_sack(&sack, reack)?;
+    assert_eq!(t3_errors(&mut a, reack), 0);
+    assert_eq!(
+        a.poll_timeout(),
+        deadline,
+        "the earliest TSN is still missing"
+    );
+    assert_eq!(a.rto_mgr.get_rto(), rto, "Karn excludes retransmitted DATA");
+    assert_eq!(release_events(&mut a, 1), (0, 0));
+    assert_eq!(a.inflight_queue.outstanding_bytes(), 128);
+    assert_eq!(a.stream(1)?.buffered_amount()?, 128);
+
+    sack.gap_ack_blocks.clear();
+    a.handle_sack(&sack, reack + Duration::from_millis(1))?;
+    // Keep application DATA pending so congestion-window growth is observable.
+    // The next SACK newly delivers only TSN 1; TSN 2's credit was already spent.
+    a.stream(1)?.write_sctp(reack, &payload, ppi)?;
+    let cwnd = a.cwnd;
+    assert!(cwnd <= a.ssthresh);
+    sack.cumulative_tsn_ack = first;
+    sack.gap_ack_blocks.push(GapAckBlock { start: 1, end: 1 });
+    let progressed = reack + Duration::from_millis(2);
+    a.handle_sack(&sack, progressed)?;
+    assert_eq!(a.cwnd, cwnd + 64, "reneged DATA must not grow cwnd twice");
+    assert_eq!(release_events(&mut a, 1), (64, 0));
+    assert_eq!(a.stream(1)?.buffered_amount()?, 128);
+    assert_eq!(
+        a.poll_timeout(),
+        Some(progressed + Duration::from_millis(rto)),
+        "acknowledgment of the earliest outstanding TSN restarts T3"
+    );
+    a.handle_sack(&sack, progressed + Duration::from_millis(1))?;
+    assert_eq!(a.cwnd, cwnd + 64);
+    assert_eq!(release_events(&mut a, 1), (0, 0));
+
+    sack.cumulative_tsn_ack = first.wrapping_add(2);
+    sack.gap_ack_blocks.clear();
+    a.handle_sack(&sack, progressed + Duration::from_millis(2))?;
+    assert_eq!(release_events(&mut a, 1), (64, 0));
+    let final_data = transmitted_data(&a.gather_outbound(progressed + Duration::from_millis(2)).0);
+    assert_eq!(final_data.len(), 1);
+    assert_eq!(final_data[0].user_data, payload);
+    sack.cumulative_tsn_ack = final_data[0].tsn;
+    a.handle_sack(&sack, progressed + Duration::from_millis(3))?;
+    assert_eq!(release_events(&mut a, 1), (64, 1));
+    assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+    assert!(a.inflight_queue.is_empty());
+    assert!(a.poll_timeout().is_none());
+    Ok(())
+}
+
+struct TrackedPayload {
+    data: Vec<u8>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for TrackedPayload {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl Drop for TrackedPayload {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn final_abandonment_drops_payload_owner_before_cumulative_ack() -> Result<()> {
+    for unordered in [false, true] {
+        for size in [64, 4000] {
+            let mut a = timed_test_association();
+            let now = Instant::now();
+            let first = a.my_next_tsn;
+            let ppi = PayloadProtocolIdentifier::Binary;
+            a.cwnd = 2 * a.max_payload_size + 1;
+            a.open_stream(2, ppi)?
+                .write_sctp(now, &Bytes::from_static(b"x"), ppi)?;
+            a.gather_outbound(now); // Keep a reliable hole before the timed DATA.
+            let dropped = Arc::new(AtomicUsize::new(0));
+            {
+                let payload = Bytes::from_owner(TrackedPayload {
+                    data: vec![42; size],
+                    dropped: Arc::clone(&dropped),
+                });
+                let mut stream = a.open_stream(1, ppi)?;
+                stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+                stream.write_chunk_with_ppi(now, &payload, ppi)?;
+            }
+            // Decoded wire DATA owns a serialized copy, never the tracked owner.
+            let sent = transmitted_data(&a.gather_outbound(now).0);
+            assert_eq!(sent.len(), if size == 64 { 1 } else { 2 });
+            assert_eq!(dropped.load(Ordering::SeqCst), 0);
+            let mut sack = ChunkSelectiveAck {
+                cumulative_tsn_ack: first.wrapping_sub(1),
+                advertised_receiver_window_credit: 65536,
+                ..Default::default()
+            };
+            let mut released = 0;
+            if size == 4000 {
+                assert!(!a.pending_queue.is_empty());
+                sack.gap_ack_blocks.push(GapAckBlock { start: 2, end: 2 });
+                a.handle_sack(&sack, now + Duration::from_millis(50))?;
+                let events = release_events(&mut a, 1);
+                released += events.0;
+                assert_eq!(events, (sent[0].user_data.len(), 0));
+                assert_eq!(dropped.load(Ordering::SeqCst), 0);
+            }
+
+            let timeout = a.poll_timeout().unwrap();
+            a.handle_timeout(timeout);
+            let retried = transmitted_data(&a.gather_outbound(timeout).0);
+            assert_eq!(retried.len(), 1);
+            assert_eq!(retried[0].stream_identifier, 2);
+            assert_eq!(
+                dropped.load(Ordering::SeqCst),
+                1,
+                "final abandonment must drop backing, including gap-ACKed and pending slices"
+            );
+            assert!(a.pending_queue.is_empty());
+            assert!(a.inflight_queue.len() > 1, "TSNs still await peer progress");
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+            assert_eq!(release_events(&mut a, 1), (size - released, 1));
+            assert_eq!(t3_errors(&mut a, timeout), 1);
+
+            // The newly acknowledged fragment was actually sent before expiry.
+            // It clears T3's error count even though its payload is already gone.
+            sack.gap_ack_blocks = vec![GapAckBlock {
+                start: 2,
+                end: sent.len() as u16 + 1,
+            }];
+            let late = timeout + Duration::from_millis(10);
+            a.handle_sack(&sack, late)?;
+            assert_eq!(t3_errors(&mut a, late), 0);
+            assert_eq!(release_events(&mut a, 1), (0, 0));
+            sack.gap_ack_blocks.clear();
+            a.handle_sack(&sack, late + Duration::from_millis(1))?;
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert_eq!(release_events(&mut a, 1), (0, 0));
+
+            sack.cumulative_tsn_ack = first;
+            a.handle_sack(&sack, late + Duration::from_millis(2))?;
+            let forwarded = a.create_forward_tsn().new_cumulative_tsn;
+            assert_eq!(forwarded, a.my_next_tsn.wrapping_sub(1));
+            assert!(
+                transmitted_data(&a.gather_outbound(late + Duration::from_millis(2)).0).is_empty()
+            );
+            assert!(!a.inflight_queue.is_empty());
+            sack.cumulative_tsn_ack = forwarded;
+            a.handle_sack(&sack, late + Duration::from_millis(3))?;
+            assert_eq!(release_events(&mut a, 1), (0, 0));
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert!(a.inflight_queue.is_empty());
+            assert!(a.poll_timeout().is_none());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn gap_range_overlap_matches_small_set_reference_across_cumulative_advance_and_wrap() -> Result<()>
+{
+    const COUNT: usize = 5;
+
+    fn blocks(mask: u8, advanced: usize, split: bool) -> Vec<GapAckBlock> {
+        let mut gaps: Vec<GapAckBlock> = Vec::new();
+        for index in 0..COUNT {
+            if mask & (1 << index) == 0 {
+                continue;
+            }
+            let offset = (index - advanced + 1) as u16;
+            if !split
+                && let Some(last) = gaps.last_mut()
+                && last.end + 1 == offset
+            {
+                last.end = offset;
+            } else {
+                gaps.push(GapAckBlock {
+                    start: offset,
+                    end: offset,
+                });
+            }
+        }
+        gaps
+    }
+
+    let all = (1u8 << COUNT) - 1;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    for first in [12345, u32::MAX - 2] {
+        for old in 0..=all {
+            if old & 1 != 0 {
+                continue; // Leave the first TSN missing before the initial gaps.
+            }
+            for advanced in 0..=COUNT {
+                // A valid peer still has a hole immediately after its cumulative
+                // ACK. Subsequent TSNs may appear in any combination of gaps.
+                let allowed = all & !((1u8 << (advanced + 1)) - 1);
+                for new in 0..=all {
+                    if new & !allowed != 0 {
+                        continue;
+                    }
+                    for (old_split, new_split) in
+                        [(false, false), (false, true), (true, false), (true, true)]
+                    {
+                        let mut a = timed_test_association();
+                        let now = Instant::now();
+                        a.my_next_tsn = first;
+                        a.cumulative_tsn_ack_point = first.wrapping_sub(1);
+                        a.advanced_peer_tsn_ack_point = first.wrapping_sub(1);
+                        let mut stream = a.open_stream(1, ppi)?;
+                        for index in 0..COUNT {
+                            stream.write_sctp(
+                                now,
+                                &Bytes::from(vec![index as u8; index + 1]),
+                                ppi,
+                            )?;
+                        }
+                        assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), COUNT);
+
+                        // The model tracks individual relative TSNs, independently
+                        // of the production range cursor and serial comparisons.
+                        // Return to the old set after the second SACK so removed
+                        // gaps must be re-ACKed using the replaced range cache.
+                        let mut credited = 0u8;
+                        let mut total_released = 0;
+                        for (phase, (prefix, mask, split)) in [
+                            (0, old, old_split),
+                            (advanced, new, new_split),
+                            (advanced, old & allowed, !old_split),
+                            (COUNT, 0, false),
+                        ]
+                        .into_iter()
+                        .enumerate()
+                        {
+                            let context = format!(
+                                "first={first} old={old:05b} new={new:05b} advanced={advanced} \
+                                 old_split={old_split} new_split={new_split} phase={phase}"
+                            );
+                            let before = credited;
+                            credited |= mask | ((1u8 << prefix) - 1);
+                            let released: usize = (0..COUNT)
+                                .filter(|&index| (credited & !before) & (1 << index) != 0)
+                                .map(|index| index + 1)
+                                .sum();
+                            let buffered: usize = (0..COUNT)
+                                .filter(|&index| credited & (1 << index) == 0)
+                                .map(|index| index + 1)
+                                .sum();
+                            let outstanding: usize = (prefix..COUNT)
+                                .filter(|&index| mask & (1 << index) == 0)
+                                .map(|index| index + 1)
+                                .sum();
+                            a.handle_sack(
+                                &ChunkSelectiveAck {
+                                    cumulative_tsn_ack: first
+                                        .wrapping_add(prefix as u32)
+                                        .wrapping_sub(1),
+                                    advertised_receiver_window_credit: 65536,
+                                    gap_ack_blocks: blocks(mask, prefix, split),
+                                    ..Default::default()
+                                },
+                                now + Duration::from_millis(10 * (phase as u64 + 1)),
+                            )?;
+                            assert_eq!(
+                                release_events(&mut a, 1),
+                                (released, usize::from(before != all && credited == all)),
+                                "{context}"
+                            );
+                            total_released += released;
+                            assert_eq!(a.stream(1)?.buffered_amount()?, buffered, "{context}");
+                            assert_eq!(a.inflight_queue.buffered_bytes(), buffered, "{context}");
+                            assert_eq!(
+                                a.inflight_queue.outstanding_bytes(),
+                                outstanding,
+                                "{context}"
+                            );
+                            assert_eq!(a.poll_timeout().is_none(), prefix == COUNT, "{context}");
+                            for index in 0..COUNT {
+                                let chunk = a.inflight_queue.get(first.wrapping_add(index as u32));
+                                if index < prefix {
+                                    assert!(chunk.is_none(), "{context}: cumulative TSN {index}");
+                                    continue;
+                                }
+                                let chunk = chunk.unwrap();
+                                assert_eq!(
+                                    chunk.acknowledged,
+                                    mask & (1 << index) != 0,
+                                    "{context}: receipt of TSN {index}"
+                                );
+                                assert_eq!(
+                                    (chunk.buffer_released, chunk.delivery_credited),
+                                    (credited & (1 << index) != 0, credited & (1 << index) != 0),
+                                    "{context}: credit of TSN {index}"
+                                );
+                                assert_eq!(chunk.user_data.len(), index + 1, "{context}");
+                            }
+                        }
+                        assert_eq!(total_released, COUNT * (COUNT + 1) / 2);
+                        assert!(a.inflight_queue.is_empty());
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn closed_association_does_not_reuse_gap_ack_cache_after_cookie_echo() -> Result<()> {
+    let mut a = timed_test_association();
+    let cookie = ParamStateCookie::new();
+    let echo = ChunkCookieEcho {
+        cookie: cookie.cookie.clone(),
+    };
+    a.my_cookie = Some(cookie);
+    let now = Instant::now();
+    let first = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    for _ in 0..2 {
+        stream.write_sctp(now, &Bytes::from_static(b"payload"), ppi)?;
+    }
+    assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 2);
+    let sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: first.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now)?;
+    assert!(!a.peer_gap_ack_ranges.is_empty());
+    a.close(AssociationError::TransportError)?;
+    assert_eq!(a.state(), AssociationState::Closed);
+    assert!(a.inflight_queue.is_empty());
+
+    // The existing handshake accepts a matching COOKIE ECHO in Closed. A
+    // cached gap must not bypass validation of DATA removed during close().
+    assert_eq!(a.handle_cookie_echo(&echo)?.len(), 1);
+    assert_eq!(a.state(), AssociationState::Established);
+    assert!(matches!(
+        a.handle_sack(&sack, now + Duration::from_millis(1)),
+        Err(Error::ErrTsnRequestNotExist)
+    ));
+    Ok(())
+}

--- a/rtc-sctp/src/association/ack_range_boundary_test.rs
+++ b/rtc-sctp/src/association/ack_range_boundary_test.rs
@@ -1,0 +1,459 @@
+//! Boundary checks for advisory ACK range traversal, using per-TSN state as the oracle.
+
+use super::*;
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+
+const WINDOW: u32 = 1 << 20;
+
+fn releases(a: &mut Association) -> (usize, usize) {
+    let (mut bytes, mut low) = (0, 0);
+    while let Some(event) = a.poll() {
+        match event {
+            Event::Stream(StreamEvent::BufferedAmountReleased { id: 1, n_bytes }) => {
+                bytes += n_bytes
+            }
+            Event::Stream(StreamEvent::BufferedAmountLow { id: 1 }) => low += 1,
+            _ => {}
+        }
+    }
+    (bytes, low)
+}
+
+fn sack(cumulative_tsn_ack: u32, gaps: &[(u16, u16)]) -> ChunkSelectiveAck {
+    ChunkSelectiveAck {
+        cumulative_tsn_ack,
+        advertised_receiver_window_credit: WINDOW,
+        gap_ack_blocks: gaps
+            .iter()
+            .map(|&(start, end)| GapAckBlock { start, end })
+            .collect(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn maximum_gap_offset_matches_individual_receipts_through_wrap_and_reack() -> Result<()> {
+    const COUNT: usize = u16::MAX as usize;
+    let first = u32::MAX - 32767;
+    let now = Instant::now();
+    let mut a = timed_test_association();
+    a.my_next_tsn = first;
+    a.cumulative_tsn_ack_point = first.wrapping_sub(1);
+    a.advanced_peer_tsn_ack_point = first.wrapping_sub(1);
+    a.cwnd = WINDOW;
+    a.rwnd = WINDOW;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let payload = Bytes::from_static(b"abc");
+    let size = |index: usize| 1 + index % payload.len();
+    {
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(true, ReliabilityType::Rexmit, 0)?;
+        for index in 0..COUNT {
+            stream.write_sctp(now, &payload.slice(..size(index)), ppi)?;
+        }
+    }
+    // A single bounded flight makes offset 65535 a real assigned TSN. Wire
+    // serialization is exercised, but no decoded copies are needed by the model.
+    assert!(!a.gather_outbound(now).0.is_empty());
+    assert!(a.pending_queue.is_empty());
+    assert_eq!(a.inflight_queue.len(), COUNT);
+    assert_eq!(a.my_next_tsn, first.wrapping_add(COUNT as u32));
+    assert_eq!(releases(&mut a), (0, 0));
+
+    // Each range names inclusive indices in the original flight. This oracle
+    // tests membership for individual indices; it has no old/new range cursor,
+    // serial-number ordering, or dependency on the production ACK cache.
+    let phases: &[(usize, &[(usize, usize)])] = &[
+        (0, &[(1, 16383), (32760, 65534)]),
+        // Splitting contiguous evidence is entirely duplicate acknowledgment.
+        (
+            0,
+            &[(1, 8191), (8192, 16383), (32760, 49151), (49152, 65534)],
+        ),
+        (0, &[(8192, 32768), (49152, 65534)]),
+        (16384, &[(16385, 40000), (50000, 65534)]),
+        // This cumulative ACK is u32::MAX; the remaining flight starts at zero.
+        (32768, &[(32769, 45000), (50000, 65534)]),
+        (32768, &[(32769, 38000), (38001, 40000), (45001, 65534)]),
+        (32768, &[(32769, 65534)]),
+        (COUNT, &[]),
+    ];
+    let mut credited = vec![false; COUNT];
+    let mut total_released = 0;
+    let total_size: usize = (0..COUNT).map(size).sum();
+    for (phase, &(prefix, ranges)) in phases.iter().enumerate() {
+        let before_buffered: usize = (0..COUNT).filter(|&index| !credited[index]).map(size).sum();
+        let acknowledged: Vec<bool> = (0..COUNT)
+            .map(|index| {
+                index < prefix || ranges.iter().any(|&(lo, hi)| lo <= index && index <= hi)
+            })
+            .collect();
+        let released: usize = (0..COUNT)
+            .filter(|&index| acknowledged[index] && !credited[index])
+            .map(size)
+            .sum();
+        for index in 0..COUNT {
+            credited[index] |= acknowledged[index];
+        }
+        let buffered: usize = (0..COUNT).filter(|&index| !credited[index]).map(size).sum();
+        let outstanding: usize = (prefix..COUNT)
+            .filter(|&index| !acknowledged[index])
+            .map(size)
+            .sum();
+        let gaps: Vec<_> = ranges
+            .iter()
+            .map(|&(lo, hi)| {
+                assert!(prefix <= lo && lo <= hi && hi < COUNT);
+                (
+                    u16::try_from(lo + 1 - prefix).unwrap(),
+                    u16::try_from(hi + 1 - prefix).unwrap(),
+                )
+            })
+            .collect();
+        if phase <= 2 {
+            assert_eq!(gaps.last().unwrap().1, u16::MAX);
+        }
+        a.handle_sack(
+            &sack(first.wrapping_add(prefix as u32).wrapping_sub(1), &gaps),
+            now + Duration::from_millis(10 * (phase as u64 + 1)),
+        )?;
+        assert_eq!(
+            releases(&mut a),
+            (released, usize::from(before_buffered != 0 && buffered == 0)),
+            "phase {phase}: application release"
+        );
+        total_released += released;
+        assert_eq!(a.stream(1)?.buffered_amount()?, buffered, "phase {phase}");
+        assert_eq!(a.inflight_queue.buffered_bytes(), buffered, "phase {phase}");
+        assert_eq!(
+            a.inflight_queue.outstanding_bytes(),
+            outstanding,
+            "phase {phase}"
+        );
+        assert_eq!(a.rwnd, WINDOW - outstanding as u32, "phase {phase}");
+        assert_eq!(a.inflight_queue.len(), COUNT - prefix, "phase {phase}");
+        assert_eq!(a.poll_timeout().is_none(), prefix == COUNT, "phase {phase}");
+        for index in 0..COUNT {
+            let chunk = a.inflight_queue.get(first.wrapping_add(index as u32));
+            if index < prefix {
+                assert!(chunk.is_none(), "phase {phase}: cumulative index {index}");
+                continue;
+            }
+            let chunk = chunk.unwrap();
+            assert_eq!(
+                chunk.acknowledged, acknowledged[index],
+                "phase {phase}, index {index}"
+            );
+            assert_eq!(
+                (chunk.buffer_released, chunk.delivery_credited),
+                (credited[index], credited[index]),
+                "phase {phase}, index {index}: once-only credit"
+            );
+            assert_eq!(
+                chunk.user_data.len(),
+                if credited[index] { 0 } else { size(index) },
+                "phase {phase}, index {index}: Rexmit(0) payload eviction"
+            );
+            assert!(
+                !chunk.abandoned,
+                "phase {phase}, index {index}: SACK alone is not a retry"
+            );
+            assert_eq!(chunk.nsent, 1, "phase {phase}, index {index}");
+        }
+    }
+    assert_eq!(total_released, total_size);
+    assert!(a.inflight_queue.is_empty());
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+struct SackState {
+    cumulative: u32,
+    advanced: u32,
+    gaps: Vec<(u32, u32)>,
+    // TSN, receipt, application credit, delivery credit, miss count, sends,
+    // abandonment and retransmission status; original bytes are checked below.
+    chunks: Vec<(u32, bool, bool, bool, u32, u32, bool, bool)>,
+    outstanding: usize,
+    retained: usize,
+    buffered: usize,
+    stream_buffered: usize,
+    rwnd: u32,
+    cwnd: u32,
+    ssthresh: u32,
+    partial_bytes_acked: u32,
+    in_fast_recovery: bool,
+    fast_recover_exit_point: u32,
+    will_retransmit_fast: bool,
+    deadline: Option<Instant>,
+    rto: u64,
+    srtt: u64,
+    t3_errors: usize,
+}
+
+fn sack_state(a: &mut Association, now: Instant) -> Result<SackState> {
+    let (expired, failed, t3_errors) = a.timers.is_expired(Timer::T3RTX, now);
+    assert!(!expired && !failed, "snapshot must not expire T3");
+    Ok(SackState {
+        cumulative: a.cumulative_tsn_ack_point,
+        advanced: a.advanced_peer_tsn_ack_point,
+        gaps: a.peer_gap_ack_ranges.clone(),
+        chunks: a
+            .inflight_queue
+            .tsns()
+            .map(|tsn| {
+                let c = a.inflight_queue.get(tsn).unwrap();
+                assert_eq!(c.user_data, Bytes::from_static(b"retained"));
+                (
+                    tsn,
+                    c.acknowledged,
+                    c.buffer_released,
+                    c.delivery_credited,
+                    c.miss_indicator,
+                    c.nsent,
+                    c.abandoned,
+                    c.retransmit,
+                )
+            })
+            .collect(),
+        outstanding: a.inflight_queue.outstanding_bytes(),
+        retained: a.inflight_queue.get_num_bytes(),
+        buffered: a.inflight_queue.buffered_bytes(),
+        stream_buffered: a.stream(1)?.buffered_amount()?,
+        rwnd: a.rwnd,
+        cwnd: a.cwnd,
+        ssthresh: a.ssthresh,
+        partial_bytes_acked: a.partial_bytes_acked,
+        in_fast_recovery: a.in_fast_recovery,
+        fast_recover_exit_point: a.fast_recover_exit_point,
+        will_retransmit_fast: a.will_retransmit_fast,
+        deadline: a.poll_timeout(),
+        rto: a.rto_mgr.get_rto(),
+        srtt: a.rto_mgr.srtt,
+        t3_errors,
+    })
+}
+
+#[test]
+fn invalid_and_stale_sacks_cannot_poison_cached_gap_evidence() -> Result<()> {
+    const COUNT: usize = 24;
+    const SIZE: usize = b"retained".len();
+    for first in [12345, u32::MAX - 12] {
+        let now = Instant::now();
+        let mut a = timed_test_association();
+        a.my_next_tsn = first;
+        a.cumulative_tsn_ack_point = first.wrapping_sub(1);
+        a.advanced_peer_tsn_ack_point = first.wrapping_sub(1);
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let mut stream = a.open_stream(1, ppi)?;
+        for _ in 0..COUNT {
+            stream.write_sctp(now, &Bytes::from_static(b"retained"), ppi)?;
+        }
+        assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), COUNT);
+        a.handle_sack(&sack(first.wrapping_sub(1), &[(3, 6), (10, 14)]), now)?;
+        // Move the cumulative point before testing stale SACK rejection.
+        let valid = sack(first, &[(2, 5), (9, 13)]);
+        a.handle_sack(&valid, now + Duration::from_millis(10))?;
+        assert_eq!(releases(&mut a), (10 * SIZE, 0));
+        let timeout = a.poll_timeout().unwrap();
+        a.handle_timeout(timeout);
+        assert_eq!(transmitted_data(&a.gather_outbound(timeout).0).len(), 14);
+        let before = sack_state(&mut a, timeout)?;
+        assert_eq!(before.t3_errors, 1);
+
+        let invalid = [
+            sack(first, &[(0, 1)]),
+            sack(first, &[(8, 7)]),
+            sack(first, &[(2, 5), (5, 7)]),
+            sack(first, &[(9, 12), (2, 5)]),
+            // A valid new range preceding an unassigned TSN must not be applied.
+            sack(first, &[(6, 7), (20, 24)]),
+            sack(a.my_next_tsn, &[]),
+            // Nor may an otherwise valid cumulative prefix be partially popped.
+            sack(first.wrapping_add(3), &[(2, 3), (23, 24)]),
+        ];
+        for (case, mut invalid) in invalid.into_iter().enumerate() {
+            invalid.advertised_receiver_window_credit = 7;
+            let at = timeout + Duration::from_millis(case as u64 + 1);
+            assert!(matches!(
+                a.handle_sack(&invalid, at),
+                Err(Error::ErrTsnRequestNotExist)
+            ));
+            assert_eq!(
+                sack_state(&mut a, at)?,
+                before,
+                "first {first}, invalid case {case}"
+            );
+            assert_eq!(releases(&mut a), (0, 0));
+        }
+        let mut stale = sack(first.wrapping_sub(1), &[(1, COUNT as u16)]);
+        stale.advertised_receiver_window_credit = 1;
+        let at = timeout + Duration::from_millis(8);
+        assert!(a.handle_sack(&stale, at)?.is_empty());
+        assert_eq!(sack_state(&mut a, at)?, before, "first {first}: stale SACK");
+        assert_eq!(releases(&mut a), (0, 0));
+
+        // This valid omission must still revoke exactly four original TSNs.
+        a.handle_sack(
+            &sack(first, &[(9, 13)]),
+            timeout + Duration::from_millis(10),
+        )?;
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 18 * SIZE);
+        assert_eq!(
+            sack_state(&mut a, timeout + Duration::from_millis(10))?.t3_errors,
+            1
+        );
+        assert_eq!(releases(&mut a), (0, 0));
+        // Re-ACK is real peer progress, but both delivery/application credits
+        // for these four TSNs were already consumed by the original SACK.
+        a.handle_sack(&valid, timeout + Duration::from_millis(20))?;
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 14 * SIZE);
+        assert_eq!(a.stream(1)?.buffered_amount()?, 14 * SIZE);
+        assert_eq!(
+            sack_state(&mut a, timeout + Duration::from_millis(20))?.t3_errors,
+            0
+        );
+        assert_eq!(
+            a.poll_timeout(),
+            before.deadline,
+            "the earliest TSN remains missing"
+        );
+        assert_eq!(releases(&mut a), (0, 0));
+        a.handle_sack(
+            &sack(first.wrapping_add(COUNT as u32 - 1), &[]),
+            timeout + Duration::from_millis(30),
+        )?;
+        assert_eq!(releases(&mut a), (14 * SIZE, 1));
+        assert!(a.inflight_queue.is_empty());
+        assert!(a.poll_timeout().is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn abandoned_gap_reappearance_is_duplicate_but_first_late_fragment_ack_is_progress() -> Result<()> {
+    // Reading this tuple must not itself expire or reset T3. Keep credit and
+    // congestion state separate from the error counter, which the late ACK is
+    // expected to change even after all timed payload ownership is gone.
+    let recovery = |a: &mut Association, at: Instant| {
+        let (expired, failed, errors) = a.timers.is_expired(Timer::T3RTX, at);
+        assert!(!expired && !failed);
+        (
+            (
+                a.poll_timeout(),
+                a.rto_mgr.get_rto(),
+                a.rto_mgr.srtt,
+                a.cwnd,
+                a.partial_bytes_acked,
+                a.in_fast_recovery,
+            ),
+            errors,
+        )
+    };
+    for first in [12345, u32::MAX - 1] {
+        let now = Instant::now();
+        let mut a = timed_test_association();
+        a.my_next_tsn = first;
+        a.cumulative_tsn_ack_point = first.wrapping_sub(1);
+        a.advanced_peer_tsn_ack_point = first.wrapping_sub(1);
+        a.cwnd = WINDOW;
+        a.rto_mgr.set_rto(1000, false);
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(2, ppi)?
+            .write_sctp(now, &Bytes::from_static(b"x"), ppi)?;
+        let hole = transmitted_data(&a.gather_outbound(now).0);
+        assert_eq!(hole.len(), 1);
+        assert_eq!(hole[0].tsn, first);
+
+        let size = a.max_payload_size as usize + 17;
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(true, ReliabilityType::Timed, 100)?;
+        stream.write_sctp(now, &Bytes::from(vec![42; size]), ppi)?;
+        let sent = transmitted_data(&a.gather_outbound(now).0);
+        assert_eq!(sent.len(), 2);
+        assert!(sent[0].beginning_fragment && !sent[0].ending_fragment);
+        assert!(!sent[1].beginning_fragment && sent[1].ending_fragment);
+        assert!(a.pending_queue.is_empty());
+        let old_ack = sack(first.wrapping_sub(1), &[(2, 2)]);
+        a.handle_sack(&old_ack, now + Duration::from_millis(50))?;
+        assert_eq!(releases(&mut a), (sent[0].user_data.len(), 0));
+        assert!(a.inflight_queue.get(sent[0].tsn).unwrap().acknowledged);
+        assert!(!a.inflight_queue.get(sent[1].tsn).unwrap().acknowledged);
+
+        let timeout = a.poll_timeout().unwrap();
+        assert!(timeout >= now + Duration::from_millis(100));
+        a.handle_timeout(timeout);
+        let retried = transmitted_data(&a.gather_outbound(timeout).0);
+        assert_eq!(retried.len(), 1, "only the reliable hole may be retried");
+        assert_eq!((retried[0].tsn, retried[0].stream_identifier), (first, 2));
+        assert_eq!(releases(&mut a), (sent[1].user_data.len(), 1));
+        for (index, original) in sent.iter().enumerate() {
+            let c = a.inflight_queue.get(original.tsn).unwrap();
+            assert!(c.abandoned && c.buffer_released && c.user_data.is_empty());
+            assert_eq!(c.nsent, 1, "both fragments were actually transmitted");
+            assert_eq!(c.acknowledged, index == 0);
+            assert_eq!(c.delivery_credited, index == 0);
+        }
+        assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+        assert_eq!(a.stream(2)?.buffered_amount()?, 1);
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+        let before = recovery(&mut a, timeout);
+        assert_eq!(before.1, 1);
+        let hole_misses = a.inflight_queue.get(first).unwrap().miss_indicator;
+
+        // A3 abandonment is final. Omission removes the cached range without
+        // unacknowledging the already received, now abandoned first fragment.
+        a.handle_sack(
+            &sack(first.wrapping_sub(1), &[]),
+            timeout + Duration::from_millis(10),
+        )?;
+        assert!(a.peer_gap_ack_ranges.is_empty());
+        assert!(a.inflight_queue.get(sent[0].tsn).unwrap().acknowledged);
+        assert_eq!(
+            recovery(&mut a, timeout + Duration::from_millis(10)),
+            before
+        );
+        assert_eq!(releases(&mut a), (0, 0));
+
+        // The first reappearance is outside the old range cache but remains a
+        // duplicate according to the TSN's actual receipt state. Repeating it
+        // once also exercises the ordinary cached-intersection skip.
+        for delay in [20, 30] {
+            let at = timeout + Duration::from_millis(delay);
+            a.handle_sack(&old_ack, at)?;
+            assert_eq!(
+                recovery(&mut a, at),
+                before,
+                "first TSN {first}, delay {delay}"
+            );
+            assert_eq!(
+                a.inflight_queue.get(first).unwrap().miss_indicator,
+                hole_misses
+            );
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+            assert_eq!(a.stream(2)?.buffered_amount()?, 1);
+            assert_eq!(releases(&mut a), (0, 0));
+            assert!(!a.inflight_queue.get(sent[1].tsn).unwrap().acknowledged);
+            assert!(!a.inflight_queue.get(sent[1].tsn).unwrap().delivery_credited);
+        }
+
+        // In contrast, this is the first peer ACK for the other sent fragment.
+        // It resets errors, but abandonment excludes RTT and delivery credit;
+        // the reliable earliest TSN is still outstanding, so T3 stays scheduled.
+        let late = timeout + Duration::from_millis(40);
+        a.handle_sack(&sack(first.wrapping_sub(1), &[(2, 3)]), late)?;
+        assert_eq!(recovery(&mut a, late), (before.0, 0));
+        let c = a.inflight_queue.get(sent[1].tsn).unwrap();
+        assert!(c.acknowledged && c.delivery_credited && c.abandoned && c.user_data.is_empty());
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+        assert_eq!(releases(&mut a), (0, 0));
+
+        a.handle_sack(&sack(sent[1].tsn, &[]), late + Duration::from_millis(10))?;
+        assert_eq!(releases(&mut a), (0, 0));
+        assert_eq!(a.stream(2)?.buffered_amount()?, 0);
+        assert!(a.inflight_queue.is_empty());
+        assert!(a.poll_timeout().is_none());
+    }
+    Ok(())
+}

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -10,6 +10,9 @@ mod sack_recovery;
 #[path = "ack_optimization_test.rs"]
 mod ack_optimization;
 
+#[path = "ack_range_boundary_test.rs"]
+mod ack_range_boundary;
+
 #[path = "send_retention_test.rs"]
 mod send_retention;
 

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -1,4 +1,17 @@
+use super::stream::ReliabilityType;
 use super::*;
+
+#[path = "reliability_reset_test.rs"]
+mod reliability_reset;
+
+#[path = "sack_recovery_test.rs"]
+mod sack_recovery;
+
+#[path = "message_selection_test.rs"]
+mod message_selection;
+
+#[path = "control_bundling_test.rs"]
+mod control_bundling;
 
 const ACCEPT_CH_SIZE: usize = 16;
 
@@ -15,8 +28,456 @@ fn create_association(config: TransportConfig) -> Association {
     )
 }
 
+fn timed_test_association() -> Association {
+    let mut a = create_association(TransportConfig::default());
+    a.control_queue.clear();
+    a.timers.stop(Timer::T1Init);
+    a.set_state(AssociationState::Established);
+    a.use_forward_tsn = true;
+    a.peer_supports_reconfig = true;
+    a.incoming_resets = IncomingResetQueue::new(1);
+    a.rwnd = 65536;
+    a.rto_mgr.set_rto(1000, true);
+    a
+}
+
+#[test]
+fn test_two_rx_epochs_without_app_read_require_two_reciprocal_resets() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let first = ChunkPayloadData {
+        tsn: a.peer_last_tsn.wrapping_add(1),
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: ppi,
+        user_data: Bytes::from_static(b"old receiver stays unread"),
+        ..Default::default()
+    };
+    a.handle_data(&first)?;
+    let first_reset = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: a.my_next_rsn.wrapping_sub(1),
+        sender_last_tsn: first.tsn,
+        stream_identifiers: vec![1],
+    };
+    assert_eq!(
+        reconfig_results(&a.handle_reconfig(now, &reset_config(&first_reset))?),
+        [ReconfigResult::SuccessPerformed],
+    );
+    let reciprocal = reset_requests(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(reciprocal.stream_identifiers, [1]);
+    receive_reset_response(&mut a, now, &reciprocal, ReconfigResult::SuccessPerformed)?;
+    assert!(a.outgoing_reset.is_none());
+    // The peer has now reset both directions, and is permitted to reuse SID 1.
+    // Receipt/delivery of the first generation by our application is separate.
+    let second = ChunkPayloadData {
+        tsn: first.tsn.wrapping_add(1),
+        user_data: Bytes::from_static(b"new receiver also closes"),
+        ..first.clone()
+    };
+    a.handle_data(&second)?;
+    let second_reset = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 2,
+        reconfig_response_sequence_number: reciprocal.reconfig_request_sequence_number,
+        sender_last_tsn: second.tsn,
+        stream_identifiers: vec![1],
+    };
+    assert_eq!(
+        reconfig_results(&a.handle_reconfig(now, &reset_config(&second_reset))?),
+        [ReconfigResult::SuccessPerformed],
+    );
+    let second_reciprocals = reset_requests(&a.gather_outbound(now).0);
+    assert_eq!(
+        second_reciprocals.len(),
+        1,
+        "each reused data channel needs its own reciprocal reset; old API delivery must not suppress it"
+    );
+    assert_eq!(second_reciprocals[0].stream_identifiers, [1]);
+    assert_eq!(
+        second_reciprocals[0].reconfig_request_sequence_number,
+        reciprocal.reconfig_request_sequence_number.wrapping_add(1),
+    );
+    receive_reset_response(
+        &mut a,
+        now,
+        &second_reciprocals[0],
+        ReconfigResult::SuccessPerformed,
+    )?;
+    for expected in [&first.user_data, &second.user_data] {
+        while a.poll().is_some() {}
+        let received = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&received[..], &expected[..]);
+    }
+    while a.poll().is_some() {}
+    assert!(a.stream(1).is_err());
+    assert_eq!(a.receive_streams[&1].get_num_bytes(), 0);
+    Ok(())
+}
+
+#[test]
+fn test_stopping_saved_receiver_does_not_close_current_wire_epoch() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let mut data = ChunkPayloadData {
+            tsn: a.peer_last_tsn.wrapping_add(1),
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: true,
+            ending_fragment: true,
+            unordered,
+            payload_type: PayloadProtocolIdentifier::Binary,
+            ..Default::default()
+        };
+        let mut last_reciprocal = a.my_next_rsn.wrapping_sub(1);
+        for (sequence, payload) in [b"old".as_slice(), b"middle".as_slice()]
+            .into_iter()
+            .enumerate()
+        {
+            data.user_data = Bytes::copy_from_slice(payload);
+            a.handle_data(&data)?;
+            let request = ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: sequence as u32 + 1,
+                reconfig_response_sequence_number: last_reciprocal,
+                sender_last_tsn: data.tsn,
+                stream_identifiers: vec![1],
+            };
+            assert_eq!(
+                reconfig_results(&a.handle_reconfig(now, &reset_config(&request))?),
+                [ReconfigResult::SuccessPerformed],
+            );
+            let reciprocals = reset_requests(&a.gather_outbound(now).0);
+            assert_eq!(reciprocals.len(), 1);
+            last_reciprocal = reciprocals[0].reconfig_request_sequence_number;
+            receive_reset_response(
+                &mut a,
+                now,
+                &reciprocals[0],
+                ReconfigResult::SuccessPerformed,
+            )?;
+            data.tsn = data.tsn.wrapping_add(1);
+        }
+
+        data.user_data = Bytes::from_static(b"current");
+        a.handle_data(&data)?;
+        let old = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&old[..], b"old");
+        while a.poll().is_some() {}
+        {
+            let mut middle = a.stream(1)?;
+            assert!(middle.is_readable());
+            assert!(
+                !middle.is_writable(),
+                "saved delivery already completed its wire reset"
+            );
+            middle.stop(now)?;
+        }
+        assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+        while a.poll().is_some() {}
+        assert!(a.stream(1)?.is_writable());
+        let current = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&current[..], b"current");
+        data.tsn = data.tsn.wrapping_add(1);
+        data.stream_sequence_number = if unordered { 0 } else { 1 };
+        data.user_data = Bytes::from_static(b"later in current");
+        a.handle_data(&data)?;
+        let later = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&later[..], b"later in current");
+        assert_eq!(a.receive_streams[&1].get_num_bytes(), 0);
+
+        let request = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 3,
+            reconfig_response_sequence_number: last_reciprocal,
+            sender_last_tsn: data.tsn,
+            stream_identifiers: vec![1],
+        };
+        a.handle_reconfig(now, &reset_config(&request))?;
+        let reciprocals = reset_requests(&a.gather_outbound(now).0);
+        assert_eq!(
+            reciprocals.len(),
+            1,
+            "the current wire epoch still needs its own reciprocal reset"
+        );
+        assert_eq!(reciprocals[0].stream_identifiers, [1]);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_reciprocal_reset_requires_new_wire_activity() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let mut last_reciprocal = a.my_next_rsn.wrapping_sub(1);
+    // No DATA is necessary for a locally opened channel to need both resets.
+    a.open_stream(1, PayloadProtocolIdentifier::Binary)?;
+    for sequence in 1..=5 {
+        if sequence == 3 {
+            a.open_stream(1, PayloadProtocolIdentifier::Binary)?;
+        } else if sequence == 5 {
+            // A first message may expire before any of its DATA reaches us.
+            a.handle_forward_tsn(&ChunkForwardTsn {
+                new_cumulative_tsn: a.peer_last_tsn.wrapping_add(1),
+                streams: vec![ChunkForwardTsnStream {
+                    identifier: 1,
+                    sequence: 0,
+                }],
+            })?;
+        }
+        let request = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: sequence,
+            reconfig_response_sequence_number: last_reciprocal,
+            sender_last_tsn: a.peer_last_tsn,
+            stream_identifiers: vec![1],
+        };
+        assert_eq!(
+            reconfig_results(&a.handle_reconfig(now, &reset_config(&request))?),
+            [ReconfigResult::SuccessPerformed],
+        );
+        let reciprocals = reset_requests(&a.gather_outbound(now).0);
+        if sequence % 2 == 0 {
+            assert!(
+                reciprocals.is_empty(),
+                "an unused reset stream must not start a reset loop"
+            );
+        } else {
+            assert_eq!(reciprocals.len(), 1);
+            last_reciprocal = reciprocals[0].reconfig_request_sequence_number;
+            receive_reset_response(
+                &mut a,
+                now,
+                &reciprocals[0],
+                ReconfigResult::SuccessPerformed,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_abandonment_preserves_t3_restart_for_outstanding_data() -> Result<()> {
+    for gap_ack in [false, true] {
+        let mut a = timed_test_association();
+        a.rto_mgr.set_rto(1000, false);
+        let now = Instant::now();
+        let first_tsn = a.my_next_tsn;
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+        stream.write_sctp(now, &Bytes::from_static(b"lost"), ppi)?;
+        let mut stream = a.open_stream(2, ppi)?;
+        for _ in 0..2 {
+            stream.write_sctp(now, &Bytes::from(vec![0; 1000]), ppi)?;
+        }
+        a.gather_outbound(now);
+        let timeout = a.poll_timeout().unwrap();
+        a.handle_timeout(timeout);
+        assert_eq!(1, data_chunks(&a.gather_outbound(timeout).0));
+        let at = timeout + Duration::from_millis(100);
+        let sack = ChunkSelectiveAck {
+            cumulative_tsn_ack: if gap_ack {
+                first_tsn - 1
+            } else {
+                first_tsn + 1
+            },
+            advertised_receiver_window_credit: 65536,
+            gap_ack_blocks: if gap_ack {
+                vec![crate::chunk::chunk_selective_ack::GapAckBlock { start: 2, end: 2 }]
+            } else {
+                vec![]
+            },
+            ..Default::default()
+        };
+        a.handle_sack(&sack, at)?;
+        assert_eq!(Some(at + Duration::from_secs(2)), a.poll_timeout());
+        a.handle_sack(&sack, at + Duration::from_millis(100))?;
+        assert_eq!(
+            Some(at + Duration::from_secs(2)),
+            a.poll_timeout(),
+            "duplicate SACK must not restart T3"
+        );
+    }
+    Ok(())
+}
+
+fn data_chunks(packets: &[Bytes]) -> usize {
+    packets
+        .iter()
+        .map(|raw| {
+            Packet::unmarshal(raw)
+                .unwrap()
+                .chunks
+                .iter()
+                .filter(|c| c.as_any().is::<ChunkPayloadData>())
+                .count()
+        })
+        .sum()
+}
+
+#[test]
+fn test_timed_retransmit_deadline_and_reliable_exemptions() -> Result<()> {
+    let lifetime = Duration::from_millis(100);
+    for (policy, ppi, forward_tsn, elapsed, retransmit) in [
+        (
+            ReliabilityType::Timed,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            lifetime - Duration::from_nanos(1),
+            true,
+        ),
+        (
+            ReliabilityType::Timed,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            lifetime,
+            false,
+        ),
+        (
+            ReliabilityType::Timed,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            Duration::from_millis(u32::MAX as u64 + 1),
+            false,
+        ),
+        (
+            ReliabilityType::Timed,
+            PayloadProtocolIdentifier::Dcep,
+            true,
+            lifetime,
+            true,
+        ),
+        (
+            ReliabilityType::Timed,
+            PayloadProtocolIdentifier::Binary,
+            false,
+            lifetime,
+            true,
+        ),
+        (
+            ReliabilityType::Reliable,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            lifetime,
+            true,
+        ),
+    ] {
+        let mut a = timed_test_association();
+        a.use_forward_tsn = forward_tsn;
+        let now = Instant::now();
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(true, policy, 100)?;
+        stream.write_sctp(now, &Bytes::from_static(b"test"), ppi)?;
+        assert_eq!(1, data_chunks(&a.gather_outbound(now).0));
+        a.inflight_queue.mark_all_to_retrasmit();
+        a.t3_retransmit_pending = true;
+        assert_eq!(
+            usize::from(retransmit),
+            data_chunks(&a.gather_outbound(now + elapsed).0)
+        );
+        assert_eq!(if retransmit { 4 } else { 0 }, a.buffered_amount());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_abandonment_covers_pending_tail_and_retries_forward_tsn() -> Result<()> {
+    for unordered in [false, true] {
+        for ack_prefix in [false, true] {
+            let mut a = timed_test_association();
+            a.cwnd = a.max_payload_size;
+            let now = Instant::now();
+            let first_tsn = a.my_next_tsn;
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let mut stream = a.open_stream(1, ppi)?;
+            stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+            stream.write_sctp(now, &Bytes::from(vec![0; 4000]), ppi)?;
+            assert_eq!(1, data_chunks(&a.gather_outbound(now).0));
+            assert!(!a.pending_queue.is_empty());
+            if ack_prefix {
+                a.handle_sack(
+                    &ChunkSelectiveAck {
+                        cumulative_tsn_ack: first_tsn,
+                        advertised_receiver_window_credit: 65536,
+                        ..Default::default()
+                    },
+                    now + Duration::from_millis(50),
+                )?;
+            }
+            let packets = a.gather_outbound(now + Duration::from_millis(100)).0;
+            assert_eq!(0, data_chunks(&packets));
+            assert!(!packets.is_empty());
+            assert!(a.pending_queue.is_empty());
+            assert_eq!(0, a.stream(1)?.buffered_amount()?);
+            assert_eq!(a.my_next_tsn - 1, a.advanced_peer_tsn_ack_point);
+            let fwd = a.create_forward_tsn();
+            assert_eq!(usize::from(!unordered), fwd.streams.len());
+            let released: usize = std::iter::from_fn(|| a.poll())
+                .filter_map(|event| {
+                    if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) =
+                        event
+                    {
+                        Some(n_bytes)
+                    } else {
+                        None
+                    }
+                })
+                .sum();
+            assert_eq!(4000, released);
+
+            // Lose FORWARD TSN, including while waiting to shut down.
+            a.set_state(AssociationState::ShutdownPending);
+            let retry = a.poll_timeout().unwrap();
+            a.handle_timeout(retry);
+            assert_eq!(packets, a.gather_outbound(retry).0);
+            assert!(
+                a.poll().is_none(),
+                "abandoned bytes must not be released twice"
+            );
+            let cwnd = a.cwnd;
+            a.handle_sack(
+                &ChunkSelectiveAck {
+                    cumulative_tsn_ack: a.advanced_peer_tsn_ack_point,
+                    advertised_receiver_window_credit: 65536,
+                    ..Default::default()
+                },
+                retry,
+            )?;
+            assert!(a.inflight_queue.is_empty());
+            assert_eq!(cwnd, a.cwnd, "abandoned bytes must not grow cwnd");
+            assert!(a.poll().is_none());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_data_expires_between_retransmit_polls() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 1500)?;
+    for _ in 0..2 {
+        stream.write_sctp(now, &Bytes::from(vec![0; 1000]), ppi)?;
+    }
+    assert_eq!(2, data_chunks(&a.gather_outbound(now).0));
+    let timeout = a.poll_timeout().unwrap();
+    a.handle_timeout(timeout);
+    assert_eq!(1, data_chunks(&a.gather_outbound(timeout).0));
+    assert!(a.t3_retransmit_pending);
+    assert_eq!(
+        0,
+        data_chunks(&a.gather_outbound(now + Duration::from_millis(1500)).0)
+    );
+    assert_eq!(0, a.buffered_amount());
+    assert!(!a.t3_retransmit_pending);
+    Ok(())
+}
+
 // `create_forward_tsn` no longer rescans the in-flight window; it emits the
-// `fwd_tsn_stream_map` that the RFC 3758 C2 loops fill via
+// `fwd_tsn_stream_map` that the RFC 3758 C2 walk fills via
 // `note_abandoned_for_forward_tsn` as each chunk is abandoned. These unit tests
 // drive that same entry point directly (ascending TSN, as C2 would); the full
 // window/SACK-driven path is exercised end-to-end by the `endpoint_test`
@@ -106,7 +567,7 @@ fn test_create_forward_tsn_omits_unordered_streams() -> Result<()> {
 // The allocation-avoiding marshal_control_chunk() must produce byte-identical wire
 // output to create_packet(vec![Box::new(chunk)]).marshal(). A 2-stream FORWARD-TSN
 // also exercises ChunkForwardTsn::marshal_to's per-stream marshal_to loop, and a
-// SACK covers the other call site.
+// SACK and RE-CONFIG cover the remaining control call sites.
 #[test]
 fn test_marshal_control_chunk_byte_identical_to_create_packet() -> Result<()> {
     let mut a = Association::default();
@@ -142,6 +603,24 @@ fn test_marshal_control_chunk_byte_identical_to_create_packet() -> Result<()> {
         sack_via_helper, sack_via_packet,
         "SACK: marshal_control_chunk must match create_packet(..).marshal()"
     );
+
+    // Odd/even SID counts exercise parameter and chunk padding, including the
+    // empty list that denotes an all-stream reset.
+    for stream_identifiers in [vec![], vec![1], vec![1, 2]] {
+        let reconfig = ChunkReconfig {
+            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 17,
+                reconfig_response_sequence_number: 16,
+                sender_last_tsn: 42,
+                stream_identifiers,
+            })),
+            ..Default::default()
+        };
+        let via_helper = a.marshal_control_chunk(&reconfig)?;
+        let via_packet = a.create_packet(vec![Box::new(reconfig)]).marshal()?;
+        assert_eq!(via_helper, via_packet, "RE-CONFIG framing changed");
+        Packet::unmarshal(&via_helper)?;
+    }
 
     Ok(())
 }
@@ -301,7 +780,10 @@ fn test_handle_forward_tsn_dup_forward_tsn_chunk_should_generate_sack() -> Resul
 
 #[test]
 fn test_assoc_create_new_stream() -> Result<()> {
-    let mut a = Association::default();
+    let mut a = Association {
+        my_max_num_inbound_streams: ACCEPT_CH_SIZE as u16,
+        ..Default::default()
+    };
 
     for i in 0..ACCEPT_CH_SIZE {
         let stream_identifier =
@@ -372,8 +854,8 @@ fn handle_init_test(name: &str, initial_state: AssociationState, expect_err: boo
         "{} should match",
         name
     );
-    assert_eq!(1001, a.my_max_num_outbound_streams, "{} should match", name);
-    assert_eq!(1002, a.my_max_num_inbound_streams, "{} should match", name);
+    assert_eq!(1002, a.my_max_num_outbound_streams, "{} should match", name);
+    assert_eq!(1001, a.my_max_num_inbound_streams, "{} should match", name);
     assert_eq!(5678, a.peer_verification_tag, "{} should match", name);
     assert_eq!(
         pkt.common_header.source_port, a.destination_port,
@@ -706,4 +1188,3337 @@ fn many_small_chunks_bundle_within_mtu() {
     let min_expected = 60 * (DATA_CHUNK_HEADER_SIZE as usize + 17)
         + raw_packets.len() * COMMON_HEADER_SIZE as usize;
     assert!(total >= min_expected);
+}
+
+fn reset_requests(packets: &[Bytes]) -> Vec<ParamOutgoingResetRequest> {
+    packets
+        .iter()
+        .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+        .filter_map(|c| {
+            c.as_any()
+                .downcast_ref::<ChunkReconfig>()
+                .and_then(|c| c.param_a.as_ref())
+                .and_then(|p| p.as_any().downcast_ref::<ParamOutgoingResetRequest>())
+                .cloned()
+        })
+        .collect()
+}
+
+#[test]
+fn test_expired_data_from_previous_sid_use_does_not_skip_new_messages() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    for _ in 0..6 {
+        stream.write_sctp(now, &Bytes::from_static(b"old"), ppi)?;
+    }
+    stream.close(now)?;
+    let reset = reset_requests(&a.gather_outbound(now).0).remove(0);
+    // The peer received our DATA and reset. Its DATA SACK was lost, but both
+    // directions complete their reset, so SID 1 can be reused.
+    a.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_b: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                reconfig_response_sequence_number: reset.reconfig_request_sequence_number,
+                sender_last_tsn: a.peer_last_tsn,
+                stream_identifiers: vec![1],
+            })),
+            param_a: Some(Box::new(ParamReconfigResponse {
+                reconfig_response_sequence_number: reset.reconfig_request_sequence_number,
+                result: ReconfigResult::SuccessPerformed,
+            })),
+        },
+    )?;
+    let mut stream = a.open_stream(2, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from_static(b"also expires"), ppi)?;
+    let new_message = Bytes::from_static(b"new reliable message");
+    a.open_stream(1, ppi)?.write_sctp(now, &new_message, ppi)?;
+    a.gather_outbound(now);
+    let at = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(at);
+    let packets = a.gather_outbound(at).0;
+    let forward = packets
+        .iter()
+        .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+        .find_map(|c| c.as_any().downcast_ref::<ChunkForwardTsn>().cloned())
+        .unwrap();
+    assert!(sna32gt(forward.new_cumulative_tsn, reset.sender_last_tsn));
+    assert!(
+        forward.streams.iter().all(|s| s.identifier != 1),
+        "old SSNs must not skip DATA on the reused stream"
+    );
+    assert_eq!(new_message.len(), a.stream(1)?.buffered_amount()?);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: reset.sender_last_tsn,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        at,
+    )?;
+    assert_eq!(new_message.len(), a.stream(1)?.buffered_amount()?);
+    Ok(())
+}
+
+fn defer_reset(a: &mut Association) -> Result<()> {
+    let now = Instant::now();
+    a.peer_last_tsn = 10;
+    a.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                sender_last_tsn: 12,
+                stream_identifiers: vec![1],
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_reconfig_backoff_must_double_once() -> Result<()> {
+    let mut a = timed_test_association();
+    a.rto_mgr.set_rto(1000, false);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"reliable data"), ppi)?;
+    stream.close(now)?;
+    a.gather_outbound(now);
+    let timeout = a.timers.get(Timer::Reconfig).unwrap();
+    assert_eq!(Some(timeout), a.timers.get(Timer::T3RTX));
+    a.handle_timeout(timeout);
+    a.gather_outbound(timeout);
+    assert_eq!(
+        Some(timeout + Duration::from_secs(2)),
+        a.timers.get(Timer::Reconfig),
+        "Reconfiguration timer must double its previous 1s interval, not back off twice"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_deferred_peer_reset_must_not_disable_timed_reliability() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(
+        now,
+        &Bytes::from_static(b"local timed message lost in flight"),
+        ppi,
+    )?;
+    a.gather_outbound(now);
+    defer_reset(&mut a)?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 12,
+        ..Default::default()
+    })?;
+    let timeout = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(timeout);
+    for raw in a.gather_outbound(timeout).0 {
+        for c in Packet::unmarshal(&raw)?.chunks {
+            assert!(
+                !c.as_any().is::<ChunkPayloadData>(),
+                "deferred incoming reset erased reliability policy; expired timed DATA was retransmitted"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn enqueue_pair(a: &mut Association, now: Instant) -> Result<u32> {
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"timed"), ppi)?;
+    a.stream(2)?
+        .write_sctp(now, &Bytes::from_static(b"reliable"), ppi)?;
+    a.gather_outbound(now);
+    Ok(a.my_next_tsn - 1)
+}
+
+#[test]
+fn test_t3_recovers_repeated_losses_when_peer_makes_progress() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?
+        .set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    a.open_stream(2, ppi)?;
+    let mut ack_through = enqueue_pair(&mut a, now)?;
+    for round in 1..=8 {
+        let timeout = a.poll_timeout().expect("outstanding DATA needs T3");
+        a.handle_timeout(timeout);
+        let packets = a.gather_outbound(timeout).0;
+        let reliable_retransmitted = packets.iter().any(|raw| {
+            Packet::unmarshal(raw).unwrap().chunks.iter().any(|chunk| {
+                chunk
+                    .as_any()
+                    .downcast_ref::<ChunkPayloadData>()
+                    .is_some_and(|data| data.stream_identifier == 2)
+            })
+        });
+        assert!(
+            reliable_retransmitted,
+            "round {round}: reliable DATA never retransmitted, timer = {:?}",
+            a.poll_timeout()
+        );
+        // Keep the send queue nonempty while successfully acknowledging every
+        // TSN in the previous flight. Each round has actual receiver progress.
+        let next_ack = enqueue_pair(&mut a, timeout)?;
+        a.handle_sack(
+            &ChunkSelectiveAck {
+                cumulative_tsn_ack: ack_through,
+                advertised_receiver_window_credit: 65536,
+                ..Default::default()
+            },
+            timeout + Duration::from_millis(50),
+        )?;
+        ack_through = next_ack;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_reset_waits_for_queued_data_and_starts_timer() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.cwnd = a.mtu;
+    a.open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from(vec![1; 4000]), ppi)?;
+    defer_reset(&mut a)?;
+    let reply = a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 12,
+        ..Default::default()
+    })?;
+    let mut sent_bytes = 0;
+    let mut last_data_tsn = 0;
+    let mut packets: Vec<Bytes> = reply.iter().map(|p| p.marshal().unwrap()).collect();
+    // A small send window forces the pending message to span several flights.
+    for _ in 0..10 {
+        packets.extend(a.gather_outbound(now).0);
+        for raw in &packets {
+            for c in Packet::unmarshal(raw)?.chunks {
+                if let Some(c) = c.as_any().downcast_ref::<ChunkPayloadData>() {
+                    sent_bytes += c.user_data.len();
+                    last_data_tsn = c.tsn;
+                }
+            }
+        }
+        let resets = reset_requests(&packets);
+        if let Some(reset) = resets.first() {
+            assert_eq!(4000, sent_bytes, "reset overtook queued DATA");
+            assert_eq!(last_data_tsn, reset.sender_last_tsn);
+            assert_eq!(1, reset.reconfig_response_sequence_number);
+            assert!(a.timers.get(Timer::Reconfig).is_some());
+            return Ok(());
+        }
+        assert!(sent_bytes > 0);
+        a.handle_sack(
+            &ChunkSelectiveAck {
+                cumulative_tsn_ack: last_data_tsn,
+                advertised_receiver_window_credit: 65536,
+                ..Default::default()
+            },
+            now,
+        )?;
+        packets.clear();
+    }
+    panic!("reciprocal reset was never sent");
+}
+
+#[test]
+fn test_ready_reset_preserves_unrelated_fragmented_data_and_last_tsn() -> Result<()> {
+    fn data(packets: &[Bytes]) -> Vec<ChunkPayloadData> {
+        packets
+            .iter()
+            .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+            .filter_map(|c| c.as_any().downcast_ref::<ChunkPayloadData>().cloned())
+            .collect()
+    }
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.cwnd = a.mtu;
+        a.open_stream(1, ppi)?;
+        let payload = Bytes::from(vec![7; 4000]);
+        let mut s = a.open_stream(2, ppi)?;
+        s.set_reliability_params(unordered, ReliabilityType::Reliable, 0)?;
+        s.write_sctp(now, &payload, ppi)?;
+        let mut chunks = data(&a.gather_outbound(now).0);
+        assert_eq!(1, chunks.len());
+        let first_tsn = chunks[0].tsn;
+        a.handle_sack(
+            &ChunkSelectiveAck {
+                cumulative_tsn_ack: first_tsn,
+                advertised_receiver_window_credit: 0,
+                ..Default::default()
+            },
+            now,
+        )?;
+        // Reset 2 must wait for its tail; the later reset 1 is already ready.
+        for (index, id) in [2, 1].into_iter().enumerate() {
+            a.handle_reconfig(
+                now,
+                &ChunkReconfig {
+                    param_a: Some(Box::new(ParamOutgoingResetRequest {
+                        reconfig_request_sequence_number: index as u32 + 1,
+                        sender_last_tsn: a.peer_last_tsn,
+                        stream_identifiers: vec![id],
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            )?;
+        }
+        let packets = a.gather_outbound(now).0;
+        assert_eq!(
+            0,
+            data_chunks(&packets),
+            "ready reset must precede any new rwnd probe"
+        );
+        let resets = reset_requests(&packets);
+        assert_eq!(1, resets.len());
+        assert_eq!(vec![1], resets[0].stream_identifiers);
+        assert_eq!(first_tsn, resets[0].sender_last_tsn);
+        assert!(a.timers.get(Timer::Reconfig).is_some());
+        a.handle_reconfig(
+            now,
+            &ChunkReconfig {
+                param_a: Some(Box::new(ParamReconfigResponse {
+                    reconfig_response_sequence_number: resets[0].reconfig_request_sequence_number,
+                    result: ReconfigResult::SuccessPerformed,
+                })),
+                ..Default::default()
+            },
+        )?;
+        // Restoring credit must continue the selected message with every byte intact.
+        let mut reset_two = None;
+        for _ in 0..10 {
+            a.handle_sack(
+                &ChunkSelectiveAck {
+                    cumulative_tsn_ack: chunks.last().unwrap().tsn,
+                    advertised_receiver_window_credit: 65536,
+                    ..Default::default()
+                },
+                now,
+            )?;
+            let packets = a.gather_outbound(now).0;
+            chunks.extend(data(&packets));
+            if let Some(reset) = reset_requests(&packets).pop() {
+                reset_two = Some(reset);
+                break;
+            }
+        }
+        let reset_two = reset_two.expect("reset 2 must follow its own DATA");
+        assert_eq!(vec![2], reset_two.stream_identifiers);
+        assert_eq!(chunks.last().unwrap().tsn, reset_two.sender_last_tsn);
+        assert!(chunks[0].beginning_fragment);
+        assert!(chunks.last().unwrap().ending_fragment);
+        assert!(chunks.iter().all(|c| c.unordered == unordered));
+        let received: Vec<u8> = chunks
+            .iter()
+            .flat_map(|c| c.user_data.iter().copied())
+            .collect();
+        assert_eq!(payload.as_ref(), received.as_slice());
+        assert!(a.pending_queue.is_empty());
+        assert_eq!(0, a.pending_queue.get_num_bytes());
+    }
+    Ok(())
+}
+
+#[test]
+#[ignore = "manual queue benchmark; run with --release --ignored --nocapture"]
+fn benchmark_pending_data_before_reset() -> Result<()> {
+    for count in [2048usize, 4096, 8192, 16384] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.cwnd = 1024 * 1024;
+        a.rwnd = 1024 * 1024;
+        let mut stream = a.open_stream(1, ppi)?;
+        for _ in 0..count {
+            stream.write_sctp(now, &Bytes::from_static(b"0123456789abcdef"), ppi)?;
+        }
+        a.handle_reconfig(
+            now,
+            &ChunkReconfig {
+                param_a: Some(Box::new(ParamOutgoingResetRequest {
+                    reconfig_request_sequence_number: 1,
+                    sender_last_tsn: a.peer_last_tsn,
+                    stream_identifiers: vec![1],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+        )?;
+        let started = Instant::now();
+        let (chunks, resets) = std::hint::black_box(&mut a).pop_pending_data_chunks_to_send(now);
+        let elapsed = started.elapsed();
+        assert_eq!(count, chunks.len());
+        assert_eq!(
+            vec![1],
+            resets
+                .iter()
+                .map(|reset| reset.stream_identifier)
+                .collect::<Vec<_>>()
+        );
+        eprintln!(
+            "queued_messages={count} payload_bytes={} send_queue_us={}",
+            count * 16,
+            elapsed.as_micros()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_zero_lifetime_sends_every_fragment_once() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        a.cwnd = 1300;
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(unordered, ReliabilityType::Timed, 0)?;
+        stream.write_sctp(now, &Bytes::from(vec![0; 4000]), ppi)?;
+        let mut sent = 0;
+        for round in 0..3 {
+            let at = now + Duration::from_millis(round * 10);
+            let packets = a.gather_outbound(at).0;
+            for raw in packets {
+                for chunk in Packet::unmarshal(&raw)?.chunks {
+                    if let Some(data) = chunk.as_any().downcast_ref::<ChunkPayloadData>() {
+                        sent += data.user_data.len();
+                        a.handle_sack(
+                            &ChunkSelectiveAck {
+                                cumulative_tsn_ack: data.tsn,
+                                advertised_receiver_window_credit: 65536,
+                                ..Default::default()
+                            },
+                            at,
+                        )?;
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            4000, sent,
+            "zero lifetime must allow every fragment's first send"
+        );
+        assert!(a.pending_queue.is_empty());
+        assert!(a.inflight_queue.is_empty());
+        assert_eq!(0, a.stream(1)?.buffered_amount()?);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_expiry_does_not_abandon_gap_acked_messages() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let first_tsn = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    for _ in 0..2 {
+        stream.write_sctp(now, &Bytes::from_static(b"test"), ppi)?;
+    }
+    a.gather_outbound(now);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: first_tsn - 1,
+            advertised_receiver_window_credit: 65536,
+            gap_ack_blocks: vec![crate::chunk::chunk_selective_ack::GapAckBlock {
+                start: 2,
+                end: 2,
+            }],
+            ..Default::default()
+        },
+        now + Duration::from_millis(50),
+    )?;
+    let timeout = a.poll_timeout().unwrap();
+    a.handle_timeout(timeout);
+    a.gather_outbound(timeout);
+    assert!(!a.inflight_queue.get(first_tsn + 1).unwrap().abandoned());
+    assert!(sna32lt(a.advanced_peer_tsn_ack_point, first_tsn + 1));
+    let streams = a.create_forward_tsn().streams;
+    assert!(streams.iter().all(|s| s.sequence != 1));
+    Ok(())
+}
+
+#[test]
+fn test_reciprocal_reset_precedes_writes_on_reused_sid() -> Result<()> {
+    for old_size in [0, 32, 4000] {
+        for old_unordered in [false, true] {
+            for new_unordered in [false, true] {
+                let mut a = timed_test_association();
+                a.cwnd = 65536;
+                let now = Instant::now();
+                let first_tsn = a.my_next_tsn;
+                let ppi = PayloadProtocolIdentifier::Binary;
+                let mut old = a.open_stream(5, ppi)?;
+                old.set_reliability_params(old_unordered, ReliabilityType::Reliable, 0)?;
+                if old_size > 0 {
+                    old.write_sctp(now, &Bytes::from(vec![1; old_size]), ppi)?;
+                }
+                a.handle_reconfig(
+                    now,
+                    &ChunkReconfig {
+                        param_a: Some(Box::new(ParamOutgoingResetRequest {
+                            reconfig_request_sequence_number: 1,
+                            sender_last_tsn: a.peer_last_tsn,
+                            stream_identifiers: vec![5],
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    },
+                )?;
+                let mut new = a.open_stream(5, ppi)?;
+                new.set_reliability_params(new_unordered, ReliabilityType::Reliable, 0)?;
+                let new_payload = Bytes::from_static(b"new stream data");
+                new.write_sctp(now, &new_payload, ppi)?;
+
+                let packets = a.gather_outbound(now).0;
+                let reset = reset_requests(&packets).remove(0);
+                assert_eq!(vec![5], reset.stream_identifiers);
+                assert_eq!(1, reset.reconfig_response_sequence_number);
+                let data: Vec<_> = packets
+                    .iter()
+                    .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+                    .filter_map(|c| c.as_any().downcast_ref::<ChunkPayloadData>().cloned())
+                    .collect();
+                let payload: Vec<u8> = data
+                    .iter()
+                    .flat_map(|c| c.user_data.iter().copied())
+                    .collect();
+                assert_eq!(
+                    vec![1; old_size],
+                    payload,
+                    "new DATA crossed the reset: old_size={old_size}, old_unordered={old_unordered}, new_unordered={new_unordered}"
+                );
+                let last_tsn = reset.sender_last_tsn;
+                assert_eq!(
+                    first_tsn.wrapping_add(data.len() as u32).wrapping_sub(1),
+                    last_tsn
+                );
+                assert_eq!(0, data_chunks(&a.gather_outbound(now).0));
+                receive_reset_response(&mut a, now, &reset, ReconfigResult::SuccessPerformed)?;
+                let (data, resets) = a.pop_pending_data_chunks_to_send(now);
+                assert!(resets.is_empty());
+                assert_eq!(1, data.len());
+                assert_eq!(new_payload, data[0].user_data);
+                assert!(sna32gt(data[0].tsn, last_tsn));
+                assert!(a.pending_queue.is_empty());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_abandonment_discards_gap_acked_fragments() -> Result<()> {
+    for unordered in [false, true] {
+        for (size, lost_fragment) in [(2000, 0), (2000, 1), (4000, 0), (4000, 1), (4000, 2)] {
+            let mut sender = timed_test_association();
+            let mut receiver = timed_test_association();
+            sender.cwnd = 65536;
+            receiver.ack_mode = AckMode::NoDelay;
+            receiver.peer_last_tsn = sender.my_next_tsn.wrapping_sub(1);
+            receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+            let receive_window = receiver.get_my_receiver_window_credit();
+            let now = Instant::now();
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let mut stream = sender.open_stream(1, ppi)?;
+            stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+            stream.write_sctp(now, &Bytes::from(vec![0x55; size]), ppi)?;
+            // A fully received message must survive even with the same SID,
+            // deadline and (for unordered DATA) SSN as the abandoned message.
+            let delivered = Bytes::from(vec![0x66; size]);
+            stream.write_sctp(now, &delivered, ppi)?;
+            receiver.open_stream(1, ppi)?.set_reliability_params(
+                unordered,
+                ReliabilityType::Timed,
+                100,
+            )?;
+            let data: Vec<ChunkPayloadData> = sender
+                .gather_outbound(now)
+                .0
+                .iter()
+                .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+                .filter_map(|c| c.as_any().downcast_ref::<ChunkPayloadData>().cloned())
+                .collect();
+            let fragments = size.div_ceil(sender.max_payload_size as usize);
+            assert_eq!(2 * fragments, data.len());
+            for (index, chunk) in data.iter().enumerate() {
+                if index != lost_fragment {
+                    receiver.handle_data(chunk)?;
+                }
+            }
+            sender.handle_sack(
+                &receiver.create_selective_ack_chunk(),
+                now + Duration::from_millis(10),
+            )?;
+            let at = sender.poll_timeout().unwrap();
+            sender.handle_timeout(at);
+            let packets = sender.gather_outbound(at).0;
+            assert_eq!(
+                0,
+                data_chunks(&packets),
+                "expired DATA must not be retransmitted"
+            );
+            for chunk in &data[fragments..] {
+                assert!(
+                    !sender.inflight_queue.get(chunk.tsn).unwrap().abandoned(),
+                    "a fully Gap-ACKed message must not be abandoned"
+                );
+            }
+            let forwards: Vec<ChunkForwardTsn> = packets
+                .iter()
+                .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+                .filter_map(|c| c.as_any().downcast_ref::<ChunkForwardTsn>().cloned())
+                .collect();
+            assert_eq!(1, forwards.len());
+            assert_eq!(data[fragments - 1].tsn, forwards[0].new_cumulative_tsn);
+            receiver.handle_forward_tsn(&forwards[0])?;
+            sender.handle_sack(&receiver.create_selective_ack_chunk(), at)?;
+            assert!(sender.inflight_queue.is_empty());
+            assert_eq!(0, sender.stream(1)?.buffered_amount()?);
+            let released: usize = std::iter::from_fn(|| sender.poll())
+                .filter_map(|event| {
+                    if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) =
+                        event
+                    {
+                        Some(n_bytes)
+                    } else {
+                        None
+                    }
+                })
+                .sum();
+            assert_eq!(
+                2 * size,
+                released,
+                "Gap-ACKed bytes must not be released twice"
+            );
+            let queue = &receiver.receive_streams.get(&1).unwrap();
+            assert_eq!(
+                size,
+                queue.get_num_bytes(),
+                "abandoned fragments still occupy rwnd: unordered={unordered}, size={size}, lost_fragment={lost_fragment}"
+            );
+            let chunks = receiver
+                .stream(1)?
+                .read_sctp()?
+                .expect("the complete message must remain readable");
+            let mut received = vec![0; size];
+            assert_eq!(size, chunks.read(&mut received)?);
+            assert_eq!(delivered.as_ref(), received.as_slice());
+            assert!(receiver.stream(1)?.read_sctp()?.is_none());
+            assert_eq!(receive_window, receiver.get_my_receiver_window_credit());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_t3_recovers_with_acked_timed_zero_data() -> Result<()> {
+    for gap_ack in [false, true] {
+        let mut a = timed_test_association();
+        let mut receiver = timed_test_association();
+        receiver.peer_last_tsn = a.my_next_tsn.wrapping_sub(1);
+        receiver.incoming_resets = IncomingResetQueue::new(a.my_next_rsn);
+        receiver.ack_mode = AckMode::NoDelay;
+        a.rto_mgr.set_rto(1000, false);
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?
+            .set_reliability_params(true, ReliabilityType::Timed, 100)?;
+        a.open_stream(2, ppi)?
+            .set_reliability_params(true, ReliabilityType::Timed, 0)?;
+        receiver
+            .open_stream(2, ppi)?
+            .set_reliability_params(true, ReliabilityType::Timed, 0)?;
+        let mut now = Instant::now();
+        a.stream(1)?
+            .write_sctp(now, &Bytes::from_static(b"lost timed message"), ppi)?;
+        a.gather_outbound(now);
+        for round in 1..=8 {
+            now = a
+                .poll_timeout()
+                .expect("unacknowledged DATA needs a T3 timer");
+            a.handle_timeout(now);
+            let packets = a.gather_outbound(now).0;
+            assert_eq!(
+                0,
+                data_chunks(&packets),
+                "expired DATA must not be retransmitted"
+            );
+            let forwards: Vec<ChunkForwardTsn> = packets
+                .iter()
+                .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+                .filter_map(|c| c.as_any().downcast_ref::<ChunkForwardTsn>().cloned())
+                .collect();
+            assert!(
+                !forwards.is_empty(),
+                "round {round}, gap_ack={gap_ack}: T3 stopped producing FORWARD TSN despite peer progress"
+            );
+            if !gap_ack {
+                for forward in &forwards {
+                    receiver.handle_forward_tsn(forward)?;
+                }
+            }
+            // Deliver fresh Timed(0) DATA. Drop FORWARD TSN in the gap-ACK case
+            // so the actual DATA receipt must clear T3's error counter there too.
+            a.stream(2)?.write_sctp(
+                now,
+                &Bytes::from_static(b"delivered timed zero message"),
+                ppi,
+            )?;
+            for raw in a.gather_outbound(now).0 {
+                for c in Packet::unmarshal(&raw)?.chunks {
+                    if let Some(data) = c.as_any().downcast_ref::<ChunkPayloadData>() {
+                        receiver.handle_data(data)?;
+                    }
+                }
+            }
+            assert!(
+                receiver.stream(2)?.read_sctp()?.is_some(),
+                "fresh Timed(0) DATA reached the peer"
+            );
+            let sack = receiver.create_selective_ack_chunk();
+            if gap_ack {
+                assert!(!sack.gap_ack_blocks.is_empty());
+            } else {
+                assert_eq!(a.my_next_tsn.wrapping_sub(1), sack.cumulative_tsn_ack);
+            }
+            // Keep new traffic in flight when the preceding DATA is ACKed.
+            a.stream(1)?
+                .write_sctp(now, &Bytes::from_static(b"lost timed message"), ppi)?;
+            a.gather_outbound(now);
+            a.handle_sack(&sack, now + Duration::from_millis(10))?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_zero_fragment_loss_restores_receive_window() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    sender.cwnd = 1400;
+    receiver.peer_last_tsn = sender.my_next_tsn - 1;
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender
+        .open_stream(1, ppi)?
+        .set_reliability_params(true, ReliabilityType::Timed, 0)?;
+    receiver.open_stream(1, ppi)?;
+    sender
+        .stream(1)?
+        .write_sctp(now, &Bytes::from(vec![0x55; 4000]), ppi)?;
+    let lost = sender.gather_outbound(now).0;
+    assert_eq!(1, lost.len());
+    assert!(!sender.pending_queue.is_empty());
+    let at = sender.poll_timeout().unwrap();
+    sender.handle_timeout(at);
+    for _ in 0..10 {
+        let packets = sender.gather_outbound(at).0;
+        for raw in packets {
+            for c in Packet::unmarshal(&raw)?.chunks {
+                if let Some(c) = c.as_any().downcast_ref::<ChunkPayloadData>() {
+                    receiver.handle_data(c)?;
+                } else if let Some(c) = c.as_any().downcast_ref::<ChunkForwardTsn>() {
+                    receiver.handle_forward_tsn(c)?;
+                }
+            }
+        }
+        sender.handle_sack(&receiver.create_selective_ack_chunk(), at)?;
+        while receiver.stream(1)?.read_sctp()?.is_some() {}
+        if sender.pending_queue.is_empty() && sender.inflight_queue.is_empty() {
+            break;
+        }
+    }
+    assert!(sender.pending_queue.is_empty());
+    assert!(sender.inflight_queue.is_empty());
+    assert!(sender.poll_timeout().is_none());
+    assert_eq!(
+        0,
+        receiver.receive_streams.get(&1).unwrap().get_num_bytes(),
+        "abandoned Timed(0) message must not strand ACKed tail fragments in rwnd"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_late_real_data_acks_keep_t3_alive() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    sender.rto_mgr.set_rto(1000, false);
+    receiver.peer_last_tsn = sender.my_next_tsn - 1;
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender
+        .open_stream(1, ppi)?
+        .set_reliability_params(true, ReliabilityType::Timed, 100)?;
+    receiver.open_stream(1, ppi)?;
+    let deliver_new_data =
+        |sender: &mut Association, receiver: &mut Association, at: Instant| -> Result<()> {
+            sender
+                .stream(1)?
+                .write_sctp(at, &Bytes::from_static(b"actually received"), ppi)?;
+            let mut delivered = 0;
+            for raw in sender.gather_outbound(at).0 {
+                for c in Packet::unmarshal(&raw)?.chunks {
+                    if let Some(c) = c.as_any().downcast_ref::<ChunkPayloadData>() {
+                        receiver.handle_data(c)?;
+                        delivered += 1;
+                    }
+                }
+            }
+            assert_eq!(1, delivered);
+            assert!(receiver.stream(1)?.read_sctp()?.is_some());
+            Ok(())
+        };
+    deliver_new_data(&mut sender, &mut receiver, Instant::now())?;
+    for round in 1..=5 {
+        let at = sender.poll_timeout().unwrap();
+        let previous_ack = receiver.create_selective_ack_chunk();
+        sender.handle_timeout(at);
+        // Ignore the retransmission/FORWARD TSN: the peer already received this DATA.
+        sender.gather_outbound(at);
+        // A busy sender has the next message in flight when the old SACK arrives.
+        if round < 5 {
+            deliver_new_data(&mut sender, &mut receiver, at)?;
+        } else {
+            sender.open_stream(2, ppi)?.write_sctp(
+                at,
+                &Bytes::from_static(b"reliable, first send lost"),
+                ppi,
+            )?;
+            assert!(!sender.gather_outbound(at).0.is_empty());
+        }
+        sender.handle_sack(&previous_ack, at + Duration::from_millis(10))?;
+    }
+    let at = sender.poll_timeout().unwrap();
+    sender.handle_timeout(at);
+    let retried_reliable = sender
+        .gather_outbound(at)
+        .0
+        .iter()
+        .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+        .filter(|c| {
+            c.as_any()
+                .downcast_ref::<ChunkPayloadData>()
+                .is_some_and(|c| c.stream_identifier == 2)
+        })
+        .count();
+    assert_eq!(
+        1,
+        retried_reliable,
+        "T3 must retry the lost reliable DATA after five successful but late timed DATA ACKs; timer={:?}",
+        sender.poll_timeout()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_message_abandonment_is_idempotent_after_partial_and_late_acks() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.cwnd = 2 * a.max_payload_size + 1;
+        let cumulative_ack = a.my_next_tsn.wrapping_sub(1);
+        a.open_stream(2, ppi)?
+            .write_sctp(now, &Bytes::from_static(b"x"), ppi)?;
+        a.gather_outbound(now); // Leave a gap before the fragmented message.
+        let first = a.my_next_tsn;
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+        stream.write_sctp(now, &Bytes::from(vec![0; 4000]), ppi)?;
+        stream.write_sctp(now, &Bytes::from_static(b"next"), ppi)?;
+        assert_eq!(2, data_chunks(&a.gather_outbound(now).0));
+        let mut sack = ChunkSelectiveAck {
+            cumulative_tsn_ack: cumulative_ack,
+            advertised_receiver_window_credit: 65536,
+            gap_ack_blocks: vec![crate::chunk::chunk_selective_ack::GapAckBlock {
+                start: 2,
+                end: 2,
+            }],
+            ..Default::default()
+        };
+        a.handle_sack(&sack, now + Duration::from_millis(50))?;
+        while a.poll().is_some() {}
+        let at = now + Duration::from_millis(100);
+        let messages = a.unretransmittable_messages(at, ChunkPayloadData::is_outstanding);
+        assert_eq!(1, messages.len());
+        let message = messages[0];
+        assert!(a.abandon_message(message));
+        let released: usize = std::iter::from_fn(|| a.poll())
+            .filter_map(|event| {
+                if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) = event {
+                    Some(n_bytes)
+                } else {
+                    None
+                }
+            })
+            .sum();
+        assert_eq!(4000 - a.max_payload_size as usize, released);
+        assert!(!a.abandon_message(message));
+        assert!(
+            a.poll().is_none(),
+            "repeated abandonment must not release bytes twice"
+        );
+        assert_eq!(4, a.pending_queue.get_num_bytes());
+        assert_eq!(4, a.stream(1)?.buffered_amount()?);
+        assert_eq!(
+            Bytes::from_static(b"next"),
+            a.pending_queue.peek().unwrap().user_data
+        );
+        for offset in 0..3 {
+            let c = a.inflight_queue.get(first.wrapping_add(offset)).unwrap();
+            assert!(c.abandoned());
+            assert!(!c.is_outstanding());
+            assert!(c.user_data.is_empty());
+        }
+        assert!(!a.inflight_queue.get(first + 1).unwrap().acknowledged);
+        // A late real ACK changes receipt state, without reclaiming payload again.
+        sack.gap_ack_blocks[0].end = 3;
+        a.handle_sack(&sack, at)?;
+        a.handle_sack(&sack, at + Duration::from_millis(1))?;
+        assert!(a.inflight_queue.get(first + 1).unwrap().acknowledged);
+        assert!(!a.inflight_queue.get(first + 2).unwrap().acknowledged);
+        assert!(a.poll().is_none());
+        assert!(!a.abandon_message(message));
+        assert_eq!(4, a.stream(1)?.buffered_amount()?);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_repeated_pending_abandonment_preserves_the_next_message() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let first_tsn = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(true, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from(vec![0; 4000]), ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"next"), ppi)?;
+    let message = a.pending_message_to_abandon();
+    assert!(a.abandon_message(message));
+    assert!(!a.abandon_message(message));
+    a.on_messages_abandoned(now + Duration::from_millis(100));
+    assert_eq!(first_tsn, a.my_next_tsn);
+    assert!(a.inflight_queue.is_empty());
+    assert!(a.poll_timeout().is_none());
+    assert_eq!(4, a.stream(1)?.buffered_amount()?);
+    assert_eq!(
+        Bytes::from_static(b"next"),
+        a.pending_queue.peek().unwrap().user_data
+    );
+    Ok(())
+}
+
+#[test]
+fn test_split_reciprocal_reset_waits_for_ack() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?;
+    a.open_stream(2, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"queued"), ppi)?;
+    let reply = a.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                sender_last_tsn: a.peer_last_tsn,
+                stream_identifiers: vec![1, 2],
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+    )?;
+    let mut packets: Vec<_> = reply.iter().map(|p| p.marshal().unwrap()).collect();
+    packets.extend(a.gather_outbound(now).0);
+    packets.extend(a.gather_outbound(now).0);
+    let requests = reset_requests(&packets);
+    assert_eq!(
+        1,
+        requests.len(),
+        "RFC 6525 5.1.1 permits only one request in flight"
+    );
+    assert_eq!(vec![1], requests[0].stream_identifiers);
+    assert_eq!(
+        1,
+        data_chunks(&packets),
+        "other streams' earlier DATA may still send"
+    );
+    receive_reset_response(&mut a, now, &requests[0], ReconfigResult::SuccessPerformed)?;
+    let next = reset_requests(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(vec![2], next.stream_identifiers);
+    assert_ne!(
+        requests[0].reconfig_request_sequence_number,
+        next.reconfig_request_sequence_number
+    );
+    assert_eq!(a.my_next_tsn - 1, next.sender_last_tsn);
+    receive_reset_response(&mut a, now, &next, ReconfigResult::SuccessPerformed)?;
+    assert!(a.outgoing_reset.is_none());
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+    Ok(())
+}
+
+fn receive_reset_response(
+    a: &mut Association,
+    now: Instant,
+    request: &ParamOutgoingResetRequest,
+    result: ReconfigResult,
+) -> Result<()> {
+    a.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_a: Some(Box::new(ParamReconfigResponse {
+                reconfig_response_sequence_number: request.reconfig_request_sequence_number,
+                result,
+            })),
+            ..Default::default()
+        },
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_implicit_reset_ack_holds_next_request_until_result() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.close(now)?;
+    let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+    a.open_stream(2, ppi)?.close(now)?;
+    let implicit = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn.wrapping_add(1),
+        stream_identifiers: vec![1],
+    };
+    a.handle_reconfig(now, &reset_config(&implicit))?;
+    assert!(
+        a.timers.get(Timer::Reconfig).is_none(),
+        "E1 stops the timer"
+    );
+    assert!(a.streams.contains_key(&1), "receipt cannot finish RX reset");
+    assert!(
+        reset_requests(&a.gather_outbound(now).0).is_empty(),
+        "N+1 waits for N's result"
+    );
+    receive_reset_response(&mut a, now, &first, ReconfigResult::SuccessPerformed)?;
+    assert!(
+        reset_requests(&a.gather_outbound(now).0).is_empty(),
+        "H1 ignores result without timer"
+    );
+    let at = a.poll_timeout().unwrap();
+    a.handle_timeout(at);
+    assert_eq!(
+        vec![first.clone()],
+        reset_requests(&a.gather_outbound(at).0)
+    );
+    receive_reset_response(&mut a, at, &first, ReconfigResult::SuccessPerformed)?;
+    let next = reset_requests(&a.gather_outbound(at).0).remove(0);
+    assert_eq!(vec![2], next.stream_identifiers);
+    let timer = a.timers.get(Timer::Reconfig);
+    receive_reset_response(&mut a, at, &first, ReconfigResult::Denied)?;
+    assert_eq!(timer, a.timers.get(Timer::Reconfig));
+    assert_eq!(next, a.outgoing_reset.as_ref().unwrap().request);
+    Ok(())
+}
+
+#[test]
+fn test_in_progress_reset_retries_without_exhausting_error_limit() -> Result<()> {
+    let mut a = timed_test_association();
+    let mut now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.close(now)?;
+    let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+    a.open_stream(2, ppi)?.close(now)?;
+    receive_reset_response(&mut a, now, &first, ReconfigResult::InProgress)?;
+    for _ in 0..8 {
+        now = a.timers.get(Timer::Reconfig).unwrap();
+        a.handle_timeout(now);
+        let requests = reset_requests(&a.gather_outbound(now).0);
+        assert_eq!(vec![first.clone()], requests);
+        assert_eq!(AssociationState::Established, a.state());
+    }
+    receive_reset_response(&mut a, now, &first, ReconfigResult::SuccessPerformed)?;
+    let next = reset_requests(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(vec![2], next.stream_identifiers);
+    // The next request has a fresh interval and its own error budget.
+    assert_eq!(
+        Some(now + Duration::from_secs(1)),
+        a.timers.get(Timer::Reconfig)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_reset_retry_exhaustion_closes_association_and_notifies_streams() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.close(now)?;
+    a.gather_outbound(now);
+    a.open_stream(2, ppi)?.close(now)?;
+    for _ in 0..6 {
+        let at = a.timers.get(Timer::Reconfig).unwrap();
+        a.handle_timeout(at);
+        a.gather_outbound(at);
+    }
+    assert!(a.is_closed());
+    assert!(a.is_idle());
+    assert!(a.outgoing_reset.is_none());
+    let mut closed = vec![];
+    while let Some(event) = a.poll() {
+        if let Event::AssociationLost { id, reason } = event {
+            assert_eq!(AssociationError::TimedOut, reason);
+            closed.push(id);
+        }
+    }
+    closed.sort_unstable();
+    assert_eq!(vec![1, 2], closed);
+    Ok(())
+}
+
+#[test]
+fn test_serialized_resets_and_reused_sid_do_not_block_other_streams() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?.close(now)?;
+        let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+        receive_reset_response(&mut a, now, &first, ReconfigResult::InProgress)?;
+        a.open_stream(2, ppi)?;
+        a.handle_reconfig(
+            now,
+            &ChunkReconfig {
+                param_a: Some(Box::new(ParamOutgoingResetRequest {
+                    reconfig_request_sequence_number: 1,
+                    reconfig_response_sequence_number: first
+                        .reconfig_request_sequence_number
+                        .wrapping_sub(1),
+                    sender_last_tsn: a.peer_last_tsn,
+                    stream_identifiers: vec![2],
+                })),
+                ..Default::default()
+            },
+        )?;
+        let mut reused = a.open_stream(2, ppi)?;
+        reused.set_reliability_params(unordered, ReliabilityType::Reliable, 0)?;
+        reused.write_sctp(now, &Bytes::from_static(b"new"), ppi)?;
+        a.open_stream(3, ppi)?
+            .write_sctp(now, &Bytes::from_static(b"other"), ppi)?;
+        let packets = a.gather_outbound(now).0;
+        assert!(reset_requests(&packets).is_empty());
+        let data: Vec<_> = packets
+            .iter()
+            .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+            .filter_map(|c| c.as_any().downcast_ref::<ChunkPayloadData>().cloned())
+            .collect();
+        assert_eq!(1, data.len());
+        assert_eq!(3, data[0].stream_identifier);
+        assert_eq!(3, a.stream(2)?.buffered_amount()?);
+        receive_reset_response(&mut a, now, &first, ReconfigResult::SuccessPerformed)?;
+        let packets = a.gather_outbound(now).0;
+        let next = reset_requests(&packets).remove(0);
+        assert_eq!(vec![2], next.stream_identifiers);
+        assert_eq!(data[0].tsn, next.sender_last_tsn);
+        assert_eq!(0, data_chunks(&packets));
+        assert_eq!(0, data_chunks(&a.gather_outbound(now).0));
+        receive_reset_response(&mut a, now, &next, ReconfigResult::SuccessPerformed)?;
+        let (data, _) = a.pop_pending_data_chunks_to_send(now);
+        assert_eq!(1, data.len());
+        assert_eq!(2, data[0].stream_identifier);
+        assert!(sna32gt(data[0].tsn, next.sender_last_tsn));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rexmit_zero_policy_survives_peer_reset() -> Result<()> {
+    rexmit_after_peer_reset(false)
+}
+
+#[test]
+fn test_rexmit_zero_policy_survives_sid_reuse() -> Result<()> {
+    rexmit_after_peer_reset(true)
+}
+
+fn rexmit_after_peer_reset(reuse_sid: bool) -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(true, ReliabilityType::Rexmit, 0)?;
+    stream.write_sctp(now, &Bytes::from_static(b"lost maxRetransmits=0 DATA"), ppi)?;
+    assert_eq!(1, data_chunks(&a.gather_outbound(now).0));
+    defer_reset(&mut a)?;
+    a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 12,
+        ..Default::default()
+    })?;
+    assert!(!a.streams.contains_key(&1));
+    if reuse_sid {
+        a.open_stream(1, ppi)?;
+    }
+    let at = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(at);
+    let packets = a.gather_outbound(at).0;
+    assert_eq!(
+        0,
+        data_chunks(&packets),
+        "peer reset erased maxRetransmits=0 policy; reuse_sid={reuse_sid}"
+    );
+    assert!(packets.iter().any(|raw| {
+        Packet::unmarshal(raw)
+            .unwrap()
+            .chunks
+            .iter()
+            .any(|c| c.as_any().is::<ChunkForwardTsn>())
+    }));
+    Ok(())
+}
+
+#[test]
+fn test_queued_message_keeps_its_original_reliability_policy() -> Result<()> {
+    use ReliabilityType::{Reliable, Rexmit, Timed};
+    for (original, value, replacement, ppi, forward_tsn, retransmit) in [
+        (
+            Reliable,
+            0,
+            Rexmit,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            true,
+        ),
+        (
+            Rexmit,
+            0,
+            Reliable,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            false,
+        ),
+        (
+            Rexmit,
+            2,
+            Rexmit,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            true,
+        ),
+        (
+            Timed,
+            100,
+            Reliable,
+            PayloadProtocolIdentifier::Binary,
+            true,
+            false,
+        ),
+        (
+            Rexmit,
+            0,
+            Reliable,
+            PayloadProtocolIdentifier::Dcep,
+            true,
+            true,
+        ),
+        (
+            Rexmit,
+            0,
+            Reliable,
+            PayloadProtocolIdentifier::Binary,
+            false,
+            true,
+        ),
+    ] {
+        let mut a = timed_test_association();
+        a.use_forward_tsn = forward_tsn;
+        let now = Instant::now();
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(false, original, value)?;
+        stream.write_sctp(now, &Bytes::from_static(b"queued"), ppi)?;
+        // Policy is captured at enqueue, before even the first transmission.
+        stream.set_reliability_params(false, replacement, 0)?;
+        assert_eq!(1, data_chunks(&a.gather_outbound(now).0));
+        let at = a.timers.get(Timer::T3RTX).unwrap();
+        a.handle_timeout(at);
+        assert_eq!(
+            usize::from(retransmit),
+            data_chunks(&a.gather_outbound(at).0),
+            "original={original:?} value={value} replacement={replacement:?} ppi={ppi:?} forward_tsn={forward_tsn}"
+        );
+        assert_eq!(
+            if retransmit { 6 } else { 0 },
+            a.stream(1)?.buffered_amount()?
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rexmit_budget_counts_fast_and_timer_retransmissions_after_reset() -> Result<()> {
+    for max_retransmits in [0, 1, 2] {
+        for reset in [None, Some(false), Some(true)] {
+            for fast_first in [false, true] {
+                let mut a = timed_test_association();
+                let now = Instant::now();
+                let ppi = PayloadProtocolIdentifier::Binary;
+                let first_tsn = a.my_next_tsn;
+                let mut stream = a.open_stream(1, ppi)?;
+                stream.set_reliability_params(true, ReliabilityType::Rexmit, max_retransmits)?;
+                stream.write_sctp(now, &Bytes::from_static(b"lost"), ppi)?;
+                assert_eq!(1, data_chunks(&a.gather_outbound(now).0));
+                if let Some(reuse_sid) = reset {
+                    defer_reset(&mut a)?;
+                    a.handle_forward_tsn(&ChunkForwardTsn {
+                        new_cumulative_tsn: 12,
+                        ..Default::default()
+                    })?;
+                    assert!(!a.streams.contains_key(&1));
+                    if reuse_sid {
+                        a.open_stream(1, ppi)?;
+                    }
+                }
+                for attempt in 0..=max_retransmits {
+                    let at = if fast_first && attempt == 0 {
+                        a.inflight_queue.get_mut(first_tsn).unwrap().miss_indicator = 3;
+                        a.will_retransmit_fast = true;
+                        now + Duration::from_millis(1)
+                    } else {
+                        let at = a.timers.get(Timer::T3RTX).unwrap();
+                        a.handle_timeout(at);
+                        at
+                    };
+                    let packets = a.gather_outbound(at).0;
+                    let retransmit = attempt < max_retransmits;
+                    assert_eq!(
+                        usize::from(retransmit),
+                        data_chunks(&packets),
+                        "max_retransmits={max_retransmits} attempt={attempt} reset={reset:?} fast_first={fast_first}"
+                    );
+                    let chunk = a.inflight_queue.get(first_tsn).unwrap();
+                    assert_eq!(!retransmit, chunk.abandoned());
+                    assert_eq!(
+                        if retransmit { 4 } else { 0 },
+                        a.inflight_queue.get_num_bytes()
+                    );
+                    if !retransmit {
+                        assert!(packets.iter().any(|raw| {
+                            Packet::unmarshal(raw)
+                                .unwrap()
+                                .chunks
+                                .iter()
+                                .any(|c| c.as_any().is::<ChunkForwardTsn>())
+                        }));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rexmit_zero_reset_abandons_acked_and_pending_fragments() -> Result<()> {
+    for unordered in [false, true] {
+        for ack_prefix in [false, true] {
+            let mut a = timed_test_association();
+            a.cwnd = 2 * a.max_payload_size;
+            let now = Instant::now();
+            let first_tsn = a.my_next_tsn;
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let mut stream = a.open_stream(1, ppi)?;
+            stream.set_reliability_params(unordered, ReliabilityType::Rexmit, 0)?;
+            stream.write_sctp(now, &Bytes::from(vec![0; 4000]), ppi)?;
+            assert_eq!(2, data_chunks(&a.gather_outbound(now).0));
+            a.handle_sack(
+                &ChunkSelectiveAck {
+                    cumulative_tsn_ack: if ack_prefix { first_tsn } else { first_tsn - 1 },
+                    advertised_receiver_window_credit: 65536,
+                    gap_ack_blocks: if ack_prefix {
+                        vec![]
+                    } else {
+                        vec![crate::chunk::chunk_selective_ack::GapAckBlock { start: 2, end: 2 }]
+                    },
+                    ..Default::default()
+                },
+                now + Duration::from_millis(1),
+            )?;
+            defer_reset(&mut a)?;
+            a.handle_forward_tsn(&ChunkForwardTsn {
+                new_cumulative_tsn: 12,
+                ..Default::default()
+            })?;
+            a.open_stream(1, ppi)?
+                .write_sctp(now, &Bytes::from_static(b"new"), ppi)?;
+            let at = a.timers.get(Timer::T3RTX).unwrap();
+            a.handle_timeout(at);
+            let packets = a.gather_outbound(at).0;
+            assert_eq!(0, data_chunks(&packets));
+            assert_eq!(0, a.inflight_queue.get_num_bytes());
+            assert_eq!(3, a.pending_queue.get_num_bytes());
+            assert_eq!(3, a.stream(1)?.buffered_amount()?);
+            let last_tsn = first_tsn + 2;
+            for tsn in first_tsn..=last_tsn {
+                if let Some(c) = a.inflight_queue.get(tsn) {
+                    assert!(c.abandoned());
+                    assert!(!c.retransmit);
+                }
+            }
+            assert_eq!(last_tsn, a.advanced_peer_tsn_ack_point);
+            let reset = reset_requests(&packets).remove(0);
+            assert_eq!(last_tsn, reset.sender_last_tsn);
+            receive_reset_response(&mut a, at, &reset, ReconfigResult::SuccessPerformed)?;
+            assert_eq!(1, data_chunks(&a.gather_outbound(at).0));
+            a.handle_sack(
+                &ChunkSelectiveAck {
+                    cumulative_tsn_ack: last_tsn,
+                    advertised_receiver_window_credit: 65536,
+                    ..Default::default()
+                },
+                at,
+            )?;
+            assert_eq!(
+                3,
+                a.stream(1)?.buffered_amount()?,
+                "old ACK must not release new DATA"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn transmitted_data(packets: &[Bytes]) -> Vec<ChunkPayloadData> {
+    packets
+        .iter()
+        .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+        .filter_map(|c| c.as_any().downcast_ref::<ChunkPayloadData>().cloned())
+        .collect()
+}
+
+#[test]
+fn test_rexmit_one_waits_for_ack_of_first_retry() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut s = a.open_stream(1, ppi)?;
+    s.set_reliability_params(false, ReliabilityType::Rexmit, 1)?;
+    s.write_sctp(now, &Bytes::from(vec![0x55; 2000]), ppi)?;
+    let initial = transmitted_data(&a.gather_outbound(now).0);
+    assert_eq!(2, initial.len());
+    let at = a.poll_timeout().unwrap();
+    a.handle_timeout(at);
+    let first_retry = transmitted_data(&a.gather_outbound(at).0);
+    assert_eq!(1, first_retry.len());
+    assert_eq!(initial[0].tsn, first_retry[0].tsn);
+    // The normal driver drains poll_transmit until None at the same instant.
+    let more = a.gather_outbound(at).0;
+    assert!(
+        a.inflight_queue
+            .get(initial[0].tsn)
+            .unwrap()
+            .is_outstanding(),
+        "a just-retried fragment must wait for ACK or a new loss indication; second drain emitted {more:?}"
+    );
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: initial[0].tsn,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        at + Duration::from_millis(10),
+    )?;
+    // The tail may be emitted by either drain. In both cases each fragment
+    // gets its permitted retry and remains outstanding until the peer ACKs it.
+    let mut tail_retry = transmitted_data(&more);
+    tail_retry.extend(transmitted_data(
+        &a.gather_outbound(at + Duration::from_millis(10)).0,
+    ));
+    assert_eq!(1, tail_retry.len());
+    assert_eq!(initial[1].tsn, tail_retry[0].tsn);
+    assert!(
+        a.inflight_queue
+            .get(initial[1].tsn)
+            .unwrap()
+            .is_outstanding()
+    );
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = initial[0].tsn - 1;
+    for chunk in first_retry.iter().chain(tail_retry.iter()) {
+        receiver.handle_data(chunk)?;
+    }
+    assert_eq!(2000, receiver.stream(1)?.read_sctp()?.unwrap().len());
+    a.handle_sack(
+        &receiver.create_selective_ack_chunk(),
+        at + Duration::from_millis(20),
+    )?;
+    assert!(a.inflight_queue.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_fast_retry_does_not_abandon_unsent_fragment_tail_of_new_rexmit_zero() -> Result<()> {
+    for policy in [ReliabilityType::Rexmit, ReliabilityType::Timed] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?
+            .write_sctp(now, &Bytes::from_static(b"lost reliable"), ppi)?;
+        let old = transmitted_data(&a.gather_outbound(now).0).remove(0);
+        // Three real gap ACK reports request a fast retransmission for stream 1.
+        for _ in 0..3 {
+            a.stream(1)?
+                .write_sctp(now, &Bytes::from_static(b"received"), ppi)?;
+        }
+        a.gather_outbound(now);
+        for end in 2..=4 {
+            a.handle_sack(
+                &ChunkSelectiveAck {
+                    cumulative_tsn_ack: old.tsn - 1,
+                    advertised_receiver_window_credit: 65536,
+                    gap_ack_blocks: vec![crate::chunk::chunk_selective_ack::GapAckBlock {
+                        start: 2,
+                        end,
+                    }],
+                    ..Default::default()
+                },
+                now,
+            )?;
+        }
+        assert!(a.will_retransmit_fast);
+        let mut fresh = a.open_stream(2, ppi)?;
+        fresh.set_reliability_params(false, policy, 0)?;
+        fresh.write_sctp(now, &Bytes::from(vec![0x33; 16000]), ppi)?;
+        let sent = a.gather_outbound(now).0;
+        assert!(
+            transmitted_data(&sent)
+                .iter()
+                .any(|c| c.stream_identifier == 1)
+        );
+        assert!(
+            transmitted_data(&sent)
+                .iter()
+                .any(|c| c.stream_identifier == 2)
+        );
+        assert!(
+            !a.pending_queue.is_empty(),
+            "an unrelated fast retry discarded never-sent fragments of fresh DATA"
+        );
+        assert_eq!(16000, a.stream(2)?.buffered_amount()?);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_write_after_stop_uses_reset_ssn() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = sender.my_next_tsn - 1;
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender
+        .open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"old"), ppi)?;
+    for d in transmitted_data(&sender.gather_outbound(now).0) {
+        receiver.handle_data(&d)?;
+    }
+    assert!(receiver.stream(1)?.read_sctp()?.is_some());
+    sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+    sender.stream(1)?.stop(now)?;
+    assert!(sender.stream(1)?.is_writable());
+    sender
+        .stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"new"), ppi)?;
+    let mut payloads = Vec::new();
+    for raw in sender.gather_outbound(now).0 {
+        for c in Packet::unmarshal(&raw)?.chunks {
+            if let Some(d) = c.as_any().downcast_ref::<ChunkPayloadData>() {
+                receiver.handle_data(d)?;
+                if let Some(msg) = receiver.stream(1)?.read_sctp()? {
+                    payloads.push(msg);
+                }
+            } else if let Some(r) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                for response in receiver.handle_reconfig(now, r)? {
+                    for c in response.chunks {
+                        if let Some(r) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                            sender.handle_reconfig(now, r)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for d in transmitted_data(&sender.gather_outbound(now).0) {
+        receiver.handle_data(&d)?;
+        if let Some(msg) = receiver.stream(1)?.read_sctp()? {
+            payloads.push(msg);
+        }
+    }
+    assert_eq!(
+        1,
+        payloads.len(),
+        "queued writes resume with the old SSN after successful reset and remain unreadable"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_old_forward_ssn_needed_until_reciprocal_reset_is_acknowledged() -> Result<()> {
+    for reopen in [false, true] {
+        for abandon_before_reopen in [false, true] {
+            let mut sender = timed_test_association();
+            let mut receiver = timed_test_association();
+            receiver.peer_last_tsn = sender.my_next_tsn - 1;
+            receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+            let now = Instant::now();
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let mut stream = sender.open_stream(1, ppi)?;
+            stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+            stream.write_sctp(now, &Bytes::from_static(b"lost ssn zero"), ppi)?;
+            stream.write_sctp(now, &Bytes::from_static(b"received ssn one"), ppi)?;
+            let sent = transmitted_data(&sender.gather_outbound(now).0);
+            assert_eq!(2, sent.len());
+            // Peer has ACKed the second message, but cannot deliver it until SSN 0 is skipped.
+            receiver.handle_data(&sent[1])?;
+            assert!(receiver.stream(1)?.read_sctp()?.is_none());
+            sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+            // Let the sender abandon SSN 0 and build its forward map; lose these packets.
+            // A second timeout also puts the unpatched base on the FORWARD TSN path.
+            let mut at = now;
+            if abandon_before_reopen {
+                for _ in 0..2 {
+                    at = sender.timers.get(Timer::T3RTX).unwrap();
+                    sender.handle_timeout(at);
+                    sender.gather_outbound(at);
+                }
+            }
+            // Peer closes its own outgoing direction while it still expects our queued sends.
+            let peer_request = ChunkReconfig {
+                param_a: Some(Box::new(ParamOutgoingResetRequest {
+                    reconfig_request_sequence_number: 1,
+                    sender_last_tsn: sender.peer_last_tsn,
+                    stream_identifiers: vec![1],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            let mut packets = sender.handle_reconfig(at, &peer_request)?;
+            assert!(sender.stream(1).is_err());
+            if reopen {
+                sender.open_stream(1, ppi)?;
+            }
+            if !abandon_before_reopen {
+                at = sender.timers.get(Timer::T3RTX).unwrap();
+                sender.handle_timeout(at);
+            }
+            // Repeat the gap ACK so the outstanding FORWARD TSN is generated again.
+            sender.handle_sack(&receiver.create_selective_ack_chunk(), at)?;
+            packets.extend(
+                sender
+                    .gather_outbound(at)
+                    .0
+                    .iter()
+                    .map(|raw| Packet::unmarshal(raw).unwrap()),
+            );
+            // Our reciprocal reset reaches the peer before FORWARD TSN; the peer defers it.
+            for packet in &packets {
+                for c in &packet.chunks {
+                    if let Some(r) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                        receiver.handle_reconfig(at, r)?;
+                    }
+                }
+            }
+            for packet in &packets {
+                for c in &packet.chunks {
+                    if let Some(f) = c.as_any().downcast_ref::<ChunkForwardTsn>() {
+                        receiver.handle_forward_tsn(f)?;
+                    }
+                }
+            }
+            assert!(
+                receiver
+                    .stream(1)
+                    .is_ok_and(|mut s| s.read_sctp().is_ok_and(|m| m.is_some())),
+                "already acknowledged message was discarded by reset because FORWARD TSN omitted old SSN; reopen={reopen}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_reset_result_renumbers_only_released_messages() -> Result<()> {
+    for result in [
+        ReconfigResult::SuccessPerformed,
+        ReconfigResult::SuccessNop,
+        ReconfigResult::Denied,
+    ] {
+        for initial_ssn in [3u16, u16::MAX] {
+            for queued in [false, true] {
+                let mut a = timed_test_association();
+                a.cwnd = 65536;
+                let now = Instant::now();
+                let ppi = PayloadProtocolIdentifier::Binary;
+                a.open_stream(1, ppi)?;
+                a.transmit_streams.entry(1).or_default().next_ssn = initial_ssn;
+                a.stream(1)?
+                    .write_sctp(now, &Bytes::from_static(b"old"), ppi)?;
+                let old_tsn = transmitted_data(&a.gather_outbound(now).0)[0].tsn;
+                a.stream(1)?.stop(now)?;
+                if queued {
+                    a.stream(1)?
+                        .write_sctp(now, &Bytes::from(vec![7; 4000]), ppi)?;
+                    a.stream(1)?
+                        .write_sctp(now, &Bytes::from_static(b"next"), ppi)?;
+                }
+                let packets = a.gather_outbound(now).0;
+                assert_eq!(0, data_chunks(&packets));
+                let reset = reset_requests(&packets).remove(0);
+                receive_reset_response(&mut a, now, &reset, ReconfigResult::InProgress)?;
+                assert_eq!(0, data_chunks(&a.gather_outbound(now).0));
+                receive_reset_response(&mut a, now, &reset, result)?;
+                let first_ssn = if result == ReconfigResult::Denied {
+                    initial_ssn.wrapping_add(1)
+                } else {
+                    0
+                };
+                let chunks = transmitted_data(&a.gather_outbound(now).0);
+                if queued {
+                    assert_eq!(4, chunks.len());
+                    assert!(
+                        chunks[..3]
+                            .iter()
+                            .all(|c| c.stream_sequence_number == first_ssn)
+                    );
+                    assert_eq!(first_ssn.wrapping_add(1), chunks[3].stream_sequence_number);
+                } else {
+                    assert!(chunks.is_empty());
+                }
+                let next_ssn = first_ssn.wrapping_add(if queued { 2 } else { 0 });
+                a.stream(1)?
+                    .write_sctp(now, &Bytes::from_static(b"later"), ppi)?;
+                let chunks = transmitted_data(&a.gather_outbound(now).0);
+                assert_eq!(1, chunks.len());
+                assert_eq!(next_ssn, chunks[0].stream_sequence_number);
+                // A duplicate result cannot restart the SSN counter a second time.
+                receive_reset_response(&mut a, now, &reset, result)?;
+                a.stream(1)?
+                    .write_sctp(now, &Bytes::from_static(b"after duplicate"), ppi)?;
+                let chunks = transmitted_data(&a.gather_outbound(now).0);
+                assert_eq!(next_ssn.wrapping_add(1), chunks[0].stream_sequence_number);
+                a.handle_sack(
+                    &ChunkSelectiveAck {
+                        cumulative_tsn_ack: old_tsn,
+                        advertised_receiver_window_credit: 65536,
+                        ..Default::default()
+                    },
+                    now,
+                )?;
+                assert!(a.confirmed_reset_tsns.is_empty());
+                assert!(a.reset_tsn_ack_queue.is_empty());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_denied_reset_preserves_pending_forward_ssn() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from_static(b"lost"), ppi)?;
+    a.gather_outbound(now);
+    let at = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(at);
+    a.gather_outbound(at);
+    a.stream(1)?.stop(at)?;
+    let reset = reset_requests(&a.gather_outbound(at).0).remove(0);
+    let forward = a.create_forward_tsn();
+    assert_eq!(1, forward.streams.len());
+    receive_reset_response(&mut a, at, &reset, ReconfigResult::Denied)?;
+    assert_eq!(
+        a.marshal_control_chunk(&forward)?,
+        a.marshal_control_chunk(&a.create_forward_tsn())?
+    );
+    assert!(a.confirmed_reset_tsns.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_implicit_ack_does_not_confirm_deferred_reset() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = sender.my_next_tsn - 1;
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = sender.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from_static(b"lost ssn zero"), ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"received ssn one"), ppi)?;
+    let sent = transmitted_data(&sender.gather_outbound(now).0);
+    receiver.handle_data(&sent[1])?;
+    sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+    sender.stream(1)?.close(now)?;
+    let mut our_rsn = None;
+    for raw in sender.gather_outbound(now).0 {
+        for c in Packet::unmarshal(&raw)?.chunks {
+            if let Some(config) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                let request = config
+                    .param_a
+                    .as_ref()
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<ParamOutgoingResetRequest>()
+                    .unwrap();
+                our_rsn = Some(request.reconfig_request_sequence_number);
+                for response in receiver.handle_reconfig(now, config)? {
+                    for c in response.chunks {
+                        if let Some(config) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                            let response = config
+                                .param_a
+                                .as_ref()
+                                .unwrap()
+                                .as_any()
+                                .downcast_ref::<ParamReconfigResponse>()
+                                .unwrap();
+                            assert_eq!(ReconfigResult::InProgress, response.result);
+                            sender.handle_reconfig(now, config)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let our_rsn = our_rsn.unwrap();
+    // A compliant peer sends an unrelated outgoing reset. RFC 6525 A4 puts
+    // its most recently received request number in the response-sequence field,
+    // even though that earlier request is still deferred for missing DATA.
+    sender.open_stream(2, ppi)?;
+    sender.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                reconfig_response_sequence_number: our_rsn,
+                sender_last_tsn: sender.peer_last_tsn,
+                stream_identifiers: vec![2],
+            })),
+            ..Default::default()
+        },
+    )?;
+    let at = sender.timers.get(Timer::T3RTX).unwrap();
+    sender.handle_timeout(at);
+    let forwards: Vec<_> = sender
+        .gather_outbound(at)
+        .0
+        .iter()
+        .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+        .filter_map(|c| c.as_any().downcast_ref::<ChunkForwardTsn>().cloned())
+        .collect();
+    assert!(!forwards.is_empty());
+    for forward in forwards {
+        receiver.handle_forward_tsn(&forward)?;
+    }
+    assert!(
+        receiver
+            .stream(1)
+            .is_ok_and(|mut s| s.read_sctp().is_ok_and(|v| v.is_some())),
+        "an implicit request ACK was treated as reset success; it removed the SSN needed to deliver acknowledged DATA"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pending_reset_can_contain_two_stream_generations() -> Result<()> {
+    for old_len in [32, 4000] {
+        for old_unordered in [false, true] {
+            for new_unordered in [false, true] {
+                for queued_new in [false, true] {
+                    let mut sender = timed_test_association();
+                    sender.cwnd = 65536;
+                    let now = Instant::now();
+                    let ppi = PayloadProtocolIdentifier::Binary;
+                    let mut old = sender.open_stream(1, ppi)?;
+                    old.set_reliability_params(old_unordered, ReliabilityType::Reliable, 0)?;
+                    old.stop(now)?;
+                    old.write_sctp(now, &Bytes::from(vec![7; old_len]), ppi)?;
+                    let reset = reset_requests(&sender.gather_outbound(now).0).remove(0);
+                    // The simultaneous peer reset predates receipt of ours.
+                    sender.handle_reconfig(
+                        now,
+                        &ChunkReconfig {
+                            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                                reconfig_request_sequence_number: 1,
+                                reconfig_response_sequence_number: reset
+                                    .reconfig_request_sequence_number
+                                    .wrapping_sub(1),
+                                sender_last_tsn: sender.peer_last_tsn,
+                                stream_identifiers: vec![1],
+                            })),
+                            ..Default::default()
+                        },
+                    )?;
+                    let mut new = sender.open_stream(1, ppi)?;
+                    new.set_reliability_params(new_unordered, ReliabilityType::Reliable, 0)?;
+                    if queued_new {
+                        new.write_sctp(now, &Bytes::from_static(b"new generation"), ppi)?;
+                    }
+                    receive_reset_response(
+                        &mut sender,
+                        now,
+                        &reset,
+                        ReconfigResult::SuccessPerformed,
+                    )?;
+                    let mut sent = transmitted_data(&sender.gather_outbound(now).0);
+                    sender.stream(1)?.write_sctp(
+                        now,
+                        &Bytes::from_static(b"later new generation"),
+                        ppi,
+                    )?;
+                    sent.extend(transmitted_data(&sender.gather_outbound(now).0));
+                    let mut next_ssn = 0u16;
+                    for chunk in &sent {
+                        if !chunk.unordered {
+                            assert_eq!(next_ssn, chunk.stream_sequence_number);
+                            if chunk.ending_fragment {
+                                next_ssn += 1;
+                            }
+                        }
+                    }
+                    assert_eq!(next_ssn, sender.transmit_streams[&1].next_ssn);
+                    let mut receiver = timed_test_association();
+                    receiver.peer_last_tsn = sent[0].tsn - 1;
+                    for chunk in &sent {
+                        receiver.handle_data(chunk)?;
+                    }
+                    let mut received = 0;
+                    while receiver.stream(1)?.read_sctp()?.is_some() {
+                        received += 1;
+                    }
+                    assert_eq!(if queued_new { 3 } else { 2 }, received);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_implicit_ack_keeps_data_queued_until_result_without_changing_newer_timer() -> Result<()> {
+    for result in [ReconfigResult::SuccessPerformed, ReconfigResult::Denied] {
+        let mut a = timed_test_association();
+        let mut now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?
+            .write_sctp(now, &Bytes::from_static(b"old"), ppi)?;
+        a.stream(1)?.stop(now)?;
+        a.stream(1)?
+            .write_sctp(now, &Bytes::from_static(b"after reset"), ppi)?;
+        let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+        a.handle_sack(
+            &ChunkSelectiveAck {
+                cumulative_tsn_ack: first.sender_last_tsn,
+                advertised_receiver_window_credit: 65536,
+                ..Default::default()
+            },
+            now,
+        )?;
+        let implicit = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 1,
+            reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+            sender_last_tsn: a.peer_last_tsn,
+            stream_identifiers: vec![99],
+        };
+        a.handle_reconfig(now, &reset_config(&implicit))?;
+        a.open_stream(2, ppi)?.close(now)?;
+        for late in [
+            ReconfigResult::InProgress,
+            result,
+            ReconfigResult::ErrorBadSequenceNumber,
+        ] {
+            receive_reset_response(&mut a, now, &first, late)?;
+            assert!(a.gather_outbound(now).0.is_empty());
+            assert!(a.timers.get(Timer::Reconfig).is_none());
+        }
+        now = a.poll_timeout().unwrap();
+        a.handle_timeout(now);
+        assert_eq!(
+            vec![first.clone()],
+            reset_requests(&a.gather_outbound(now).0)
+        );
+        receive_reset_response(&mut a, now, &first, result)?;
+        let mut packets = a.gather_outbound(now).0;
+        packets.extend(a.gather_outbound(now).0);
+        let second = reset_requests(&packets).remove(0);
+        assert_eq!(vec![2], second.stream_identifiers);
+        let resumed = transmitted_data(&packets);
+        assert_eq!(1, resumed.len());
+        assert_eq!(
+            if result == ReconfigResult::Denied {
+                1
+            } else {
+                0
+            },
+            resumed[0].stream_sequence_number
+        );
+        let timer = a.timers.get(Timer::Reconfig);
+        for late in [
+            ReconfigResult::SuccessPerformed,
+            ReconfigResult::Denied,
+            ReconfigResult::ErrorBadSequenceNumber,
+        ] {
+            receive_reset_response(&mut a, now, &first, late)?;
+            assert_eq!(timer, a.timers.get(Timer::Reconfig));
+        }
+        a.stream(1)?
+            .write_sctp(now, &Bytes::from_static(b"later"), ppi)?;
+        assert_eq!(
+            resumed[0].stream_sequence_number + 1,
+            transmitted_data(&a.gather_outbound(now).0)[0].stream_sequence_number
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_lost_result_after_implicit_ack_is_retried_without_resetting_reused_sid() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = sender.my_next_tsn - 1;
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender.open_stream(1, ppi)?.stop(now)?;
+    sender
+        .stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"after reset"), ppi)?;
+    let request = reset_requests(&sender.gather_outbound(now).0).remove(0);
+    let config = ChunkReconfig {
+        param_a: Some(Box::new(request.clone())),
+        ..Default::default()
+    };
+    // Lose the explicit result; the unrelated request acknowledges only receipt.
+    receiver.handle_reconfig(now, &config)?;
+    sender.handle_reconfig(
+        now,
+        &ChunkReconfig {
+            param_a: Some(Box::new(ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                reconfig_response_sequence_number: request.reconfig_request_sequence_number,
+                sender_last_tsn: sender.peer_last_tsn,
+                stream_identifiers: vec![2],
+            })),
+            ..Default::default()
+        },
+    )?;
+    assert!(transmitted_data(&sender.gather_outbound(now).0).is_empty());
+    assert!(sender.timers.get(Timer::Reconfig).is_none());
+    // The peer may already have a new stream when we query the old result.
+    receiver
+        .open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"new peer stream"), ppi)?;
+    let at = sender
+        .poll_timeout()
+        .expect("a missing result needs recovery");
+    sender.handle_timeout(at);
+    let retried = reset_requests(&sender.gather_outbound(at).0);
+    assert_eq!(vec![request], retried);
+    assert!(sender.timers.get(Timer::Reconfig).is_some());
+    for response in receiver.handle_reconfig(at, &config)? {
+        for c in response.chunks {
+            if let Some(config) = c.as_any().downcast_ref::<ChunkReconfig>() {
+                sender.handle_reconfig(at, config)?;
+            }
+        }
+    }
+    assert!(
+        receiver.stream(1).is_ok(),
+        "a result query must not reset a reused stream"
+    );
+    let sent = transmitted_data(&sender.gather_outbound(at).0);
+    assert_eq!(1, sent.len());
+    assert_eq!(0, sent[0].stream_sequence_number);
+    receiver.handle_data(&sent[0])?;
+    assert!(receiver.stream(1)?.read_sctp()?.is_some());
+    assert!(sender.outgoing_reset.is_none());
+    assert!(sender.outgoing_reset.is_none());
+    Ok(())
+}
+
+#[test]
+fn test_result_queries_are_serialized_and_keep_in_progress_status() -> Result<()> {
+    for progress_before_implicit in [false, true] {
+        let mut a = timed_test_association();
+        let mut now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?.close(now)?;
+        let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+        if progress_before_implicit {
+            receive_reset_response(&mut a, now, &first, ReconfigResult::InProgress)?;
+        }
+        a.handle_reconfig(
+            now,
+            &reset_config(&ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+                sender_last_tsn: a.peer_last_tsn,
+                stream_identifiers: vec![99],
+            }),
+        )?;
+        a.open_stream(2, ppi)?.close(now)?;
+        assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+        now = a.poll_timeout().unwrap();
+        a.handle_timeout(now);
+        assert_eq!(
+            vec![first.clone()],
+            reset_requests(&a.gather_outbound(now).0)
+        );
+        if !progress_before_implicit {
+            receive_reset_response(&mut a, now, &first, ReconfigResult::InProgress)?;
+        }
+        for _ in 0..8 {
+            now = a.poll_timeout().unwrap();
+            a.handle_timeout(now);
+            assert_eq!(
+                vec![first.clone()],
+                reset_requests(&a.gather_outbound(now).0)
+            );
+            assert_eq!(AssociationState::Established, a.state());
+        }
+        receive_reset_response(&mut a, now, &first, ReconfigResult::SuccessPerformed)?;
+        let second = reset_requests(&a.gather_outbound(now).0).remove(0);
+        assert_eq!(vec![2], second.stream_identifiers);
+        receive_reset_response(&mut a, now, &second, ReconfigResult::SuccessPerformed)?;
+        assert!(a.poll_timeout().is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_completed_reset_replays_do_not_modify_reused_streams() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let request = |sequence, streams| ChunkReconfig {
+        param_a: Some(Box::new(ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: sequence,
+            sender_last_tsn: 0,
+            stream_identifiers: streams,
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    a.peer_last_tsn = 0;
+    a.incoming_resets = IncomingResetQueue::new(10);
+    a.open_stream(1, ppi)?;
+    a.open_stream(2, ppi)?;
+    let original = request(10, vec![1, 2]);
+    a.handle_reconfig(now, &original)?;
+    a.open_stream(1, ppi)?;
+    a.open_stream(2, ppi)?;
+    a.handle_reconfig(now, &request(11, vec![2]))?;
+    a.open_stream(2, ppi)?;
+    for expected in [
+        ReconfigResult::SuccessPerformed,
+        ReconfigResult::ErrorBadSequenceNumber,
+    ] {
+        let generations = (a.streams[&1].generation, a.streams[&2].generation);
+        let reply = a.handle_reconfig(now, &original)?;
+        let results: Vec<_> = reply
+            .into_iter()
+            .flat_map(|p| p.chunks)
+            .filter_map(|c| {
+                c.as_any()
+                    .downcast_ref::<ChunkReconfig>()
+                    .and_then(|r| r.param_a.as_ref())
+                    .and_then(|p| p.as_any().downcast_ref::<ParamReconfigResponse>())
+                    .map(|r| r.result)
+            })
+            .collect();
+        assert_eq!(vec![expected], results);
+        assert_eq!(
+            generations,
+            (a.streams[&1].generation, a.streams[&2].generation)
+        );
+        assert!(a.incoming_resets.is_empty());
+        if expected == ReconfigResult::SuccessPerformed {
+            a.handle_reconfig(now, &request(12, vec![1]))?;
+            a.open_stream(1, ppi)?;
+        }
+    }
+    for sequence in 13..100 {
+        a.handle_reconfig(now, &request(sequence, vec![1]))?;
+    }
+    assert_eq!(
+        2,
+        a.incoming_resets.history_len(),
+        "history is bounded independently of SID count"
+    );
+    Ok(())
+}
+
+fn reset_config(request: &ParamOutgoingResetRequest) -> ChunkReconfig {
+    ChunkReconfig {
+        param_a: Some(Box::new(request.clone())),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_old_result_query_must_not_resume_with_stale_ssn() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = sender.my_next_tsn.wrapping_sub(1);
+    receiver.incoming_resets = IncomingResetQueue::new(sender.my_next_rsn);
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender
+        .open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"before reset"), ppi)?;
+    for data in transmitted_data(&sender.gather_outbound(now).0) {
+        receiver.handle_data(&data)?;
+    }
+    assert!(receiver.stream(1)?.read_sctp()?.is_some());
+    sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+    sender.stream(1)?.stop(now)?;
+    sender
+        .stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"after reset"), ppi)?;
+    let first = reset_requests(&sender.gather_outbound(now).0).remove(0);
+    receiver.handle_reconfig(now, &reset_config(&first))?; // lose Success
+    sender.handle_reconfig(
+        now,
+        &reset_config(&ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 1,
+            reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+            sender_last_tsn: sender.peer_last_tsn,
+            stream_identifiers: vec![99],
+        }),
+    )?;
+    for sid in [2, 3] {
+        sender.open_stream(sid, ppi)?.close(now)?;
+        assert!(
+            reset_requests(&sender.gather_outbound(now).0).is_empty(),
+            "retain N even in a peer cache of only one completed result"
+        );
+    }
+    let at = sender.poll_timeout().unwrap();
+    sender.handle_timeout(at);
+    assert_eq!(
+        vec![first.clone()],
+        reset_requests(&sender.gather_outbound(at).0)
+    );
+    for packet in receiver.handle_reconfig(at, &reset_config(&first))? {
+        for chunk in packet.chunks {
+            if let Some(config) = chunk.as_any().downcast_ref::<ChunkReconfig>() {
+                sender.handle_reconfig(at, config)?;
+            }
+        }
+    }
+    let mut packets = sender.gather_outbound(at).0;
+    packets.extend(sender.gather_outbound(at).0);
+    let data = transmitted_data(&packets);
+    assert_eq!(1, data.len());
+    assert_eq!(0, data[0].stream_sequence_number);
+    receiver.handle_data(&data[0])?;
+    assert_eq!(
+        Bytes::from_static(b"after reset"),
+        receiver
+            .stream(1)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(usize::MAX)?
+            .freeze()
+    );
+    assert!(
+        !reset_requests(&packets).is_empty(),
+        "later requests eventually resume"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_newer_partial_reset_must_not_cancel_deferred_stream() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?;
+    a.open_stream(2, ppi)?;
+    let before_reset = ChunkPayloadData {
+        tsn: a.peer_last_tsn + 1,
+        stream_identifier: 2,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: ppi,
+        user_data: Bytes::from_static(b"application has not read this yet"),
+        ..Default::default()
+    };
+    a.handle_data(&before_reset)?;
+    let first = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1, 2],
+        ..Default::default()
+    };
+    a.handle_reconfig(now, &reset_config(&first))?;
+    assert!(a.stream(1).is_err());
+    assert!(a.incoming_resets.get(1).is_none());
+    // Network reset completes independently of application delivery.
+    // Our reciprocal request for the already-drained SID 1 implicitly ACKs
+    // receipt of the whole request, so the peer's request timer is stopped.
+    let reciprocal = reset_requests(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(1, reciprocal.reconfig_response_sequence_number);
+    // The peer may now send another request for SID 1 while SID 2 still
+    // waits for the application to drain its previous incarnation.
+    let newer = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 2,
+        reconfig_response_sequence_number: reciprocal.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    a.handle_reconfig(now, &reset_config(&newer))?;
+    a.open_stream(1, ppi)?;
+    let new_generation = a.streams[&1].generation;
+    // Retransmitting N must keep its completed SID 1 out of the remaining work.
+    let repeated = a.handle_reconfig(now, &reset_config(&first))?;
+    assert_eq!(
+        vec![ReconfigResult::SuccessPerformed],
+        reconfig_results(&repeated)
+    );
+    assert!(a.incoming_resets.get(1).is_none());
+    assert_eq!(new_generation, a.streams[&1].generation);
+    assert!(a.incoming_resets.get(1).is_none());
+
+    let completed = a.handle_reconfig(now, &reset_config(&first))?;
+    assert_eq!(
+        vec![ReconfigResult::SuccessPerformed],
+        reconfig_results(&completed)
+    );
+    assert_eq!(new_generation, a.streams[&1].generation);
+    // The old request should now finish resetting SID 2. A completed result
+    // for SID 1 must not turn the still-pending request into a stale replay.
+    let after_reset = ChunkPayloadData {
+        tsn: a.peer_last_tsn + 1,
+        stream_identifier: 2,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: ppi,
+        user_data: Bytes::from_static(b"message in the next SSN space"),
+        ..Default::default()
+    };
+    let credit_before = a.get_my_receiver_window_credit();
+    a.handle_data(&after_reset)?;
+    assert_eq!(
+        credit_before - after_reset.user_data.len() as u32,
+        a.get_my_receiver_window_credit()
+    );
+    assert_eq!(
+        before_reset.user_data,
+        a.stream(2)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(usize::MAX)?
+            .freeze()
+    );
+    assert!(
+        !a.streams.contains_key(&2),
+        "old receiver is retired before the next accessor publishes its successor"
+    );
+    // Poll and public accessors publish the next receiver after the old close.
+    while a.poll().is_some() {}
+    assert_eq!(
+        after_reset.user_data,
+        a.stream(2)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(usize::MAX)?
+            .freeze()
+    );
+    Ok(())
+}
+
+fn reconfig_results(packets: &[Packet]) -> Vec<ReconfigResult> {
+    packets
+        .iter()
+        .flat_map(|p| &p.chunks)
+        .filter_map(|c| c.as_any().downcast_ref::<ChunkReconfig>())
+        .flat_map(|c| c.param_a.iter().chain(c.param_b.iter()))
+        .filter_map(|p| {
+            p.as_any()
+                .downcast_ref::<ParamReconfigResponse>()
+                .map(|p| p.result)
+        })
+        .collect()
+}
+
+#[test]
+fn test_same_reset_query_preserves_gates_timers_and_late_results() -> Result<()> {
+    let mut a = timed_test_association();
+    let mut now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.stop(now)?;
+    a.stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"held until reset is known"), ppi)?;
+    let original = reset_requests(&a.gather_outbound(now).0).remove(0);
+    let implicit = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: original.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![99],
+    };
+    a.handle_reconfig(now, &reset_config(&implicit))?;
+    a.open_stream(2, ppi)?.close(now)?;
+    a.open_stream(3, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"unaffected DATA"), ppi)?;
+    let packets = a.gather_outbound(now).0;
+    assert!(reset_requests(&packets).is_empty());
+    let other = transmitted_data(&packets);
+    assert_eq!(1, other.len());
+    assert_eq!(3, other[0].stream_identifier);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: other[0].tsn,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        now,
+    )?;
+    for _ in 0..3 {
+        now = a.poll_timeout().unwrap();
+        a.handle_timeout(now);
+        let packets = a.gather_outbound(now).0;
+        assert_eq!(
+            vec![original.clone()],
+            reset_requests(&packets),
+            "lost query repeats the identical request"
+        );
+        assert!(transmitted_data(&packets).is_empty());
+    }
+    receive_reset_response(&mut a, now, &original, ReconfigResult::SuccessPerformed)?;
+    let mut packets = a.gather_outbound(now).0;
+    packets.extend(a.gather_outbound(now).0);
+    let released = transmitted_data(&packets);
+    assert_eq!(1, released.len());
+    assert_eq!(0, released[0].stream_sequence_number);
+    let next = reset_requests(&packets).remove(0);
+    assert_eq!(
+        original.reconfig_request_sequence_number.wrapping_add(1),
+        next.reconfig_request_sequence_number
+    );
+    let timer = a.timers.get(Timer::Reconfig);
+    receive_reset_response(
+        &mut a,
+        now,
+        &original,
+        ReconfigResult::ErrorBadSequenceNumber,
+    )?;
+    assert_eq!(timer, a.timers.get(Timer::Reconfig));
+    assert!(!a.is_closed());
+    Ok(())
+}
+
+#[test]
+fn test_unknown_reset_result_closes_instead_of_guessing_ssns() -> Result<()> {
+    for result in [
+        ReconfigResult::ErrorBadSequenceNumber,
+        ReconfigResult::Unknown,
+    ] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(1, ppi)?.stop(now)?;
+        a.stream(1)?
+            .write_sctp(now, &Bytes::from_static(b"unknown SSN"), ppi)?;
+        let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+        while a.poll().is_some() {}
+        receive_reset_response(&mut a, now, &first, result)?;
+        assert!(a.is_closed());
+        assert!(a.poll_timeout().is_none());
+        assert!(a.outgoing_reset.is_none());
+        let packets = a.gather_outbound(now).0;
+        assert!(transmitted_data(&packets).is_empty());
+        assert!(packets.iter().any(|p| {
+            Packet::unmarshal(p)
+                .unwrap()
+                .chunks
+                .iter()
+                .any(|c| c.as_any().is::<ChunkAbort>())
+        }));
+        assert!(matches!(
+            a.poll(),
+            Some(Event::AssociationLost {
+                id: 1,
+                reason: AssociationError::TransportError
+            })
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn test_unstarted_timed_message_expires_without_tsn_or_ssn_gap() -> Result<()> {
+    for unordered in [false, true] {
+        for size in [1, 4000] {
+            for delta in [Duration::ZERO, Duration::from_nanos(1)] {
+                let mut a = timed_test_association();
+                let now = Instant::now();
+                let ppi = PayloadProtocolIdentifier::Binary;
+                let first_tsn = a.my_next_tsn;
+                let mut stream = a.open_stream(1, ppi)?;
+                stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+                stream.write_sctp(now, &Bytes::from(vec![1; size]), ppi)?;
+                let deadline = now + Duration::from_millis(100) + delta;
+                assert!(a.gather_outbound(deadline).0.is_empty());
+                assert_eq!(first_tsn, a.my_next_tsn);
+                assert!(a.pending_queue.is_empty());
+                assert!(a.inflight_queue.is_empty());
+                assert_eq!(0, a.stream(1)?.buffered_amount()?);
+                let mut stream = a.stream(1)?;
+                stream.set_reliability_params(false, ReliabilityType::Reliable, 0)?;
+                stream.write_sctp(deadline, &Bytes::from_static(b"next"), ppi)?;
+                let data = transmitted_data(&a.gather_outbound(deadline).0);
+                assert_eq!(1, data.len());
+                assert_eq!(first_tsn, data[0].tsn);
+                assert_eq!(0, data[0].stream_sequence_number);
+                let mut receiver = timed_test_association();
+                receiver.peer_last_tsn = first_tsn.wrapping_sub(1);
+                receiver.handle_data(&data[0])?;
+                assert!(receiver.stream(1)?.read_sctp()?.is_some());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_timed_message_can_first_send_just_before_its_deadline() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from_static(b"within lifetime"), ppi)?;
+    let before = now + Duration::from_millis(100) - Duration::from_nanos(1);
+    assert_eq!(1, transmitted_data(&a.gather_outbound(before).0).len());
+    Ok(())
+}
+
+#[test]
+fn test_revoked_gap_ack_retains_payload_and_releases_buffer_once() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let initial = a.my_next_tsn;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"first"), ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"second"), ppi)?;
+    let original = transmitted_data(&a.gather_outbound(now).0);
+    assert_eq!(2, original.len());
+    while a.poll().is_some() {}
+    let mut sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: initial.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![crate::chunk::chunk_selective_ack::GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now)?;
+    assert_eq!(
+        11,
+        a.inflight_queue.get_num_bytes(),
+        "gap ACK is not final ownership release"
+    );
+    assert_eq!(5, a.inflight_queue.outstanding_bytes());
+    assert_eq!(5, a.stream(1)?.buffered_amount()?);
+    let mut released = 0;
+    while let Some(event) = a.poll() {
+        if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) = event {
+            released += n_bytes;
+        }
+    }
+    assert_eq!(6, released);
+    sack.gap_ack_blocks.clear();
+    a.handle_sack(&sack, now)?;
+    assert_eq!(11, a.inflight_queue.outstanding_bytes());
+    assert_eq!(5, a.stream(1)?.buffered_amount()?);
+    assert_eq!(
+        1,
+        a.inflight_queue
+            .get(initial.wrapping_add(1))
+            .unwrap()
+            .miss_indicator
+    );
+    let at = a.poll_timeout().expect("revoked DATA needs recovery");
+    a.handle_timeout(at);
+    let retried = transmitted_data(&a.gather_outbound(at).0);
+    assert_eq!(2, retried.len());
+    for (original, retried) in original.iter().zip(&retried) {
+        assert_eq!(original.tsn, retried.tsn);
+        assert_eq!(
+            original.user_data, retried.user_data,
+            "must retransmit retained bytes"
+        );
+    }
+    sack.gap_ack_blocks
+        .push(crate::chunk::chunk_selective_ack::GapAckBlock { start: 2, end: 2 });
+    a.handle_sack(&sack, at)?;
+    a.handle_sack(&sack, at)?;
+    sack.cumulative_tsn_ack = initial.wrapping_add(1);
+    sack.gap_ack_blocks.clear();
+    a.handle_sack(&sack, at)?;
+    while let Some(event) = a.poll() {
+        if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) = event {
+            released += n_bytes;
+        }
+    }
+    assert_eq!(11, released);
+    assert_eq!(0, a.stream(1)?.buffered_amount()?);
+    assert_eq!(0, a.inflight_queue.get_num_bytes());
+    assert!(a.poll_timeout().is_none());
+    Ok(())
+}
+
+#[test]
+fn test_revoked_gap_ack_timed_message_is_abandoned_before_retry() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let initial = a.my_next_tsn;
+    a.open_stream(2, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"reliable gap"), ppi)?;
+    a.gather_outbound(now);
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(true, ReliabilityType::Timed, 100)?;
+    stream.write_sctp(now, &Bytes::from_static(b"timed"), ppi)?;
+    a.gather_outbound(now);
+    let mut sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: initial.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![crate::chunk::chunk_selective_ack::GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now)?;
+    sack.gap_ack_blocks.clear();
+    let expired = now + Duration::from_millis(100);
+    a.handle_sack(&sack, expired)?;
+    let at = a.poll_timeout().unwrap();
+    a.handle_timeout(at);
+    let packets = a.gather_outbound(at).0;
+    assert!(
+        transmitted_data(&packets)
+            .iter()
+            .all(|c| c.stream_identifier == 2)
+    );
+    assert!(
+        a.inflight_queue
+            .get(initial.wrapping_add(1))
+            .unwrap()
+            .abandoned()
+    );
+    assert_eq!(0, a.stream(1)?.buffered_amount()?);
+    Ok(())
+}
+
+#[test]
+fn test_abandoned_tail_uses_one_terminal_tsn_after_cumulative_prefix_ack() -> Result<()> {
+    for unordered in [false, true] {
+        let mut sender = timed_test_association();
+        let mut receiver = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let first_tsn = sender.my_next_tsn;
+        receiver.peer_last_tsn = first_tsn.wrapping_sub(1);
+        sender.cwnd = sender.max_payload_size;
+        let mut stream = sender.open_stream(1, ppi)?;
+        stream.set_reliability_params(unordered, ReliabilityType::Timed, 100)?;
+        stream.write_sctp(now, &Bytes::from(vec![7; 12000]), ppi)?;
+        let first = transmitted_data(&sender.gather_outbound(now).0);
+        assert_eq!(1, first.len());
+        receiver.handle_data(&first[0])?;
+        receiver
+            .stream(1)?
+            .set_reliability_params(unordered, ReliabilityType::Reliable, 0)?;
+        sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+        assert!(sender.inflight_queue.is_empty());
+        let expired = now + Duration::from_millis(100);
+        let packets = sender.gather_outbound(expired).0;
+        assert!(
+            transmitted_data(&packets).is_empty(),
+            "terminal TSN is never an empty DATA packet"
+        );
+        assert_eq!(first_tsn.wrapping_add(2), sender.my_next_tsn);
+        let forwards: Vec<_> = packets
+            .iter()
+            .flat_map(|p| Packet::unmarshal(p).unwrap().chunks)
+            .filter_map(|c| c.as_any().downcast_ref::<ChunkForwardTsn>().cloned())
+            .collect();
+        assert_eq!(1, forwards.len());
+        receiver.handle_forward_tsn(&forwards[0])?;
+        assert_eq!(0, receiver.receive_streams[&1].get_num_bytes());
+        assert_eq!(0, sender.stream(1)?.buffered_amount()?);
+        assert!(sender.pending_queue.is_empty());
+        sender.handle_sack(&receiver.create_selective_ack_chunk(), expired)?;
+        assert!(sender.inflight_queue.is_empty());
+        assert!(sender.poll_timeout().is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_forward_tsn_crossing_reset_boundary_preserves_old_ready_message() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.peer_last_tsn = 0;
+    a.handle_data(&ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        stream_sequence_number: 1,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: ppi,
+        user_data: Bytes::from_static(b"complete after missing SSN zero"),
+        ..Default::default()
+    })?;
+    let reset = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        sender_last_tsn: 2,
+        stream_identifiers: vec![1],
+        ..Default::default()
+    };
+    assert_eq!(
+        vec![ReconfigResult::InProgress],
+        reconfig_results(&a.handle_reconfig(now, &reset_config(&reset))?)
+    );
+    // TSN 3 belongs to another abandoned stream. NewCum crosses the boundary,
+    // but SID 1's SSN still describes its OLD direction (A1/H4 and RFC 3758 C4).
+    let reply = a.handle_forward_tsn(&ChunkForwardTsn {
+        new_cumulative_tsn: 3,
+        streams: vec![ChunkForwardTsnStream {
+            identifier: 1,
+            sequence: 0,
+        }],
+    })?;
+    assert_eq!(
+        vec![ReconfigResult::SuccessPerformed],
+        reconfig_results(&reply)
+    );
+    assert_eq!(
+        Bytes::from_static(b"complete after missing SSN zero"),
+        a.stream(1)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(usize::MAX)?
+            .freeze()
+    );
+    assert!(a.stream(1).is_err());
+    Ok(())
+}
+
+#[test]
+fn test_future_data_waits_for_receive_reset_and_keeps_window_charge() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.peer_last_tsn = 0;
+        let data = |tsn, sid, ssn, unordered| ChunkPayloadData {
+            tsn,
+            stream_identifier: sid,
+            stream_sequence_number: ssn,
+            unordered,
+            beginning_fragment: true,
+            ending_fragment: true,
+            payload_type: ppi,
+            user_data: Bytes::from_static(b"saved"),
+            ..Default::default()
+        };
+        a.handle_data(&data(1, 1, 0, unordered))?;
+        assert!(a.stream(1)?.read_sctp()?.is_some());
+        a.handle_reconfig(
+            now,
+            &reset_config(&ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                sender_last_tsn: 3,
+                stream_identifiers: vec![1],
+                ..Default::default()
+            }),
+        )?;
+        let credit = a.get_my_receiver_window_credit();
+        a.handle_data(&data(4, 1, 0, unordered))?;
+        assert!(
+            a.stream(1)?.read_sctp()?.is_none(),
+            "E2 holds DATA above the boundary"
+        );
+        assert_eq!(credit - 5, a.get_my_receiver_window_credit());
+        a.handle_data(&data(2, 2, 0, false))?;
+        let reply = a.handle_data(&data(3, 2, 1, false))?;
+        assert_eq!(
+            vec![ReconfigResult::SuccessPerformed],
+            reconfig_results(&reply)
+        );
+        while a.poll().is_some() {}
+        assert_eq!(
+            Bytes::from_static(b"saved"),
+            a.stream(1)?
+                .read_sctp()?
+                .unwrap()
+                .to_payload(usize::MAX)?
+                .freeze()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_fragmented_data_and_gap_sack_cross_tsn_wrap() -> Result<()> {
+    for unordered in [false, true] {
+        let now = Instant::now();
+        let mut sender = timed_test_association();
+        let mut receiver = timed_test_association();
+        sender.my_next_tsn = u32::MAX - 1;
+        sender.cumulative_tsn_ack_point = u32::MAX - 2;
+        sender.advanced_peer_tsn_ack_point = u32::MAX - 2;
+        receiver.peer_last_tsn = u32::MAX - 2;
+        sender.cwnd = 65536;
+        let payload = Bytes::from(vec![42; 4000]);
+        let mut stream = sender.open_stream(1, PayloadProtocolIdentifier::Binary)?;
+        stream.set_reliability_params(unordered, ReliabilityType::Reliable, 0)?;
+        stream.write_sctp(now, &payload, PayloadProtocolIdentifier::Binary)?;
+        let sent = transmitted_data(&sender.gather_outbound(now).0);
+        assert_eq!(
+            vec![u32::MAX - 1, u32::MAX, 0],
+            sent.iter().map(|d| d.tsn).collect::<Vec<_>>()
+        );
+        receiver.handle_data(&sent[2])?;
+        let sack = receiver.create_selective_ack_chunk();
+        assert_eq!(
+            vec![(3, 3)],
+            sack.gap_ack_blocks
+                .iter()
+                .map(|g| (g.start, g.end))
+                .collect::<Vec<_>>()
+        );
+        sender.handle_sack(&sack, now)?;
+        receiver.handle_data(&sent[0])?;
+        receiver.handle_data(&sent[1])?;
+        assert_eq!(
+            payload,
+            receiver
+                .stream(1)?
+                .read_sctp()?
+                .unwrap()
+                .to_payload(usize::MAX)?
+                .freeze()
+        );
+        sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+        assert!(sender.inflight_queue.is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_responsive_zero_window_probe_does_not_exhaust_t3() -> Result<()> {
+    let mut sender = timed_test_association();
+    let mut receiver = timed_test_association();
+    let mut now = Instant::now();
+    receiver.peer_last_tsn = sender.my_next_tsn.wrapping_sub(1);
+    receiver.max_receive_buffer_size = 4;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    sender
+        .open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"full"), ppi)?;
+    for data in transmitted_data(&sender.gather_outbound(now).0) {
+        receiver.handle_data(&data)?;
+    }
+    sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+    sender
+        .stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"next"), ppi)?;
+    for _ in 0..9 {
+        for data in transmitted_data(&sender.gather_outbound(now).0) {
+            receiver.handle_data(&data)?;
+        }
+        let sack = receiver.create_selective_ack_chunk();
+        assert_eq!(0, sack.advertised_receiver_window_credit);
+        sender.handle_sack(&sack, now)?;
+        now = sender.timers.get(Timer::T3RTX).unwrap();
+        sender.handle_timeout(now);
+        assert!(
+            !sender.is_closed(),
+            "a slow reader is not a failed association"
+        );
+    }
+    assert_eq!(
+        Bytes::from_static(b"full"),
+        receiver
+            .stream(1)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(16)?
+            .freeze()
+    );
+    sender.handle_sack(&receiver.create_selective_ack_chunk(), now)?;
+    for data in transmitted_data(&sender.gather_outbound(now).0) {
+        receiver.handle_data(&data)?;
+    }
+    assert_eq!(
+        Bytes::from_static(b"next"),
+        receiver
+            .stream(1)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(16)?
+            .freeze()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_reset_bounds_old_forward_tsn_even_with_other_stream_abandonment() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?
+        .set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    a.stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"old SID"), ppi)?;
+    a.stream(1)?.close(now)?;
+    let reset = reset_requests(&a.gather_outbound(now).0).remove(0);
+    a.open_stream(2, ppi)?
+        .set_reliability_params(false, ReliabilityType::Timed, 100)?;
+    a.stream(2)?
+        .write_sctp(now, &Bytes::from_static(b"later TSN on another SID"), ppi)?;
+    a.gather_outbound(now);
+    let at = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(at);
+    let old_forward = a.create_forward_tsn();
+    assert_eq!(reset.sender_last_tsn, old_forward.new_cumulative_tsn);
+    assert_eq!(
+        vec![(1, 0)],
+        old_forward
+            .streams
+            .iter()
+            .map(|s| (s.identifier, s.sequence))
+            .collect::<Vec<_>>()
+    );
+    receive_reset_response(&mut a, at, &reset, ReconfigResult::SuccessPerformed)?;
+    let next_forward = a.create_forward_tsn();
+    assert_eq!(
+        reset.sender_last_tsn.wrapping_add(1),
+        next_forward.new_cumulative_tsn
+    );
+    assert_eq!(
+        vec![(2, 0)],
+        next_forward
+            .streams
+            .iter()
+            .map(|s| (s.identifier, s.sequence))
+            .collect::<Vec<_>>()
+    );
+    // Any delayed old control is at/below the peer's performed-reset TSN and
+    // therefore ignored even if new DATA of the reused SID was reordered first.
+    Ok(())
+}
+
+#[test]
+fn test_many_resets_respect_mtu_and_rsn_wrap() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    a.mtu = 96;
+    a.my_next_rsn = u32::MAX;
+    for sid in 0..100 {
+        a.open_stream(sid, PayloadProtocolIdentifier::Binary)?
+            .close(now)?;
+    }
+    let mut reset_sids = vec![];
+    let mut next_sequence = u32::MAX;
+    for _ in 0..4 {
+        let packets = a.gather_outbound(now).0;
+        assert!(packets.iter().all(|p| p.len() <= a.mtu as usize));
+        let requests = reset_requests(&packets);
+        assert_eq!(1, requests.len());
+        assert_eq!(next_sequence, requests[0].reconfig_request_sequence_number);
+        next_sequence = next_sequence.wrapping_add(1);
+        reset_sids.extend(&requests[0].stream_identifiers);
+        assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+        receive_reset_response(&mut a, now, &requests[0], ReconfigResult::SuccessPerformed)?;
+    }
+    reset_sids.sort_unstable();
+    assert_eq!((0..100u16).collect::<Vec<_>>(), reset_sids);
+    assert!(a.pending_queue.is_empty());
+    assert!(a.outgoing_reset.is_none());
+    Ok(())
+}
+
+#[test]
+fn test_invalid_reconfig_combination_has_no_partial_effects() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?;
+    a.open_stream(2, ppi)?.close(now)?;
+    let outgoing = reset_requests(&a.gather_outbound(now).0).remove(0);
+    let timer = a.timers.get(Timer::Reconfig);
+    let request = |sequence| ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: sequence,
+        reconfig_response_sequence_number: outgoing.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    let invalid = ChunkReconfig {
+        param_a: Some(Box::new(request(1))),
+        param_b: Some(Box::new(request(2))),
+    };
+    assert!(a.handle_reconfig(now, &invalid)?.is_empty());
+    assert_eq!(1, a.expected_reset_sequence());
+    assert!(a.stream(1).is_ok());
+    assert_eq!(
+        timer,
+        a.timers.get(Timer::Reconfig),
+        "invalid combination cannot apply E1"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_denied_local_reset_does_not_suppress_later_reciprocal() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.write_sctp(now, &Bytes::from_static(b"old TX epoch"), ppi)?;
+    a.gather_outbound(now);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: a.my_next_tsn.wrapping_sub(1),
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        now,
+    )?;
+    a.stream(1)?.stop(now)?;
+    let outgoing = reset_requests(&a.gather_outbound(now).0).remove(0);
+    receive_reset_response(&mut a, now, &outgoing, ReconfigResult::Denied)?;
+    assert!(a.outgoing_reset.is_none());
+    let incoming = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: outgoing.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    assert_eq!(
+        reconfig_results(&a.handle_reconfig(now, &reset_config(&incoming))?),
+        [ReconfigResult::SuccessPerformed]
+    );
+    assert_eq!(
+        reset_requests(&a.gather_outbound(now).0).len(),
+        1,
+        "a denied outgoing reset did not close TX; incoming close still needs its reciprocal"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_success_of_required_reset_does_not_bind_next_local_reset() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.stop(now)?;
+    let old = reset_requests(&a.gather_outbound(now).0).remove(0);
+    let incoming = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: old.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    a.handle_reconfig(now, &reset_config(&incoming))?;
+    assert!(matches!(
+        a.outgoing_reset.as_ref().unwrap().phase,
+        reset::RequestPhase::ReceiptOnly { .. }
+    ));
+    a.open_stream(1, ppi)?.stop(now)?;
+    let retry_at = a.next_reconfig_result_retry().unwrap().1;
+    a.handle_timeout(retry_at);
+    let query = reset_requests(&a.gather_outbound(retry_at).0).remove(0);
+    assert_eq!(
+        query.reconfig_request_sequence_number,
+        old.reconfig_request_sequence_number
+    );
+    receive_reset_response(&mut a, retry_at, &query, ReconfigResult::SuccessPerformed)?;
+    let next = reset_requests(&a.gather_outbound(retry_at).0).remove(0);
+    assert_eq!(
+        next.reconfig_request_sequence_number,
+        old.reconfig_request_sequence_number.wrapping_add(1)
+    );
+    receive_reset_response(&mut a, retry_at, &next, ReconfigResult::Denied)?;
+    assert_eq!(
+        a.state(),
+        AssociationState::Established,
+        "the successful M already met incoming N's reciprocal obligation; unrelated local M2 denial must not abort"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_denied_reset_after_peer_close_has_explicit_failure() -> Result<()> {
+    for implicit_ack in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        a.open_stream(2, ppi)?;
+        a.open_stream(1, ppi)?.stop(now)?;
+        let request = reset_requests(&a.gather_outbound(now).0).remove(0);
+        a.handle_reconfig(
+            now,
+            &reset_config(&ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: 1,
+                reconfig_response_sequence_number: request
+                    .reconfig_request_sequence_number
+                    .wrapping_sub(u32::from(!implicit_ack)),
+                sender_last_tsn: a.peer_last_tsn,
+                stream_identifiers: vec![1],
+            }),
+        )?;
+        let at = if implicit_ack {
+            receive_reset_response(&mut a, now, &request, ReconfigResult::Denied)?;
+            assert_eq!(
+                a.state(),
+                AssociationState::Established,
+                "H1 ignores a result without its timer"
+            );
+            assert!(a.outgoing_reset.is_some());
+            let at = a.next_reconfig_result_retry().unwrap().1;
+            a.handle_timeout(at);
+            assert_eq!(reset_requests(&a.gather_outbound(at).0), [request.clone()]);
+            at
+        } else {
+            now
+        };
+        receive_reset_response(&mut a, at, &request, ReconfigResult::Denied)?;
+        assert_eq!(a.state(), AssociationState::Closed);
+        assert!(a.pending_queue.is_empty());
+        assert!(a.outgoing_reset.is_none());
+        assert!(a.poll_timeout().is_none());
+        let packets = a.gather_outbound(at).0;
+        assert!(a.is_closed());
+        assert!(
+            packets
+                .iter()
+                .flat_map(|raw| Packet::unmarshal(raw).unwrap().chunks)
+                .any(|chunk| chunk.as_any().is::<ChunkAbort>())
+        );
+        let mut notified = false;
+        while let Some(event) = a.poll() {
+            notified |= matches!(
+                event,
+                Event::AssociationLost {
+                    id: 2,
+                    reason: AssociationError::TransportError
+                }
+            );
+        }
+        assert!(
+            notified,
+            "failure must be visible through the existing event API"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_reset_result_coverage_follows_each_rx_epoch() -> Result<()> {
+    for newer_peer_reset in [false, true] {
+        for first_result in [ReconfigResult::SuccessPerformed, ReconfigResult::Denied] {
+            for next_result in [ReconfigResult::SuccessPerformed, ReconfigResult::Denied] {
+                for pending_size in [0, 4000] {
+                    let mut a = timed_test_association();
+                    a.cwnd = 65536;
+                    let now = Instant::now();
+                    let ppi = PayloadProtocolIdentifier::Binary;
+                    a.open_stream(1, ppi)?
+                        .write_sctp(now, &Bytes::from_static(b"old"), ppi)?;
+                    a.gather_outbound(now);
+                    a.handle_sack(
+                        &ChunkSelectiveAck {
+                            cumulative_tsn_ack: a.my_next_tsn.wrapping_sub(1),
+                            advertised_receiver_window_credit: 65536,
+                            ..Default::default()
+                        },
+                        now,
+                    )?;
+                    a.stream(1)?.stop(now)?;
+                    let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+                    let incoming = ParamOutgoingResetRequest {
+                        reconfig_request_sequence_number: 1,
+                        reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+                        sender_last_tsn: a.peer_last_tsn,
+                        stream_identifiers: vec![1],
+                    };
+                    a.handle_reconfig(now, &reset_config(&incoming))?;
+                    let mut next = a.open_stream(1, ppi)?;
+                    if pending_size != 0 {
+                        next.write_sctp(now, &Bytes::from(vec![7; pending_size]), ppi)?;
+                    }
+                    next.stop(now)?;
+                    if newer_peer_reset {
+                        a.handle_reconfig(
+                            now,
+                            &reset_config(&ParamOutgoingResetRequest {
+                                reconfig_request_sequence_number: 2,
+                                ..incoming
+                            }),
+                        )?;
+                    }
+                    receive_reset_response(&mut a, now, &first, ReconfigResult::Denied)?;
+                    assert!(a.timers.get(Timer::Reconfig).is_none());
+                    let at = a.next_reconfig_result_retry().unwrap().1;
+                    a.handle_timeout(at);
+                    assert_eq!(reset_requests(&a.gather_outbound(at).0), [first.clone()]);
+                    receive_reset_response(&mut a, at, &first, first_result)?;
+                    assert_eq!(
+                        a.state(),
+                        AssociationState::Established,
+                        "a queued later reset can still finish the close"
+                    );
+                    let packets = a.gather_outbound(at).0;
+                    let resets = reset_requests(&packets);
+                    assert_eq!(resets.len(), 1);
+                    let next = &resets[0];
+                    assert_eq!(
+                        next.reconfig_request_sequence_number,
+                        first.reconfig_request_sequence_number.wrapping_add(1)
+                    );
+                    let data = transmitted_data(&packets);
+                    assert_eq!(
+                        data.iter().map(|data| data.user_data.len()).sum::<usize>(),
+                        pending_size
+                    );
+                    assert!(data.iter().all(|data| data.stream_sequence_number
+                        == u16::from(first_result == ReconfigResult::Denied)));
+                    // A result of the older request must not stop the next timer.
+                    let next_timer = a.timers.get(Timer::Reconfig);
+                    receive_reset_response(&mut a, at, &first, ReconfigResult::Denied)?;
+                    assert_eq!(a.timers.get(Timer::Reconfig), next_timer);
+                    receive_reset_response(&mut a, at, next, next_result)?;
+                    let refused_required = next_result == ReconfigResult::Denied
+                        && (newer_peer_reset || first_result == ReconfigResult::Denied);
+                    assert_eq!(
+                        a.state(),
+                        if refused_required {
+                            AssociationState::Closed
+                        } else {
+                            AssociationState::Established
+                        },
+                        "first={first_result:?}, next={next_result:?}, newer_peer_reset={newer_peer_reset}, bytes={pending_size}"
+                    );
+                    assert!(
+                        reset_requests(&a.gather_outbound(at).0).is_empty(),
+                        "completion must not manufacture a third reset"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_denied_old_reset_preserves_new_epoch_request() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.stop(now)?;
+    let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+    let incoming = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    a.handle_reconfig(now, &reset_config(&incoming))?;
+    a.open_stream(1, ppi)?.stop(now)?;
+    let at = a.next_reconfig_result_retry().unwrap().1;
+    a.handle_timeout(at);
+    assert_eq!(reset_requests(&a.gather_outbound(at).0), [first.clone()]);
+    receive_reset_response(&mut a, at, &first, ReconfigResult::Denied)?;
+    let next = reset_requests(&a.gather_outbound(at).0).remove(0);
+    a.handle_reconfig(
+        at,
+        &reset_config(&ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 2,
+            ..incoming
+        }),
+    )?;
+    receive_reset_response(&mut a, at, &next, ReconfigResult::SuccessPerformed)?;
+    assert!(
+        reset_requests(&a.gather_outbound(at).0).is_empty(),
+        "the old refusal cannot erase the new RX epoch's already queued reset"
+    );
+    assert_eq!(a.state(), AssociationState::Established);
+    a.open_stream(1, ppi)?.stop(at)?;
+    let subsequent = reset_requests(&a.gather_outbound(at).0).remove(0);
+    assert_eq!(
+        subsequent.reconfig_request_sequence_number,
+        first.reconfig_request_sequence_number.wrapping_add(2)
+    );
+    Ok(())
+}
+
+#[test]
+fn test_success_before_peer_reset_does_not_bind_next_local_reset() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(1, ppi)?.stop(now)?;
+    let first = reset_requests(&a.gather_outbound(now).0).remove(0);
+    receive_reset_response(&mut a, now, &first, ReconfigResult::SuccessPerformed)?;
+    a.handle_reconfig(
+        now,
+        &reset_config(&ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 1,
+            reconfig_response_sequence_number: first.reconfig_request_sequence_number,
+            sender_last_tsn: a.peer_last_tsn,
+            stream_identifiers: vec![1],
+        }),
+    )?;
+    assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+    a.open_stream(1, ppi)?.stop(now)?;
+    let next = reset_requests(&a.gather_outbound(now).0).remove(0);
+    receive_reset_response(&mut a, now, &next, ReconfigResult::Denied)?;
+    assert_eq!(a.state(), AssociationState::Established);
+    a.stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"still writable"), ppi)?;
+    assert_eq!(
+        transmitted_data(&a.gather_outbound(now).0)[0].stream_sequence_number,
+        0
+    );
+    Ok(())
 }

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -10,6 +10,9 @@ mod sack_recovery;
 #[path = "ack_optimization_test.rs"]
 mod ack_optimization;
 
+#[path = "timer_deadline_test.rs"]
+mod timer_deadline;
+
 #[path = "ack_range_boundary_test.rs"]
 mod ack_range_boundary;
 

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -10,6 +10,12 @@ mod sack_recovery;
 #[path = "ack_optimization_test.rs"]
 mod ack_optimization;
 
+#[path = "send_retention_test.rs"]
+mod send_retention;
+
+#[path = "receive_tracking_test.rs"]
+mod receive_tracking;
+
 #[path = "message_selection_test.rs"]
 mod message_selection;
 
@@ -670,18 +676,7 @@ fn test_handle_forward_tsn_forward_1for1_missing() -> Result<()> {
     let prev_tsn = a.peer_last_tsn;
 
     // this chunk is blocked by the missing chunk at tsn=1
-    a.payload_queue.push(
-        ChunkPayloadData {
-            beginning_fragment: true,
-            ending_fragment: true,
-            tsn: a.peer_last_tsn + 2,
-            stream_identifier: 0,
-            stream_sequence_number: 1,
-            user_data: Bytes::from_static(b"ABC"),
-            ..Default::default()
-        },
-        a.peer_last_tsn,
-    );
+    a.payload_queue.push(a.peer_last_tsn + 2, a.peer_last_tsn);
 
     let fwdtsn = ChunkForwardTsn {
         new_cumulative_tsn: a.peer_last_tsn + 1,
@@ -718,18 +713,7 @@ fn test_handle_forward_tsn_forward_1for2_missing() -> Result<()> {
     let prev_tsn = a.peer_last_tsn;
 
     // this chunk is blocked by the missing chunk at tsn=1
-    a.payload_queue.push(
-        ChunkPayloadData {
-            beginning_fragment: true,
-            ending_fragment: true,
-            tsn: a.peer_last_tsn + 3,
-            stream_identifier: 0,
-            stream_sequence_number: 1,
-            user_data: Bytes::from_static(b"ABC"),
-            ..Default::default()
-        },
-        a.peer_last_tsn,
-    );
+    a.payload_queue.push(a.peer_last_tsn + 3, a.peer_last_tsn);
 
     let fwdtsn = ChunkForwardTsn {
         new_cumulative_tsn: a.peer_last_tsn + 1,

--- a/rtc-sctp/src/association/association_test.rs
+++ b/rtc-sctp/src/association/association_test.rs
@@ -7,6 +7,9 @@ mod reliability_reset;
 #[path = "sack_recovery_test.rs"]
 mod sack_recovery;
 
+#[path = "ack_optimization_test.rs"]
+mod ack_optimization;
+
 #[path = "message_selection_test.rs"]
 mod message_selection;
 

--- a/rtc-sctp/src/association/control_bundling_test.rs
+++ b/rtc-sctp/src/association/control_bundling_test.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+#[test]
+fn reconfig_response_bundles_the_complete_immediate_sack_within_mtu() -> Result<()> {
+    for mtu in [52, 51] {
+        let now = Instant::now();
+        let mut association = timed_test_association();
+        association.mtu = mtu;
+        let cumulative = association.peer_last_tsn;
+        let gap_tsn = cumulative.wrapping_add(2);
+        let data = ChunkPayloadData {
+            tsn: gap_tsn,
+            ..Default::default()
+        };
+        assert!(association.payload_queue.push(data.clone(), cumulative));
+        assert!(!association.payload_queue.push(data, cumulative));
+        association.ack_state = AckState::Immediate;
+        association
+            .control_queue
+            .push_back(association.reconfig_response_packet(17, ReconfigResult::SuccessPerformed));
+
+        let (raw, keep_open) = association.gather_outbound(now);
+        assert!(keep_open);
+        assert_eq!(raw.len(), if mtu == 52 { 1 } else { 2 });
+        assert!(raw.iter().all(|packet| packet.len() <= mtu as usize));
+        let packets = raw
+            .iter()
+            .map(Packet::unmarshal)
+            .collect::<Result<Vec<_>>>()?;
+        assert!(packets[0].chunks[0].as_any().is::<ChunkReconfig>());
+        let sacks: Vec<_> = packets
+            .iter()
+            .flat_map(|packet| &packet.chunks)
+            .filter_map(|chunk| chunk.as_any().downcast_ref::<ChunkSelectiveAck>())
+            .collect();
+        assert_eq!(sacks.len(), 1);
+        assert_eq!(sacks[0].cumulative_tsn_ack, cumulative);
+        assert_eq!(sacks[0].gap_ack_blocks.len(), 1);
+        assert_eq!(sacks[0].gap_ack_blocks[0].start, 2);
+        assert_eq!(sacks[0].gap_ack_blocks[0].end, 2);
+        assert_eq!(sacks[0].duplicate_tsn, [gap_tsn]);
+        assert_eq!(association.ack_state, AckState::Idle);
+        assert!(association.payload_queue.pop_duplicates().is_empty());
+        assert!(association.gather_outbound(now).0.is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn reconfig_bundling_does_not_turn_a_delayed_ack_into_an_immediate_ack() -> Result<()> {
+    let mut association = timed_test_association();
+    let now = Instant::now();
+    association.ack_state = AckState::Delay;
+    association
+        .control_queue
+        .push_back(association.reconfig_response_packet(17, ReconfigResult::SuccessPerformed));
+    let packets = association.gather_outbound(now).0;
+    assert_eq!(packets.len(), 1);
+    assert_eq!(Packet::unmarshal(&packets[0])?.chunks.len(), 1);
+    assert_eq!(association.ack_state, AckState::Delay);
+    Ok(())
+}
+
+#[test]
+fn standalone_control_chunks_never_acquire_a_bundled_sack() -> Result<()> {
+    let mut chunks: Vec<Box<dyn Chunk>> = [false, true]
+        .into_iter()
+        .map(|is_ack| {
+            Box::new(ChunkInit {
+                is_ack,
+                initiate_tag: 1,
+                num_outbound_streams: 1,
+                num_inbound_streams: 1,
+                ..Default::default()
+            }) as Box<dyn Chunk>
+        })
+        .collect();
+    chunks.push(Box::new(ChunkShutdownComplete {}));
+    for chunk in chunks {
+        let mut association = timed_test_association();
+        association.ack_state = AckState::Immediate;
+        association
+            .control_queue
+            .push_back(association.create_packet(vec![chunk]));
+        let packets = association.gather_outbound(Instant::now()).0;
+        assert_eq!(packets.len(), 2);
+        for packet in packets {
+            assert_eq!(Packet::unmarshal(&packet)?.chunks.len(), 1);
+        }
+    }
+    Ok(())
+}

--- a/rtc-sctp/src/association/control_bundling_test.rs
+++ b/rtc-sctp/src/association/control_bundling_test.rs
@@ -8,12 +8,8 @@ fn reconfig_response_bundles_the_complete_immediate_sack_within_mtu() -> Result<
         association.mtu = mtu;
         let cumulative = association.peer_last_tsn;
         let gap_tsn = cumulative.wrapping_add(2);
-        let data = ChunkPayloadData {
-            tsn: gap_tsn,
-            ..Default::default()
-        };
-        assert!(association.payload_queue.push(data.clone(), cumulative));
-        assert!(!association.payload_queue.push(data, cumulative));
+        assert!(association.payload_queue.push(gap_tsn, cumulative));
+        assert!(!association.payload_queue.push(gap_tsn, cumulative));
         association.ack_state = AckState::Immediate;
         association
             .control_queue

--- a/rtc-sctp/src/association/message_selection_test.rs
+++ b/rtc-sctp/src/association/message_selection_test.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+#[test]
+fn a_stale_whole_message_selection_cannot_abandon_a_reused_tsn() -> Result<()> {
+    for (policy, value) in [(ReliabilityType::Timed, 100), (ReliabilityType::Rexmit, 0)] {
+        for first_tsn in [12345, u32::MAX] {
+            let now = Instant::now();
+            let mut sender = timed_test_association();
+            let mut receiver = timed_test_association();
+            sender.my_next_tsn = first_tsn;
+            sender.cumulative_tsn_ack_point = first_tsn.wrapping_sub(1);
+            sender.advanced_peer_tsn_ack_point = first_tsn.wrapping_sub(1);
+            receiver.peer_last_tsn = first_tsn.wrapping_sub(1);
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let old = Bytes::from_static(b"delivered before the delayed SACK");
+            let fresh = Bytes::from_static(b"a new message using the same wire TSN");
+            let mut stream = sender.open_stream(1, ppi)?;
+            stream.set_reliability_params(false, policy, value)?;
+            stream.write_sctp(now, &old, ppi)?;
+            let sent = transmitted_data(&sender.gather_outbound(now).0);
+            assert_eq!(sent.len(), 1);
+            receiver.handle_data(&sent[0])?;
+            assert_eq!(
+                receiver
+                    .stream(1)?
+                    .read_sctp()?
+                    .unwrap()
+                    .to_payload(1024)?
+                    .freeze(),
+                old
+            );
+            let delayed_sack = receiver.create_selective_ack_chunk();
+
+            // The message can be selected for recovery before its real peer
+            // acknowledgment arrives, even though the peer already delivered it.
+            let retry_at = now + Duration::from_millis(100);
+            let candidates =
+                sender.unretransmittable_messages(retry_at, ChunkPayloadData::is_outstanding);
+            assert_eq!(candidates.len(), 1);
+            let selected = candidates[0];
+            assert!(sender.abandon_message(selected));
+            assert!(!sender.abandon_message(selected));
+            sender.handle_sack(&delayed_sack, retry_at)?;
+            assert!(sender.inflight_queue.is_empty());
+            assert_eq!(sender.stream(1)?.buffered_amount()?, 0);
+
+            // Elide a complete cycle of acknowledged TSNs instead of sending
+            // 2^32 packets. Message identity and stream sequence state are not
+            // rewound: this is a new message, not the old transport obligation.
+            sender.my_next_tsn = first_tsn;
+            sender.cumulative_tsn_ack_point = first_tsn.wrapping_sub(1);
+            sender.advanced_peer_tsn_ack_point = first_tsn.wrapping_sub(1);
+            receiver.peer_last_tsn = first_tsn.wrapping_sub(1);
+            sender.stream(1)?.write_sctp(retry_at, &fresh, ppi)?;
+            let sent = transmitted_data(&sender.gather_outbound(retry_at).0);
+            assert_eq!(sent.len(), 1);
+            assert_eq!(sent[0].tsn, first_tsn);
+            assert_ne!(
+                sender.inflight_queue.get(first_tsn).unwrap().message_id,
+                Some(selected.id)
+            );
+
+            assert!(
+                !sender.abandon_message(selected),
+                "a previously selected TSN must not identify the new message"
+            );
+            assert_eq!(sender.inflight_queue.outstanding_bytes(), fresh.len());
+            assert_eq!(sender.stream(1)?.buffered_amount()?, fresh.len());
+            receiver.handle_data(&sent[0])?;
+            assert_eq!(
+                receiver
+                    .stream(1)?
+                    .read_sctp()?
+                    .unwrap()
+                    .to_payload(1024)?
+                    .freeze(),
+                fresh
+            );
+            sender.handle_sack(&receiver.create_selective_ack_chunk(), retry_at)?;
+            assert!(sender.inflight_queue.is_empty());
+            assert_eq!(sender.stream(1)?.buffered_amount()?, 0);
+            let mut released = 0;
+            while let Some(event) = sender.poll() {
+                if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) = event {
+                    released += n_bytes;
+                }
+            }
+            assert_eq!(released, old.len() + fresh.len());
+        }
+    }
+    Ok(())
+}

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -1869,7 +1869,7 @@ impl Association {
         let mut newly_acked_data = false;
         // Abandoned DATA can precede the earliest outstanding TSN. RFC 9260
         // 6.3.2 R3 applies to that outstanding DATA, including gap acknowledgments.
-        let earliest_outstanding = self.inflight_queue.sorted.iter().copied().find(|tsn| {
+        let earliest_outstanding = self.inflight_queue.tsns().find(|tsn| {
             self.inflight_queue
                 .get(*tsn)
                 .is_some_and(ChunkPayloadData::is_outstanding)
@@ -1937,58 +1937,97 @@ impl Association {
 
         let mut htna = d.cumulative_tsn_ack;
 
-        // Record peer acknowledgments independently of local payload release.
+        // Compare ranges before visiting DATA. A long-lived hole can make each
+        // SACK repeat tens of thousands of already acknowledged TSNs. Only the
+        // newly covered portions need queue lookups; revocation above preserves
+        // recovery when an old gap disappears (RFC 9260 6.2.1 D(iii)).
+        let mut previous_gap = 0;
         for g in &d.gap_ack_blocks {
-            for i in g.start..=g.end {
-                let tsn = d.cumulative_tsn_ack.wrapping_add(i as u32);
-
-                let GapAck::New {
-                    chunk: c,
-                    released_buffer,
-                    delivery_credit,
-                } = self
-                    .inflight_queue
-                    .acknowledge(tsn, self.use_forward_tsn)
-                    .ok_or(Error::ErrTsnRequestNotExist)?
-                else {
-                    continue;
-                };
-                newly_acked_data |= c.nsent > 0;
-                total_bytes_acked += delivery_credit as i64;
-                if self
-                    .streams
-                    .get(&c.stream_identifier)
-                    .is_some_and(|s| s.generation == c.stream_generation)
+            let mut offset = u32::from(g.start);
+            let end = u32::from(g.end);
+            while offset <= end {
+                let tsn = d.cumulative_tsn_ack.wrapping_add(offset);
+                while self
+                    .peer_gap_ack_ranges
+                    .get(previous_gap)
+                    .is_some_and(|&(_, old_end)| sna32lt(old_end, tsn))
                 {
-                    *bytes_acked_per_stream
-                        .entry(c.stream_identifier)
-                        .or_default() += released_buffer as i64;
+                    previous_gap += 1;
                 }
+                let previous = self.peer_gap_ack_ranges.get(previous_gap);
+                if let Some(&(old_start, old_end)) = previous
+                    && sna32lte(old_start, tsn)
+                {
+                    offset = old_end.wrapping_sub(d.cumulative_tsn_ack) + 1;
+                    continue;
+                }
+                let new_end = previous.map_or(end, |&(old_start, _)| {
+                    end.min(old_start.wrapping_sub(d.cumulative_tsn_ack) - 1)
+                });
+                // Keep range comparisons outside the per-TSN loop, including
+                // the common case where this entire gap is newly acknowledged.
+                for i in offset..=new_end {
+                    let tsn = d.cumulative_tsn_ack.wrapping_add(i);
 
-                trace!("[{}] tsn={} has been sacked", self.side, c.tsn);
+                    let GapAck::New {
+                        chunk: c,
+                        released_buffer,
+                        delivery_credit,
+                    } = self
+                        .inflight_queue
+                        .acknowledge(tsn, self.use_forward_tsn)
+                        .ok_or(Error::ErrTsnRequestNotExist)?
+                    else {
+                        continue;
+                    };
+                    newly_acked_data |= c.nsent > 0;
+                    total_bytes_acked += delivery_credit as i64;
+                    if self
+                        .streams
+                        .get(&c.stream_identifier)
+                        .is_some_and(|s| s.generation == c.stream_generation)
+                    {
+                        *bytes_acked_per_stream
+                            .entry(c.stream_identifier)
+                            .or_default() += released_buffer as i64;
+                    }
 
-                if !c.abandoned() && c.nsent == 1 {
-                    self.min_tsn2measure_rtt = self.my_next_tsn;
-                    if let Some(since) = &c.since {
-                        let rtt = now.duration_since(*since);
-                        let srtt = self.rto_mgr.set_new_rtt(rtt.as_millis() as u64);
-                        trace!(
-                            "[{}] SACK: measured-rtt={} srtt={} new-rto={}",
-                            self.side,
-                            rtt.as_millis(),
-                            srtt,
-                            self.rto_mgr.get_rto()
-                        );
-                    } else {
-                        error!("[{}] invalid c.since", self.side);
+                    trace!("[{}] tsn={} has been sacked", self.side, c.tsn);
+
+                    if !c.abandoned() && c.nsent == 1 {
+                        self.min_tsn2measure_rtt = self.my_next_tsn;
+                        if let Some(since) = &c.since {
+                            let rtt = now.duration_since(*since);
+                            let srtt = self.rto_mgr.set_new_rtt(rtt.as_millis() as u64);
+                            trace!(
+                                "[{}] SACK: measured-rtt={} srtt={} new-rto={}",
+                                self.side,
+                                rtt.as_millis(),
+                                srtt,
+                                self.rto_mgr.get_rto()
+                            );
+                        } else {
+                            error!("[{}] invalid c.since", self.side);
+                        }
+                    }
+
+                    if sna32lt(htna, tsn) {
+                        htna = tsn;
                     }
                 }
-
-                if sna32lt(htna, tsn) {
-                    htna = tsn;
-                }
+                offset = new_end + 1;
             }
         }
+        // The cache describes successfully processed peer evidence. Keep the
+        // previous SACK until both revocation and new-ACK processing finish.
+        self.peer_gap_ack_ranges.clear();
+        self.peer_gap_ack_ranges
+            .extend(d.gap_ack_blocks.iter().map(|gap| {
+                (
+                    d.cumulative_tsn_ack.wrapping_add(gap.start as u32),
+                    d.cumulative_tsn_ack.wrapping_add(gap.end as u32),
+                )
+            }));
 
         // RFC 9260 8.1-8.2: an acknowledgment of new DATA clears the error
         // counter, including a late SACK after local abandonment. Payload
@@ -2053,14 +2092,6 @@ impl Association {
                 offset = missing_end + 1;
             }
         }
-        self.peer_gap_ack_ranges.clear();
-        self.peer_gap_ack_ranges
-            .extend(d.gap_ack_blocks.iter().map(|gap| {
-                (
-                    d.cumulative_tsn_ack.wrapping_add(gap.start as u32),
-                    d.cumulative_tsn_ack.wrapping_add(gap.end as u32),
-                )
-            }));
         revoked
     }
 
@@ -2942,7 +2973,7 @@ impl Association {
     ) -> Vec<MessageToAbandon> {
         let mut messages = vec![];
         let mut selected = rustc_hash::FxHashSet::default();
-        for &tsn in &self.inflight_queue.sorted {
+        for tsn in self.inflight_queue.tsns() {
             let c = self.inflight_queue.get(tsn).unwrap();
             if c.is_outstanding()
                 && self.retransmission_policy_exhausted(c, now, is_candidate(c))

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -37,7 +37,7 @@ use crate::param::{
     param_supported_extensions::ParamSupportedExtensions,
 };
 use crate::queue::{
-    payload_queue::PayloadQueue,
+    payload_queue::{GapAck, PayloadQueue},
     pending_queue::{PendingQueue, ResetMarker},
     receive_queue::{DeferredReceive, ReceiveQueue},
 };
@@ -762,6 +762,7 @@ impl Association {
             self.transmit_streams.clear();
             self.pending_queue = PendingQueue::new();
             self.inflight_queue = PayloadQueue::default();
+            self.peer_gap_ack_ranges.clear();
             self.payload_queue = PayloadQueue::default();
             self.incoming_resets = IncomingResetQueue::new(0);
             self.fwd_tsn_stream_map.clear();
@@ -1941,53 +1942,50 @@ impl Association {
             for i in g.start..=g.end {
                 let tsn = d.cumulative_tsn_ack.wrapping_add(i as u32);
 
-                let newly_acknowledged = self.inflight_queue.acknowledge(tsn);
-                let n_bytes_acked = if newly_acknowledged {
-                    self.inflight_queue.release_buffer(tsn) as i64
-                } else {
-                    0
-                };
-
-                let delivery_credit = self
+                let GapAck::New {
+                    chunk: c,
+                    released_buffer,
+                    delivery_credit,
+                } = self
                     .inflight_queue
-                    .get_mut(tsn)
-                    .map_or(0, ChunkPayloadData::take_delivery_credit)
-                    as i64;
-                if let Some(c) = self.inflight_queue.get(tsn) {
-                    if newly_acknowledged {
-                        newly_acked_data |= c.nsent > 0;
-                        total_bytes_acked += delivery_credit;
-                        if self.is_current_stream_data(c) {
-                            *bytes_acked_per_stream
-                                .entry(c.stream_identifier)
-                                .or_default() += n_bytes_acked;
-                        }
+                    .acknowledge(tsn)
+                    .ok_or(Error::ErrTsnRequestNotExist)?
+                else {
+                    continue;
+                };
+                newly_acked_data |= c.nsent > 0;
+                total_bytes_acked += delivery_credit as i64;
+                if self
+                    .streams
+                    .get(&c.stream_identifier)
+                    .is_some_and(|s| s.generation == c.stream_generation)
+                {
+                    *bytes_acked_per_stream
+                        .entry(c.stream_identifier)
+                        .or_default() += released_buffer as i64;
+                }
 
-                        trace!("[{}] tsn={} has been sacked", self.side, c.tsn);
+                trace!("[{}] tsn={} has been sacked", self.side, c.tsn);
 
-                        if !c.abandoned() && c.nsent == 1 {
-                            self.min_tsn2measure_rtt = self.my_next_tsn;
-                            if let Some(since) = &c.since {
-                                let rtt = now.duration_since(*since);
-                                let srtt = self.rto_mgr.set_new_rtt(rtt.as_millis() as u64);
-                                trace!(
-                                    "[{}] SACK: measured-rtt={} srtt={} new-rto={}",
-                                    self.side,
-                                    rtt.as_millis(),
-                                    srtt,
-                                    self.rto_mgr.get_rto()
-                                );
-                            } else {
-                                error!("[{}] invalid c.since", self.side);
-                            }
-                        }
-
-                        if sna32lt(htna, tsn) {
-                            htna = tsn;
-                        }
+                if !c.abandoned() && c.nsent == 1 {
+                    self.min_tsn2measure_rtt = self.my_next_tsn;
+                    if let Some(since) = &c.since {
+                        let rtt = now.duration_since(*since);
+                        let srtt = self.rto_mgr.set_new_rtt(rtt.as_millis() as u64);
+                        trace!(
+                            "[{}] SACK: measured-rtt={} srtt={} new-rto={}",
+                            self.side,
+                            rtt.as_millis(),
+                            srtt,
+                            self.rto_mgr.get_rto()
+                        );
+                    } else {
+                        error!("[{}] invalid c.since", self.side);
                     }
-                } else {
-                    return Err(Error::ErrTsnRequestNotExist);
+                }
+
+                if sna32lt(htna, tsn) {
+                    htna = tsn;
                 }
             }
         }

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -1502,6 +1502,9 @@ impl Association {
                 self.side, self.cumulative_tsn_ack_point, d.cumulative_tsn_ack
             );
 
+            // The complete cumulative-pop batch and all borrowed gap-ACK views
+            // are finished before queue storage can move.
+            self.inflight_queue.shrink_after_cumulative_ack();
             self.cumulative_tsn_ack_point = d.cumulative_tsn_ack;
             while self
                 .reset_tsn_ack_queue
@@ -2109,7 +2112,7 @@ impl Association {
         } else {
             trace!("[{}] T3-rtx timer start (pt2)", self.side);
             self.timers
-                .restart_if_stale(Timer::T3RTX, now, self.rto_mgr.get_rto());
+                .start_if_idle(Timer::T3RTX, now, self.rto_mgr.get_rto());
         }
 
         // Update congestion control parameters
@@ -2260,7 +2263,7 @@ impl Association {
             // Start timer. (noop if already started)
             trace!("[{}] T3-rtx timer start (pt3)", self.side);
             self.timers
-                .restart_if_stale(Timer::T3RTX, now, self.rto_mgr.get_rto());
+                .start_if_idle(Timer::T3RTX, now, self.rto_mgr.get_rto());
         } else if state == AssociationState::ShutdownPending {
             // No more outstanding, send shutdown.
             should_awake_write_loop = true;
@@ -2616,7 +2619,7 @@ impl Association {
             // Start timer. (noop if already started)
             trace!("[{}] T3-rtx timer start (pt1)", self.side);
             self.timers
-                .restart_if_stale(Timer::T3RTX, now, self.rto_mgr.get_rto());
+                .start_if_idle(Timer::T3RTX, now, self.rto_mgr.get_rto());
 
             self.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
         }
@@ -3059,7 +3062,7 @@ impl Association {
             self.cumulative_tsn_ack_point,
         ) {
             self.timers
-                .restart_if_stale(Timer::T3RTX, now, self.rto_mgr.get_rto());
+                .start_if_idle(Timer::T3RTX, now, self.rto_mgr.get_rto());
         }
     }
 

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -4,33 +4,49 @@ use crate::association::{
 };
 use crate::chunk::chunk_header::CHUNK_HEADER_SIZE;
 use crate::chunk::{
-    Chunk, ErrorCauseUnrecognizedChunkType, USER_INITIATED_ABORT, chunk_abort::ChunkAbort,
-    chunk_cookie_ack::ChunkCookieAck, chunk_cookie_echo::ChunkCookieEcho, chunk_error::ChunkError,
-    chunk_forward_tsn::ChunkForwardTsn, chunk_forward_tsn::ChunkForwardTsnStream,
-    chunk_heartbeat::ChunkHeartbeat, chunk_heartbeat_ack::ChunkHeartbeatAck, chunk_init::ChunkInit,
-    chunk_init::ChunkInitAck, chunk_payload_data::ChunkPayloadData,
-    chunk_payload_data::PayloadProtocolIdentifier, chunk_reconfig::ChunkReconfig,
-    chunk_selective_ack::ChunkSelectiveAck, chunk_shutdown::ChunkShutdown,
-    chunk_shutdown_ack::ChunkShutdownAck, chunk_shutdown_complete::ChunkShutdownComplete,
-    chunk_type::CT_FORWARD_TSN,
+    Chunk, ErrorCauseUnrecognizedChunkType, USER_INITIATED_ABORT,
+    chunk_abort::ChunkAbort,
+    chunk_cookie_ack::ChunkCookieAck,
+    chunk_cookie_echo::ChunkCookieEcho,
+    chunk_error::ChunkError,
+    chunk_forward_tsn::ChunkForwardTsn,
+    chunk_forward_tsn::ChunkForwardTsnStream,
+    chunk_heartbeat::ChunkHeartbeat,
+    chunk_heartbeat_ack::ChunkHeartbeatAck,
+    chunk_init::ChunkInit,
+    chunk_init::ChunkInitAck,
+    chunk_payload_data::ChunkPayloadData,
+    chunk_payload_data::PayloadProtocolIdentifier,
+    chunk_payload_data::{MessageId, MessageReliability},
+    chunk_reconfig::ChunkReconfig,
+    chunk_selective_ack::ChunkSelectiveAck,
+    chunk_shutdown::ChunkShutdown,
+    chunk_shutdown_ack::ChunkShutdownAck,
+    chunk_shutdown_complete::ChunkShutdownComplete,
+    chunk_type::{CT_FORWARD_TSN, CT_RECONFIG},
 };
 use crate::config::{COMMON_HEADER_SIZE, DATA_CHUNK_HEADER_SIZE, ServerConfig, TransportConfig};
 use crate::packet::{CommonHeader, Packet};
 use crate::param::{
     Param,
+    param_forward_tsn_supported::ParamForwardTsnSupported,
     param_heartbeat_info::ParamHeartbeatInfo,
     param_outgoing_reset_request::ParamOutgoingResetRequest,
     param_reconfig_response::{ParamReconfigResponse, ReconfigResult},
     param_state_cookie::ParamStateCookie,
     param_supported_extensions::ParamSupportedExtensions,
 };
-use crate::queue::{payload_queue::PayloadQueue, pending_queue::PendingQueue};
+use crate::queue::{
+    payload_queue::PayloadQueue,
+    pending_queue::{PendingQueue, ResetMarker},
+    receive_queue::{DeferredReceive, ReceiveQueue},
+};
 use crate::shared::{AssociationEventInner, AssociationId, EndpointEvent, EndpointEventInner};
 use crate::util::{constant_time_eq, sna16lt, sna32gt, sna32gte, sna32lt, sna32lte};
 use crate::{AssociationEvent, Payload, Side};
 use shared::error::{Error, Result};
 use shared::{TransportContext, TransportMessage, TransportProtocol};
-use stream::{ReliabilityType, Stream, StreamEvent, StreamId, StreamState};
+use stream::{Stream, StreamEvent, StreamId, StreamState};
 use timer::{ACK_INTERVAL, RtoManager, Timer, TimerTable};
 
 use crate::association::stream::RecvSendState;
@@ -38,20 +54,27 @@ use bytes::{Bytes, BytesMut};
 use log::{debug, error, trace, warn};
 use rand::random;
 use rustc_hash::FxHashMap;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 
+mod reset;
+mod reset_receive;
+use reset_receive::{IncomingResetQueue, ReceiveResetAction};
 pub(crate) mod state;
 pub(crate) mod stats;
 pub(crate) mod stream;
 pub(crate) mod timer;
+mod transmit;
+use reset::OutgoingReset;
 
 #[cfg(test)]
 mod association_test;
+#[cfg(test)]
+mod model_test;
 
 /// Reasons why an association might be lost
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -110,6 +133,25 @@ pub enum Event {
     DatagramReceived,
 }
 
+/// Effects of one validated SACK, keeping buffer release, delivery credit and
+/// advisory acknowledgments distinct.
+struct SackProgress {
+    bytes_acked_per_stream: FxHashMap<u16, i64>,
+    total_bytes_acked: i64,
+    htna: u32,
+    // Serial TSN order, so recovery can merge these with its normal prefix.
+    revoked: Vec<u32>,
+}
+
+/// Selection is stable even after fragments leave either queue.
+#[derive(Debug, Copy, Clone)]
+struct MessageToAbandon {
+    id: MessageId,
+    // A whole message is already identified by its candidate TSN. Fragmented
+    // messages still use the group index, including when selected in pending.
+    sent_tsn: Option<u32>,
+}
+
 ///Association represents an SCTP association
 //13.2.  Parameters Necessary per Association (i.e., the TCB)
 //Peer : Tag value to be sent in every packet and is received
@@ -158,9 +200,15 @@ pub struct Association {
 
     // Reconfig
     my_next_rsn: u32,
-    reconfigs: HashMap<u32, ChunkReconfig>,
-    reconfig_requests: HashMap<u32, ParamOutgoingResetRequest>,
-
+    next_stream_generation: u64,
+    next_message_id: u64,
+    transmit_streams: FxHashMap<StreamId, transmit::TransmitStream>,
+    pub(crate) receive_streams: FxHashMap<StreamId, ReceiveQueue>,
+    receive_buffered_bytes: usize,
+    pending_receivers: BTreeSet<StreamId>,
+    peer_supports_reconfig: bool,
+    outgoing_reset: Option<OutgoingReset>,
+    incoming_resets: IncomingResetQueue,
     // Non-RFC internal data
     remote_addr: SocketAddr,
     local_addr: SocketAddr,
@@ -174,6 +222,9 @@ pub struct Association {
 
     pub(crate) payload_queue: PayloadQueue,
     inflight_queue: PayloadQueue,
+    /// Absolute, inclusive ranges from the last validated SACK. Comparing
+    /// ranges detects reneging without visiting every outstanding DATA chunk.
+    peer_gap_ack_ranges: Vec<(u32, u32)>,
     pending_queue: PendingQueue,
     control_queue: VecDeque<Packet>,
     stream_queue: VecDeque<u16>,
@@ -187,13 +238,18 @@ pub struct Association {
     /// Max stream-sequence-number per *ordered* stream among abandoned chunks
     /// currently in the forward-TSN window `(cumulative_tsn_ack_point,
     /// advanced_peer_tsn_ack_point]`. Maintained incrementally as chunks are
-    /// abandoned (the two RFC 3758 C2 loops) so that `create_forward_tsn` is
+    /// abandoned (the RFC 3758 C2 walk) so that `create_forward_tsn` is
     /// O(streams) instead of rescanning the whole in-flight window — which, for
     /// PR-SCTP data channels, ran ~1000 hashmap probes per FORWARD-TSN and was
     /// ~9% of send CPU in profiles. Unordered chunks are omitted: the receiver
     /// ignores the per-stream list for them (it advances by `new_cumulative_tsn`
     /// alone), so reporting them was pure waste.
     fwd_tsn_stream_map: FxHashMap<u16, u16>,
+    /// Successful outgoing resets retire SSNs through their last assigned TSN.
+    /// Keep these bounds only while old DATA can remain locally in flight.
+    confirmed_reset_tsns: FxHashMap<u16, u32>,
+    /// Successful reset bounds in TSN order, even if results arrived out of order.
+    reset_tsn_ack_queue: VecDeque<(u32, Vec<u16>)>,
 
     pub(crate) rto_mgr: RtoManager,
     timers: TimerTable,
@@ -204,6 +260,7 @@ pub struct Association {
     pub(crate) cwnd: u32,
     // calculated peer's receiver windows size
     rwnd: u32,
+    zero_window_probe: Option<u32>,
     // slow start threshold
     pub(crate) ssthresh: u32,
     partial_bytes_acked: u32,
@@ -260,8 +317,15 @@ impl Default for Association {
 
             // Reconfig
             my_next_rsn: 0,
-            reconfigs: HashMap::default(),
-            reconfig_requests: HashMap::default(),
+            next_stream_generation: 0,
+            next_message_id: 0,
+            transmit_streams: FxHashMap::default(),
+            receive_streams: FxHashMap::default(),
+            receive_buffered_bytes: 0,
+            pending_receivers: BTreeSet::new(),
+            peer_supports_reconfig: false,
+            outgoing_reset: None,
+            incoming_resets: IncomingResetQueue::new(0),
 
             // Non-RFC internal data
             remote_addr: SocketAddr::from_str("0.0.0.0:0").unwrap(),
@@ -276,6 +340,7 @@ impl Default for Association {
 
             payload_queue: PayloadQueue::default(),
             inflight_queue: PayloadQueue::default(),
+            peer_gap_ack_ranges: Vec::new(),
             pending_queue: PendingQueue::default(),
             control_queue: VecDeque::default(),
             stream_queue: VecDeque::default(),
@@ -287,6 +352,8 @@ impl Default for Association {
             advanced_peer_tsn_ack_point: 0,
             use_forward_tsn: false,
             fwd_tsn_stream_map: FxHashMap::default(),
+            confirmed_reset_tsns: FxHashMap::default(),
+            reset_tsn_ack_queue: VecDeque::default(),
 
             rto_mgr: RtoManager::default(),
             timers: TimerTable::default(),
@@ -297,6 +364,7 @@ impl Default for Association {
             cwnd: 0,
             // calculated peer's receiver windows size
             rwnd: 0,
+            zero_window_probe: None,
             // slow start threshold
             ssthresh: 0,
             partial_bytes_acked: 0,
@@ -417,8 +485,10 @@ impl Association {
     /// Associations should be polled for events after:
     /// - a call was made to `handle_event`
     /// - a call was made to `handle_timeout`
+    /// - a call was made to `poll_transmit`, which can abandon expired messages
     #[must_use]
     pub fn poll(&mut self) -> Option<Event> {
+        self.publish_ready_streams();
         if let Some(x) = self.events.pop_front() {
             return Some(x);
         }
@@ -449,7 +519,11 @@ impl Association {
     /// - a call was made to `handle_timeout`
     #[must_use]
     pub fn poll_timeout(&self) -> Option<Instant> {
-        self.timers.next_timeout()
+        self.timers
+            .next_timeout()
+            .into_iter()
+            .chain(self.next_reconfig_result_retry().map(|(_, at)| at))
+            .min()
     }
 
     /// Returns packets to transmit
@@ -506,7 +580,7 @@ impl Association {
             } else if failure {
                 self.on_retransmission_failure(timer);
             } else {
-                self.on_retransmission_timeout(timer, n_rtos);
+                self.on_retransmission_timeout(timer, n_rtos, now);
                 self.timers.start(timer, now, self.rto_mgr.get_rto());
             }
         }
@@ -676,11 +750,24 @@ impl Association {
             debug!("[{}] closing association..", self.side);
 
             self.close_all_timers();
+            self.outgoing_reset = None;
 
             for si in self.streams.keys().cloned().collect::<Vec<u16>>() {
                 self.unregister_stream(si, reason.clone());
             }
 
+            self.receive_streams.clear();
+            self.receive_buffered_bytes = 0;
+            self.pending_receivers.clear();
+            self.transmit_streams.clear();
+            self.pending_queue = PendingQueue::new();
+            self.inflight_queue = PayloadQueue::default();
+            self.payload_queue = PayloadQueue::default();
+            self.incoming_resets = IncomingResetQueue::new(0);
+            self.fwd_tsn_stream_map.clear();
+            self.confirmed_reset_tsns.clear();
+            self.reset_tsn_ack_queue.clear();
+            self.control_queue.clear();
             debug!("[{}] association closed", self.side);
             debug!(
                 "[{}] stats nDATAs (in) : {}",
@@ -718,6 +805,7 @@ impl Association {
         stream_identifier: StreamId,
         default_payload_type: PayloadProtocolIdentifier,
     ) -> Result<Stream<'_>> {
+        self.publish_ready_streams();
         if self.streams.contains_key(&stream_identifier) {
             return Err(Error::ErrStreamAlreadyExist);
         }
@@ -731,6 +819,7 @@ impl Association {
 
     /// accept_stream accepts a stream
     pub fn accept_stream(&mut self) -> Option<Stream<'_>> {
+        self.publish_ready_streams();
         self.stream_queue
             .pop_front()
             .map(move |stream_identifier| Stream {
@@ -741,6 +830,7 @@ impl Association {
 
     /// stream returns a stream
     pub fn stream(&mut self, stream_identifier: StreamId) -> Result<Stream<'_>> {
+        self.publish_ready_streams();
         if !self.streams.contains_key(&stream_identifier) {
             Err(Error::ErrStreamNotExisted)
         } else {
@@ -779,44 +869,65 @@ impl Association {
     /// unregister_stream un-registers a stream from the association
     /// The caller should hold the association write lock.
     fn unregister_stream(&mut self, stream_identifier: StreamId, reason: AssociationError) {
-        if let Some(mut s) = self.streams.remove(&stream_identifier) {
+        if self.streams.remove(&stream_identifier).is_some() {
             debug!("[{}] unregister_stream {}", self.side, stream_identifier);
             self.events.push_back(Event::AssociationLost {
                 reason,
                 id: stream_identifier,
             });
-            s.state = RecvSendState::Closed;
+            self.stream_queue.retain(|id| *id != stream_identifier);
         }
     }
 
-    /// Re-run any reset request that was answered In Progress because
-    /// `stream_identifier` still had data the application had not collected
-    /// Called when that stream drains.
-    ///
-    /// The reply is queued like any other control packet; a request naming
-    /// several streams is retried as a whole and simply defers again if another
-    /// of its streams is still readable.
-    pub(crate) fn retry_deferred_resets(&mut self, stream_identifier: StreamId) {
-        let pending: Vec<ParamOutgoingResetRequest> = self
-            .reconfig_requests
-            .values()
-            .filter(|p| p.stream_identifiers.contains(&stream_identifier))
-            .cloned()
-            .collect();
-        if pending.is_empty() {
+    /// Retire the API receiver only after its saved messages have been read.
+    pub(crate) fn finish_stream_delivery(&mut self, id: StreamId) {
+        let Some(received) = self.receive_streams.get_mut(&id) else {
+            return;
+        };
+        if !received.finish_delivery() {
             return;
         }
+        if received.is_readable() {
+            self.pending_receivers.insert(id);
+        }
+        self.unregister_stream(id, AssociationError::Reset);
+    }
 
-        let mut reply = vec![];
-        for p in pending {
-            if let Err(err) = self.reset_streams_if_any(&p, true, &mut reply) {
-                debug!("[{}] retry of deferred reset failed: {:?}", self.side, err);
+    /// Account every payload mutation at the RX ownership boundary. Complete
+    /// delivery, incomplete reassembly and deferred future DATA share rwnd.
+    /// Lifecycle-only changes do not change this charge.
+    pub(crate) fn with_receive_queue<R>(
+        &mut self,
+        id: StreamId,
+        update: impl FnOnce(&mut ReceiveQueue) -> R,
+    ) -> R {
+        let received = self
+            .receive_streams
+            .entry(id)
+            .or_insert_with(|| ReceiveQueue::new(id));
+        let before = received.get_num_bytes();
+        let result = update(received);
+        self.receive_buffered_bytes =
+            self.receive_buffered_bytes - before + received.get_num_bytes();
+        result
+    }
+
+    fn publish_ready_streams(&mut self) {
+        // Only retiring a saved delivery can expose another receiver without
+        // incoming DATA creating it. Avoid scanning every retained SID for
+        // every event; old close events remain ahead of the new publication.
+        while let Some(id) = self.pending_receivers.pop_first() {
+            if !self.streams.contains_key(&id)
+                && self
+                    .receive_streams
+                    .get(&id)
+                    .is_some_and(ReceiveQueue::is_readable)
+            {
+                self.create_stream(id, true, PayloadProtocolIdentifier::default());
+                self.events
+                    .push_back(Event::Stream(StreamEvent::Readable { id }));
             }
         }
-        for packet in reply {
-            self.control_queue.push_back(packet);
-        }
-        self.awake_write_loop();
     }
 
     /// set_state atomically sets the state of the Association.
@@ -957,7 +1068,7 @@ impl Association {
         } else if let Some(c) = chunk_any.downcast_ref::<ChunkSelectiveAck>() {
             self.handle_sack(c, now)?
         } else if let Some(c) = chunk_any.downcast_ref::<ChunkReconfig>() {
-            self.handle_reconfig(c)?
+            self.handle_reconfig(now, c)?
         } else if let Some(c) = chunk_any.downcast_ref::<ChunkForwardTsn>() {
             self.handle_forward_tsn(c)?
         } else if let Some(c) = chunk_any.downcast_ref::<ChunkShutdown>() {
@@ -1001,9 +1112,9 @@ impl Association {
 
         // Should we be setting any of these permanently until we've ACKed further?
         self.my_max_num_inbound_streams =
-            std::cmp::min(i.num_inbound_streams, self.my_max_num_inbound_streams);
+            std::cmp::min(i.num_outbound_streams, self.my_max_num_inbound_streams);
         self.my_max_num_outbound_streams =
-            std::cmp::min(i.num_outbound_streams, self.my_max_num_outbound_streams);
+            std::cmp::min(i.num_inbound_streams, self.my_max_num_outbound_streams);
         self.peer_verification_tag = i.initiate_tag;
         self.source_port = p.common_header.destination_port;
         self.destination_port = p.common_header.source_port;
@@ -1012,6 +1123,7 @@ impl Association {
         // is set initially by taking the peer's initial TSN,
         // received in the INIT or INIT ACK chunk, and
         // subtracting one from it.
+        self.incoming_resets = IncomingResetQueue::new(i.initial_tsn);
         self.peer_last_tsn = if i.initial_tsn == 0 {
             u32::MAX
         } else {
@@ -1028,19 +1140,7 @@ impl Association {
         debug!("[{}] initial rwnd={}", self.side, self.rwnd);
         self.ssthresh = self.rwnd;
 
-        for param in &i.params {
-            if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
-                for t in &v.chunk_types {
-                    if *t == CT_FORWARD_TSN {
-                        debug!("[{}] use ForwardTSN (on init)", self.side);
-                        self.use_forward_tsn = true;
-                    }
-                }
-            }
-        }
-        if !self.use_forward_tsn {
-            warn!("[{}] not using ForwardTSN (on init)", self.side);
-        }
+        self.negotiate_extensions(&i.params);
 
         let mut outbound = Packet {
             common_header: CommonHeader {
@@ -1095,10 +1195,11 @@ impl Association {
         }
 
         self.my_max_num_inbound_streams =
-            std::cmp::min(i.num_inbound_streams, self.my_max_num_inbound_streams);
+            std::cmp::min(i.num_outbound_streams, self.my_max_num_inbound_streams);
         self.my_max_num_outbound_streams =
-            std::cmp::min(i.num_outbound_streams, self.my_max_num_outbound_streams);
+            std::cmp::min(i.num_inbound_streams, self.my_max_num_outbound_streams);
         self.peer_verification_tag = i.initiate_tag;
+        self.incoming_resets = IncomingResetQueue::new(i.initial_tsn);
         self.peer_last_tsn = if i.initial_tsn == 0 {
             u32::MAX
         } else {
@@ -1124,28 +1225,17 @@ impl Association {
             self.side,
             self.cwnd,
             self.ssthresh,
-            self.inflight_queue.get_num_bytes()
+            self.inflight_queue.outstanding_bytes()
         );
 
         self.timers.stop(Timer::T1Init);
         self.stored_init = None;
 
-        let mut cookie_param = None;
-        for param in &i.params {
-            if let Some(v) = param.as_any().downcast_ref::<ParamStateCookie>() {
-                cookie_param = Some(v);
-            } else if let Some(v) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
-                for t in &v.chunk_types {
-                    if *t == CT_FORWARD_TSN {
-                        debug!("[{}] use ForwardTSN (on initAck)", self.side);
-                        self.use_forward_tsn = true;
-                    }
-                }
-            }
-        }
-        if !self.use_forward_tsn {
-            warn!("[{}] not using ForwardTSN (on initAck)", self.side);
-        }
+        self.negotiate_extensions(&i.params);
+        let cookie_param = i
+            .params
+            .iter()
+            .find_map(|param| param.as_any().downcast_ref::<ParamStateCookie>());
 
         if let Some(v) = cookie_param {
             self.stored_cookie_echo = Some(ChunkCookieEcho {
@@ -1162,6 +1252,21 @@ impl Association {
             Ok(vec![])
         } else {
             Err(Error::ErrInitAckNoCookie)
+        }
+    }
+
+    fn negotiate_extensions(&mut self, params: &[Box<dyn Param>]) {
+        self.use_forward_tsn = false;
+        self.peer_supports_reconfig = false;
+        for param in params {
+            if param.as_any().is::<ParamForwardTsnSupported>() {
+                // RFC 3758 3.3: the original PR-SCTP advertisement remains
+                // valid independently of the newer supported-chunk list.
+                self.use_forward_tsn = true;
+            } else if let Some(ext) = param.as_any().downcast_ref::<ParamSupportedExtensions>() {
+                self.use_forward_tsn |= ext.chunk_types.contains(&CT_FORWARD_TSN);
+                self.peer_supports_reconfig |= ext.chunk_types.contains(&CT_RECONFIG);
+            }
         }
     }
 
@@ -1273,7 +1378,7 @@ impl Association {
         let can_push = self.payload_queue.can_push(d, self.peer_last_tsn);
         let mut stream_handle_data = false;
         if can_push {
-            if self.get_or_create_stream(d.stream_identifier).is_some() {
+            if d.stream_identifier < self.my_max_num_inbound_streams {
                 if self.get_my_receiver_window_credit() > 0 {
                     // Pass the new chunk to stream level as soon as it arrives
                     self.payload_queue.push(d.clone(), self.peer_last_tsn);
@@ -1337,13 +1442,9 @@ impl Association {
 
         let immediate_sack = d.immediate_sack;
 
-        if stream_handle_data && let Some(s) = self.streams.get_mut(&d.stream_identifier) {
+        if stream_handle_data {
             self.events.push_back(Event::DatagramReceived);
-            if s.handle_data(d) && s.reassembly_queue.is_readable() {
-                self.events.push_back(Event::Stream(StreamEvent::Readable {
-                    id: s.stream_identifier,
-                }));
-            }
+            self.deliver_received_data(d.clone());
         }
 
         self.handle_peer_last_tsn_and_acknowledgement(immediate_sack)
@@ -1385,12 +1486,12 @@ impl Association {
         }
 
         // Process selective ack
-        let (bytes_acked_per_stream, htna) = self.process_selective_ack(d, now)?;
-
-        let mut total_bytes_acked = 0;
-        for n_bytes_acked in bytes_acked_per_stream.values() {
-            total_bytes_acked += *n_bytes_acked;
-        }
+        let SackProgress {
+            bytes_acked_per_stream,
+            total_bytes_acked,
+            htna,
+            revoked,
+        } = self.process_selective_ack(d, now)?;
 
         let mut cum_tsn_ack_point_advanced = false;
         if sna32lt(self.cumulative_tsn_ack_point, d.cumulative_tsn_ack) {
@@ -1400,31 +1501,23 @@ impl Association {
             );
 
             self.cumulative_tsn_ack_point = d.cumulative_tsn_ack;
+            while self
+                .reset_tsn_ack_queue
+                .front()
+                .is_some_and(|(tsn, _)| sna32lte(*tsn, d.cumulative_tsn_ack))
+            {
+                let (tsn, streams) = self.reset_tsn_ack_queue.pop_front().unwrap();
+                for si in streams {
+                    if self.confirmed_reset_tsns.get(&si) == Some(&tsn) {
+                        self.confirmed_reset_tsns.remove(&si);
+                    }
+                }
+            }
             cum_tsn_ack_point_advanced = true;
             self.on_cumulative_tsn_ack_point_advanced(total_bytes_acked, now);
         }
 
-        for (si, n_bytes_acked) in &bytes_acked_per_stream {
-            if *n_bytes_acked > 0 {
-                // Report the exact bytes released for this stream (acknowledged OR
-                // abandoned — both funnel through bytes_acked_per_stream) so upper
-                // layers can decrement their own send-buffer accounting. Unlike the
-                // edge-triggered BufferedAmountLow advisory below, this fires on
-                // every release with the byte delta.
-                self.events
-                    .push_back(Event::Stream(StreamEvent::BufferedAmountReleased {
-                        id: *si,
-                        n_bytes: *n_bytes_acked as usize,
-                    }));
-            }
-            if let Some(s) = self.streams.get_mut(si)
-                && s.on_buffer_released(*n_bytes_acked)
-            {
-                trace!("StreamEvent::BufferedAmountLow");
-                self.events
-                    .push_back(Event::Stream(StreamEvent::BufferedAmountLow { id: *si }))
-            }
-        }
+        self.release_stream_buffers(&bytes_acked_per_stream);
 
         // New rwnd value
         // RFC 4960 sec 6.2.1.  Processing a Received SACK
@@ -1433,15 +1526,35 @@ impl Association {
         //       of bytes still outstanding after processing the Cumulative
         //       TSN Ack and the Gap Ack Blocks.
 
-        // bytes acked were already subtracted by markAsAcked() method
-        let bytes_outstanding = self.inflight_queue.get_num_bytes() as u32;
+        // acknowledged payload bytes were already released from the in-flight queue
+        let bytes_outstanding = self.inflight_queue.outstanding_bytes() as u32;
         if bytes_outstanding >= d.advertised_receiver_window_credit {
             self.rwnd = 0;
         } else {
             self.rwnd = d.advertised_receiver_window_credit - bytes_outstanding;
         }
 
-        self.process_fast_retransmission(d.cumulative_tsn_ack, htna, cum_tsn_ack_point_advanced)?;
+        if let Some(probe) = self.zero_window_probe {
+            let window_still_closed = self.inflight_queue.get(probe).is_some_and(|chunk| {
+                chunk.is_outstanding()
+                    && (d.advertised_receiver_window_credit as usize) < chunk.user_data.len()
+            });
+            if !window_still_closed {
+                self.zero_window_probe = None;
+            } else {
+                // RFC 9260 6.1 A: a reader may keep its window shut indefinitely
+                // while its SACKs demonstrate that the path is still alive.
+                // Positive credit smaller than the probe is also insufficient.
+                self.timers.reset_retrans(Timer::T3RTX);
+            }
+        }
+
+        self.process_fast_retransmission(
+            d.cumulative_tsn_ack,
+            htna,
+            cum_tsn_ack_point_advanced,
+            &revoked,
+        )?;
 
         if self.use_forward_tsn {
             // RFC 3758 Sec 3.5 C1
@@ -1455,44 +1568,7 @@ impl Association {
                 self.fwd_tsn_stream_map.clear();
             }
 
-            // RFC 3758 Sec 3.5 C2 — advance over newly-abandoned chunks,
-            // folding each ordered one into the forward-TSN stream map so
-            // create_forward_tsn needn't rescan the window.
-            let mut i = self.advanced_peer_tsn_ack_point + 1;
-            while let Some((abandoned, unordered, si, ssn)) = self.inflight_queue.get(i).map(|c| {
-                (
-                    c.abandoned(),
-                    c.unordered,
-                    c.stream_identifier,
-                    c.stream_sequence_number,
-                )
-            }) {
-                if !abandoned {
-                    break;
-                }
-                self.advanced_peer_tsn_ack_point = i;
-                self.note_abandoned_for_forward_tsn(unordered, si, ssn);
-                i += 1;
-            }
-
-            // RFC 3758 Sec 3.5 C3
-            if sna32gt(
-                self.advanced_peer_tsn_ack_point,
-                self.cumulative_tsn_ack_point,
-            ) {
-                self.will_send_forward_tsn = true;
-                debug!(
-                    "[{}] handleSack {}: sna32GT({}, {})",
-                    self.side,
-                    self.will_send_forward_tsn,
-                    self.advanced_peer_tsn_ack_point,
-                    self.cumulative_tsn_ack_point
-                );
-            } else {
-                // No forward-TSN window open (receiver has caught up): drop any
-                // stale per-stream SSNs so they aren't reported later.
-                self.fwd_tsn_stream_map.clear();
-            }
+            self.advance_peer_ack_point();
             self.awake_write_loop();
         }
 
@@ -1501,17 +1577,36 @@ impl Association {
         Ok(vec![])
     }
 
-    fn handle_reconfig(&mut self, c: &ChunkReconfig) -> Result<Vec<Packet>> {
+    fn handle_reconfig(&mut self, now: Instant, c: &ChunkReconfig) -> Result<Vec<Packet>> {
         trace!("[{}] handle_reconfig", self.side);
 
+        // RFC 6525 3.1: validate the whole supported parameter combination
+        // before applying either half. In particular, two outgoing requests
+        // cannot smuggle a second state transition into one RE-CONFIG.
+        let kind = |p: &dyn Param| {
+            if p.as_any().is::<ParamReconfigResponse>() {
+                0
+            } else if p.as_any().is::<ParamOutgoingResetRequest>() {
+                1
+            } else {
+                2
+            }
+        };
+        let combination = (
+            c.param_a.as_deref().map(kind),
+            c.param_b.as_deref().map(kind),
+        );
+        if !matches!(combination, (Some(0 | 1), None) | (Some(0), Some(0 | 1))) {
+            return Ok(vec![]);
+        }
         let mut pp = vec![];
 
         if let Some(param_a) = &c.param_a {
-            self.handle_reconfig_param(param_a, &mut pp)?;
+            self.handle_reconfig_param(now, param_a, &mut pp)?;
         }
 
         if let Some(param_b) = &c.param_b {
-            self.handle_reconfig_param(param_b, &mut pp)?;
+            self.handle_reconfig_param(now, param_b, &mut pp)?;
         }
 
         Ok(pp)
@@ -1569,36 +1664,27 @@ impl Association {
         //   chunk,
 
         // Advance peer_last_tsn
-        while sna32lt(self.peer_last_tsn, c.new_cumulative_tsn) {
-            self.payload_queue.pop(self.peer_last_tsn + 1); // may not exist
-            self.peer_last_tsn += 1;
+        while let Some(&tsn) = self.payload_queue.sorted.front()
+            && sna32lte(tsn, c.new_cumulative_tsn)
+        {
+            self.payload_queue.pop(tsn);
         }
+        self.peer_last_tsn = c.new_cumulative_tsn;
 
-        // Report new peer_last_tsn value and abandoned largest SSN value to
-        // corresponding streams so that the abandoned chunks can be removed
-        // from the reassemblyQueue.
+        // RX sequence state exists independently of API stream registration.
+        // An abandoned first message may precede the first DATA we ever receive.
         for forwarded in &c.streams {
-            if let Some(s) = self.streams.get_mut(&forwarded.identifier) {
-                s.handle_forward_tsn_for_ordered(forwarded.sequence);
-                if s.reassembly_queue.is_readable() {
-                    self.events.push_back(Event::Stream(StreamEvent::Readable {
-                        id: s.stream_identifier,
-                    }));
-                }
+            if forwarded.identifier >= self.my_max_num_inbound_streams {
+                continue;
             }
+            self.incoming_resets.observe_stream(forwarded.identifier);
+            self.with_receive_queue(forwarded.identifier, |received| {
+                received.forward_tsn_for_ordered(forwarded.sequence)
+            });
         }
-
-        // TSN may be forwarded for unordered chunks. ForwardTSN chunk does not
-        // report which stream identifier it skipped for unordered chunks.
-        // Therefore, we need to broadcast this event to all existing streams for
-        // unordered chunks.
-        for s in self.streams.values_mut() {
-            s.handle_forward_tsn_for_unordered(c.new_cumulative_tsn);
-            if s.reassembly_queue.is_readable() {
-                self.events.push_back(Event::Stream(StreamEvent::Readable {
-                    id: s.stream_identifier,
-                }));
-            }
+        let receive_ids: Vec<_> = self.receive_streams.keys().copied().collect();
+        for id in receive_ids {
+            self.forward_unordered_receive(id, c.new_cumulative_tsn);
         }
 
         self.handle_peer_last_tsn_and_acknowledgement(false)
@@ -1666,15 +1752,19 @@ impl Association {
         // Meaning, if peer_last_tsn+1 points to a chunk that is received,
         // advance peer_last_tsn until peer_last_tsn+1 points to unreceived chunk.
         //debug!("[{}] peer_last_tsn = {}", self.side, self.peer_last_tsn);
-        while self.payload_queue.pop(self.peer_last_tsn + 1).is_some() {
-            self.peer_last_tsn += 1;
+        while self
+            .payload_queue
+            .pop(self.peer_last_tsn.wrapping_add(1))
+            .is_some()
+        {
+            self.peer_last_tsn = self.peer_last_tsn.wrapping_add(1);
             //debug!("[{}] peer_last_tsn = {}", self.side, self.peer_last_tsn);
+        }
 
-            let rst_reqs: Vec<ParamOutgoingResetRequest> =
-                self.reconfig_requests.values().cloned().collect();
-            for rst_req in rst_reqs {
-                self.reset_streams_if_any(&rst_req, false, &mut reply)?;
-            }
+        // RFC 6525 5.2.2 E2-E5 also applies when FORWARD TSN filled the gap.
+        let sequences = self.incoming_resets.ready(self.peer_last_tsn);
+        for sequence in sequences {
+            self.retry_incoming_reset(sequence, &mut reply)?;
         }
 
         let has_packet_loss = !self.payload_queue.is_empty();
@@ -1708,19 +1798,42 @@ impl Association {
     #[allow(clippy::borrowed_box)]
     fn handle_reconfig_param(
         &mut self,
+        now: Instant,
         raw: &Box<dyn Param>,
         reply: &mut Vec<Packet>,
     ) -> Result<()> {
         if let Some(p) = raw.as_any().downcast_ref::<ParamOutgoingResetRequest>() {
-            self.reconfig_requests
-                .insert(p.reconfig_request_sequence_number, p.clone());
-            self.reset_streams_if_any(p, true, reply)?;
+            let action = self.incoming_resets.accept(
+                p,
+                self.receive_streams
+                    .keys()
+                    .chain(self.streams.keys())
+                    .copied(),
+                self.my_max_num_inbound_streams,
+            );
+            // E1 is part of accepting the request, not an unchecked way to stop
+            // another procedure's timer using an invalid/reused sequence number.
+            if !matches!(
+                action,
+                ReceiveResetAction::Reply(
+                    ReconfigResult::ErrorBadSequenceNumber | ReconfigResult::Denied
+                )
+            ) {
+                self.acknowledge_reconfig(p.reconfig_response_sequence_number, now);
+            }
+            let sequence = p.reconfig_request_sequence_number;
+            match action {
+                ReceiveResetAction::Reply(result) => {
+                    reply.push(self.reconfig_response_packet(sequence, result))
+                }
+                ReceiveResetAction::New | ReceiveResetAction::Pending => {
+                    self.retry_incoming_reset(sequence, reply)?
+                }
+            }
+            self.immediate_ack_triggered = true;
             Ok(())
         } else if let Some(p) = raw.as_any().downcast_ref::<ParamReconfigResponse>() {
-            self.reconfigs.remove(&p.reconfig_response_sequence_number);
-            if self.reconfigs.is_empty() {
-                self.timers.stop(Timer::Reconfig);
-            }
+            self.handle_reset_response(now, p);
             Ok(())
         } else {
             Err(Error::ErrParameterType)
@@ -1731,34 +1844,54 @@ impl Association {
         &mut self,
         d: &ChunkSelectiveAck,
         now: Instant,
-    ) -> Result<(FxHashMap<u16, i64>, u32)> {
+    ) -> Result<SackProgress> {
+        // Reject acknowledgments for unassigned TSNs before modifying queues.
+        if sna32gte(d.cumulative_tsn_ack, self.my_next_tsn) {
+            return Err(Error::ErrTsnRequestNotExist);
+        }
+        let mut last_end = 0;
+        for gap in &d.gap_ack_blocks {
+            if gap.start == 0
+                || gap.start <= last_end
+                || gap.end < gap.start
+                || sna32gte(
+                    d.cumulative_tsn_ack.wrapping_add(gap.end as u32),
+                    self.my_next_tsn,
+                )
+            {
+                return Err(Error::ErrTsnRequestNotExist);
+            }
+            last_end = gap.end;
+        }
         let mut bytes_acked_per_stream = FxHashMap::default();
+        let mut total_bytes_acked = 0;
+        let mut newly_acked_data = false;
+        // Abandoned DATA can precede the earliest outstanding TSN. RFC 9260
+        // 6.3.2 R3 applies to that outstanding DATA, including gap acknowledgments.
+        let earliest_outstanding = self.inflight_queue.sorted.iter().copied().find(|tsn| {
+            self.inflight_queue
+                .get(*tsn)
+                .is_some_and(ChunkPayloadData::is_outstanding)
+        });
 
         // New ack point, so pop all ACKed packets from inflight_queue
         // We add 1 because the "currentAckPoint" has already been popped from the inflight queue
         // For the first SACK we take care of this by setting the ackpoint to cumAck - 1
-        let mut i = self.cumulative_tsn_ack_point + 1;
+        let mut i = self.cumulative_tsn_ack_point.wrapping_add(1);
         //log::debug!("[{}] i={} d={}", self.name, i, d.cumulative_tsn_ack);
         while sna32lte(i, d.cumulative_tsn_ack) {
-            if let Some(c) = self.inflight_queue.pop(i) {
-                if !c.acked {
-                    // RFC 4096 sec 6.3.2.  Retransmission Timer Rules
-                    //   R3)  Whenever a SACK is received that acknowledges the DATA chunk
-                    //        with the earliest outstanding TSN for that address, restart the
-                    //        T3-rtx timer for that address with its current RTO (if there is
-                    //        still outstanding data on that address).
-                    if i == self.cumulative_tsn_ack_point + 1 {
-                        // T3 timer needs to be reset. Stop it for now.
-                        self.timers.stop(Timer::T3RTX);
-                    }
+            if let Some(mut c) = self.inflight_queue.pop(i) {
+                if c.acknowledge() {
+                    newly_acked_data |= c.nsent > 0;
 
-                    let n_bytes_acked = c.user_data.len() as i64;
-
-                    // Sum the number of bytes acknowledged per stream
-                    if let Some(amount) = bytes_acked_per_stream.get_mut(&c.stream_identifier) {
-                        *amount += n_bytes_acked;
-                    } else {
-                        bytes_acked_per_stream.insert(c.stream_identifier, n_bytes_acked);
+                    let n_bytes_acked = c.release_buffer() as i64;
+                    total_bytes_acked += c.take_delivery_credit() as i64;
+                    // A late SACK for a retired stream must not release bytes
+                    // belonging to a new channel that reused its SID.
+                    if self.is_current_stream_data(&c) {
+                        *bytes_acked_per_stream
+                            .entry(c.stream_identifier)
+                            .or_default() += n_bytes_acked;
                     }
 
                     // RFC 4960 sec 6.3.1.  RTO Calculation
@@ -1770,7 +1903,7 @@ impl Association {
                     //        packets that were retransmitted (and thus for which it is
                     //        ambiguous whether the reply was for the first instance of the
                     //        chunk or for a later instance)
-                    if c.nsent == 1 && sna32gte(c.tsn, self.min_tsn2measure_rtt) {
+                    if !c.abandoned() && c.nsent == 1 && sna32gte(c.tsn, self.min_tsn2measure_rtt) {
                         self.min_tsn2measure_rtt = self.my_next_tsn;
                         if let Some(since) = &c.since {
                             let rtt = now.duration_since(*since);
@@ -1796,39 +1929,43 @@ impl Association {
                 return Err(Error::ErrInflightQueueTsnPop);
             }
 
-            i += 1;
+            i = i.wrapping_add(1);
         }
+
+        let revoked = self.revoke_missing_gap_acks(d);
 
         let mut htna = d.cumulative_tsn_ack;
 
-        // Mark selectively acknowledged chunks as "acked"
+        // Record peer acknowledgments independently of local payload release.
         for g in &d.gap_ack_blocks {
             for i in g.start..=g.end {
-                let tsn = d.cumulative_tsn_ack + i as u32;
+                let tsn = d.cumulative_tsn_ack.wrapping_add(i as u32);
 
-                let (is_existed, is_acked) = if let Some(c) = self.inflight_queue.get(tsn) {
-                    (true, c.acked)
-                } else {
-                    (false, false)
-                };
-                let n_bytes_acked = if is_existed && !is_acked {
-                    self.inflight_queue.mark_as_acked(tsn) as i64
+                let newly_acknowledged = self.inflight_queue.acknowledge(tsn);
+                let n_bytes_acked = if newly_acknowledged {
+                    self.inflight_queue.release_buffer(tsn) as i64
                 } else {
                     0
                 };
 
+                let delivery_credit = self
+                    .inflight_queue
+                    .get_mut(tsn)
+                    .map_or(0, ChunkPayloadData::take_delivery_credit)
+                    as i64;
                 if let Some(c) = self.inflight_queue.get(tsn) {
-                    if !is_acked {
-                        // Sum the number of bytes acknowledged per stream
-                        if let Some(amount) = bytes_acked_per_stream.get_mut(&c.stream_identifier) {
-                            *amount += n_bytes_acked;
-                        } else {
-                            bytes_acked_per_stream.insert(c.stream_identifier, n_bytes_acked);
+                    if newly_acknowledged {
+                        newly_acked_data |= c.nsent > 0;
+                        total_bytes_acked += delivery_credit;
+                        if self.is_current_stream_data(c) {
+                            *bytes_acked_per_stream
+                                .entry(c.stream_identifier)
+                                .or_default() += n_bytes_acked;
                         }
 
                         trace!("[{}] tsn={} has been sacked", self.side, c.tsn);
 
-                        if c.nsent == 1 {
+                        if !c.abandoned() && c.nsent == 1 {
                             self.min_tsn2measure_rtt = self.my_next_tsn;
                             if let Some(since) = &c.since {
                                 let rtt = now.duration_since(*since);
@@ -1855,7 +1992,78 @@ impl Association {
             }
         }
 
-        Ok((bytes_acked_per_stream, htna))
+        // RFC 9260 8.1-8.2: an acknowledgment of new DATA clears the error
+        // counter, including a late SACK after local abandonment. Payload
+        // release does not acknowledge DATA; duplicates and never-sent TSNs
+        // assigned only for FORWARD TSN do not count as newly acknowledged DATA.
+        if newly_acked_data {
+            self.timers.reset_retrans(Timer::T3RTX);
+        }
+        if earliest_outstanding.is_some_and(|tsn| {
+            sna32lte(tsn, d.cumulative_tsn_ack)
+                || self.inflight_queue.get(tsn).is_some_and(|c| c.acknowledged)
+        }) {
+            // Postprocessing restarts T3 with the current RTO if DATA/FORWARD
+            // TSN remains outstanding.
+            self.timers.set(Timer::T3RTX, None);
+        }
+        Ok(SackProgress {
+            bytes_acked_per_stream,
+            total_bytes_acked,
+            htna,
+            revoked,
+        })
+    }
+
+    /// RFC 9260 6.2.1 D(iii): a disappearing gap returns its DATA to recovery.
+    /// Diff the two ordered sets of ranges, visiting chunks only in the removed
+    /// portions. Ordinary cumulative SACKs need no inflight scan or allocation.
+    fn revoke_missing_gap_acks(&mut self, d: &ChunkSelectiveAck) -> Vec<u32> {
+        let mut revoked = Vec::new();
+        let mut gap_index = 0;
+        for &(start_tsn, end_tsn) in &self.peer_gap_ack_ranges {
+            if sna32lte(end_tsn, d.cumulative_tsn_ack) {
+                continue; // The cumulative ACK already removed this whole range.
+            }
+            let mut offset = if sna32lte(start_tsn, d.cumulative_tsn_ack) {
+                1
+            } else {
+                start_tsn.wrapping_sub(d.cumulative_tsn_ack)
+            };
+            let end = end_tsn.wrapping_sub(d.cumulative_tsn_ack);
+            while offset <= end {
+                while gap_index < d.gap_ack_blocks.len()
+                    && (d.gap_ack_blocks[gap_index].end as u32) < offset
+                {
+                    gap_index += 1;
+                }
+                let next_gap = d.gap_ack_blocks.get(gap_index);
+                if let Some(gap) = next_gap
+                    && gap.start as u32 <= offset
+                {
+                    offset = gap.end as u32 + 1;
+                    continue;
+                }
+                let missing_end = next_gap.map_or(end, |gap| end.min(gap.start as u32 - 1));
+                for missing in offset..=missing_end {
+                    let tsn = d.cumulative_tsn_ack.wrapping_add(missing);
+                    // Local abandonment may already have retired this payload.
+                    if self.inflight_queue.revoke_gap_ack(tsn) {
+                        revoked.push(tsn);
+                    }
+                }
+                offset = missing_end + 1;
+            }
+        }
+        self.peer_gap_ack_ranges.clear();
+        self.peer_gap_ack_ranges
+            .extend(d.gap_ack_blocks.iter().map(|gap| {
+                (
+                    d.cumulative_tsn_ack.wrapping_add(gap.start as u32),
+                    d.cumulative_tsn_ack.wrapping_add(gap.end as u32),
+                )
+            }));
+        revoked
     }
 
     fn on_cumulative_tsn_ack_point_advanced(&mut self, total_bytes_acked: i64, now: Instant) {
@@ -1936,6 +2144,7 @@ impl Association {
         cum_tsn_ack_point: u32,
         htna: u32,
         cum_tsn_ack_point_advanced: bool,
+        revoked: &[u32],
     ) -> Result<()> {
         // HTNA algorithm - RFC 4960 Sec 7.2.4
         // Increment missIndicator of each chunks that the SACK reported missing
@@ -1946,19 +2155,36 @@ impl Association {
         // b)  In fast-recovery AND the Cumulative TSN Ack Point advanced
         //     the miss indications are incremented for all TSNs reported missing
         //     in the SACK.
-        if !self.in_fast_recovery || cum_tsn_ack_point_advanced {
+        if !self.in_fast_recovery || cum_tsn_ack_point_advanced || !revoked.is_empty() {
+            let normal_reports = !self.in_fast_recovery || cum_tsn_ack_point_advanced;
             let max_tsn = if !self.in_fast_recovery {
                 // a) increment only for missing TSNs prior to the HTNA
                 htna
             } else {
                 // b) increment for all TSNs reported missing
-                cum_tsn_ack_point + (self.inflight_queue.len() as u32) + 1
+                cum_tsn_ack_point
+                    .wrapping_add(self.inflight_queue.len() as u32)
+                    .wrapping_add(1)
             };
 
-            let mut tsn = cum_tsn_ack_point + 1;
-            while sna32lt(tsn, max_tsn) {
+            // Capture the normal range before a missing chunk can enter fast
+            // recovery. Revoked TSNs are already in serial order; append only
+            // those beyond that range, reporting an overlapping TSN once.
+            let normal_end = if normal_reports {
+                max_tsn
+                    .wrapping_sub(cum_tsn_ack_point)
+                    .min(self.inflight_queue.len() as u32 + 1)
+            } else {
+                0
+            };
+            let normal = (1..normal_end).map(|offset| cum_tsn_ack_point.wrapping_add(offset));
+            let additional = revoked
+                .iter()
+                .copied()
+                .filter(|tsn| tsn.wrapping_sub(cum_tsn_ack_point) >= normal_end);
+            for tsn in normal.chain(additional) {
                 if let Some(c) = self.inflight_queue.get_mut(tsn) {
-                    if !c.acked && !c.abandoned() && c.miss_indicator < 3 {
+                    if c.is_outstanding() && c.miss_indicator < 3 {
                         c.miss_indicator += 1;
                         if c.miss_indicator == 3 && !self.in_fast_recovery {
                             // 2)  If not in Fast Recovery, adjust the ssthresh and cwnd of the
@@ -1976,15 +2202,13 @@ impl Association {
                                 self.side,
                                 self.cwnd,
                                 self.ssthresh,
-                                self.inflight_queue.get_num_bytes()
+                                self.inflight_queue.outstanding_bytes()
                             );
                         }
                     }
                 } else {
                     return Err(Error::ErrTsnRequestNotExist);
                 }
-
-                tsn += 1;
             }
         }
 
@@ -2025,106 +2249,105 @@ impl Association {
         }
     }
 
-    /// Streams named by `p` that still hold a complete message the application
-    /// has not collected, so a reset naming them cannot be performed yet.
-    ///
-    /// Only *readable* data counts: an incomplete fragment set can never be
-    /// completed once the peer has reset, so it is discardable and must not
-    /// hold the reset open forever.
-    fn streams_awaiting_drain(&self, p: &ParamOutgoingResetRequest) -> Vec<StreamId> {
-        p.stream_identifiers
-            .iter()
-            .copied()
-            .filter(|id| {
-                self.streams
-                    .get(id)
-                    .is_some_and(|s| s.reassembly_queue.is_readable())
-            })
-            .collect()
+    fn retry_incoming_reset(&mut self, sequence: u32, reply: &mut Vec<Packet>) -> Result<()> {
+        if self.incoming_resets.get(sequence).is_none() {
+            return Ok(());
+        }
+        if !self.incoming_resets.is_ready(sequence, self.peer_last_tsn) {
+            reply.push(self.reconfig_response_packet(sequence, ReconfigResult::InProgress));
+            return Ok(());
+        }
+        let streams = self
+            .incoming_resets
+            .complete(sequence, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        for &id in streams.iter() {
+            // RFC 8831 6.7 closes each reused wire channel in both directions.
+            // An unread API receiver may still describe an earlier RX epoch.
+            let reciprocal = self
+                .receive_streams
+                .get(&id)
+                .is_some_and(ReceiveQueue::needs_reciprocal_reset);
+            if let Some(s) = self.streams.get_mut(&id) {
+                s.incoming_reset = true;
+                s.state = ((s.state as u8) & 1).into();
+            }
+            if reciprocal {
+                self.queue_reset_request(id);
+            }
+            let awaiting_outgoing = self.pending_queue.is_resetting(id);
+            self.with_receive_queue(id, |received| {
+                if awaiting_outgoing {
+                    received.require_outgoing_reset();
+                }
+                received.reset();
+            });
+            self.finish_stream_delivery(id);
+        }
+        // E4 replays received DATA after this boundary's RX mutation. A second
+        // accepted reset can retain part of the same stream's future queue.
+        for &id in streams.iter() {
+            let actions = self.with_receive_queue(id, ReceiveQueue::take_deferred);
+            for action in actions {
+                match action {
+                    DeferredReceive::Data(data) => self.deliver_received_data(data),
+                    DeferredReceive::ForwardUnordered(tsn) => {
+                        self.forward_unordered_receive(id, tsn)
+                    }
+                }
+            }
+        }
+        reply.push(self.reconfig_response_packet(sequence, ReconfigResult::SuccessPerformed));
+        Ok(())
     }
 
-    fn reset_streams_if_any(
-        &mut self,
-        p: &ParamOutgoingResetRequest,
-        respond: bool,
-        reply: &mut Vec<Packet>,
-    ) -> Result<()> {
-        let mut result = ReconfigResult::SuccessPerformed;
-        let mut sis_to_reset = vec![];
-
-        if sna32lte(p.sender_last_tsn, self.peer_last_tsn) {
-            debug!(
-                "[{}] resetStream(): senderLastTSN={} <= peer_last_tsn={}",
-                self.side, p.sender_last_tsn, self.peer_last_tsn
-            );
-
-            let draining = self.streams_awaiting_drain(p);
-
-            for id in &p.stream_identifiers {
-                if draining.contains(id) {
-                    continue;
-                }
-                if self.streams.contains_key(id) {
-                    if respond {
-                        sis_to_reset.push(*id);
-                    }
-                    self.unregister_stream(*id, AssociationError::Reset);
-                }
-            }
-
-            if draining.is_empty() {
-                self.reconfig_requests
-                    .remove(&p.reconfig_request_sequence_number);
-            } else {
-                debug!(
-                    "[{}] resetStream(): deferring reset of {:?}, application has not drained",
-                    self.side, draining
-                );
-                result = ReconfigResult::InProgress;
-            }
+    fn deliver_received_data(&mut self, data: ChunkPayloadData) {
+        let id = data.stream_identifier;
+        self.incoming_resets.observe_stream(id);
+        let deferred = self
+            .incoming_resets
+            .boundary(id)
+            .is_some_and(|boundary| sna32gt(data.tsn, boundary));
+        if deferred {
+            self.with_receive_queue(id, |received| received.defer(DeferredReceive::Data(data)));
         } else {
-            debug!(
-                "[{}] resetStream(): senderLastTSN={} > peer_last_tsn={}",
-                self.side, p.sender_last_tsn, self.peer_last_tsn
-            );
-            result = ReconfigResult::InProgress;
+            self.get_or_create_stream(id);
+            if self.with_receive_queue(id, |received| received.push(data)) {
+                self.events
+                    .push_back(Event::Stream(StreamEvent::Readable { id }));
+            }
         }
+    }
 
-        // Answer incoming reset requests with the same reset request, but with
-        // reconfig_response_sequence_number.
-        if !sis_to_reset.is_empty() {
-            let rsn = self.generate_next_rsn();
-            let tsn = self.my_next_tsn - 1;
-
-            let c = ChunkReconfig {
-                param_a: Some(Box::new(ParamOutgoingResetRequest {
-                    reconfig_request_sequence_number: rsn,
-                    reconfig_response_sequence_number: p.reconfig_request_sequence_number,
-                    sender_last_tsn: tsn,
-                    stream_identifiers: sis_to_reset,
-                })),
-                ..Default::default()
-            };
-
-            self.reconfigs.insert(rsn, c.clone()); // store in the map for retransmission
-
-            let p = self.create_packet(vec![Box::new(c)]);
-            reply.push(p);
+    fn forward_unordered_receive(&mut self, id: StreamId, tsn: u32) {
+        let boundary = self.incoming_resets.boundary(id);
+        if self.receive_streams.contains_key(&id) {
+            let readable = self.with_receive_queue(id, |received| {
+                if let Some(boundary) = boundary
+                    && sna32gt(tsn, boundary)
+                {
+                    received.forward_tsn_for_unordered(boundary);
+                    received.defer(DeferredReceive::ForwardUnordered(tsn));
+                } else {
+                    received.forward_tsn_for_unordered(tsn);
+                }
+                received.is_readable()
+            });
+            if readable && self.streams.contains_key(&id) {
+                self.events
+                    .push_back(Event::Stream(StreamEvent::Readable { id }));
+            }
         }
+    }
 
-        let packet = self.create_packet(vec![Box::new(ChunkReconfig {
+    fn reconfig_response_packet(&self, sequence: u32, result: ReconfigResult) -> Packet {
+        self.create_packet(vec![Box::new(ChunkReconfig {
             param_a: Some(Box::new(ParamReconfigResponse {
-                reconfig_response_sequence_number: p.reconfig_request_sequence_number,
+                reconfig_response_sequence_number: sequence,
                 result,
             })),
             param_b: None,
-        })]);
-
-        debug!("[{}] RESET RESPONSE: {}", self.side, packet);
-
-        reply.push(packet);
-
-        Ok(())
+        })])
     }
 
     /// create_packet wraps chunks in a packet.
@@ -2167,12 +2390,22 @@ impl Association {
         accept: bool,
         default_payload_type: PayloadProtocolIdentifier,
     ) -> Option<Stream<'_>> {
-        let s = StreamState::new(
+        let limit = if accept {
+            self.my_max_num_inbound_streams
+        } else {
+            self.my_max_num_outbound_streams
+        };
+        if stream_identifier >= limit {
+            return None;
+        }
+        let mut s = StreamState::new(
             self.side,
             stream_identifier,
             self.max_payload_size,
             default_payload_type,
         );
+        s.generation = self.next_stream_generation;
+        self.next_stream_generation = self.next_stream_generation.wrapping_add(1);
 
         if accept {
             self.stream_queue.push_back(stream_identifier);
@@ -2181,6 +2414,18 @@ impl Association {
             }));
         }
 
+        let received = self
+            .receive_streams
+            .entry(stream_identifier)
+            .or_insert_with(|| ReceiveQueue::new(stream_identifier));
+        if !accept {
+            received.open();
+        } else if received.delivery_closed() {
+            // Saved messages can be published after their wire reset already
+            // finished. Stopping this receiver must not reset a newer channel.
+            s.incoming_reset = true;
+            s.state = RecvSendState::Readable;
+        }
         self.streams.insert(stream_identifier, s);
 
         Some(Stream {
@@ -2212,37 +2457,85 @@ impl Association {
     /// drain anything however attentive it is. Only the second justifies accepting a chunk
     /// into a full receive buffer.
     fn has_readable_data(&self) -> bool {
-        self.streams
-            .values()
-            .any(|s| s.reassembly_queue.is_readable())
+        self.receive_streams.values().any(ReceiveQueue::is_readable)
     }
 
     pub(crate) fn get_my_receiver_window_credit(&self) -> u32 {
-        let mut bytes_queued = 0;
-        for s in self.streams.values() {
-            bytes_queued += s.get_num_bytes_in_reassembly_queue() as u32;
-        }
+        self.max_receive_buffer_size
+            .saturating_sub(self.receive_buffered_bytes.min(u32::MAX as usize) as u32)
+    }
 
-        self.max_receive_buffer_size.saturating_sub(bytes_queued)
+    #[cfg(any(test, fuzzing, feature = "bench"))]
+    pub(crate) fn assert_receive_accounting(&self) {
+        assert_eq!(
+            self.receive_buffered_bytes,
+            self.receive_streams
+                .values()
+                .map(ReceiveQueue::get_num_bytes)
+                .sum::<usize>(),
+            "receive credit differs from retained payload ownership"
+        );
     }
 
     /// gather_outbound gathers outgoing packets. The returned bool value set to
     /// false means the association should be closed down after the final send.
     fn gather_outbound(&mut self, now: Instant) -> (Vec<Bytes>, bool) {
         let mut raw_packets = vec![];
-
-        if !self.control_queue.is_empty() {
-            for p in self.control_queue.drain(..) {
-                if let Ok(raw) = p.marshal() {
-                    raw_packets.push(raw);
-                } else {
-                    warn!("[{}] failed to serialize a control packet", self.side);
-                    continue;
+        let state = self.state();
+        let sack_allowed = matches!(
+            state,
+            AssociationState::Established
+                | AssociationState::ShutdownPending
+                | AssociationState::ShutdownSent
+                | AssociationState::ShutdownReceived
+        );
+        let mut pending_sack = None;
+        while let Some(packet) = self.control_queue.pop_front() {
+            // RFC 6525 §5.2 recommends bundling the SACK with a reset response.
+            // Keep other control chunks' framing rules unchanged and never grow
+            // this packet beyond the same MTU limit used for DATA bundling.
+            if sack_allowed
+                && self.ack_state == AckState::Immediate
+                && packet.chunks.len() == 1
+                && packet.chunks[0].as_any().is::<ChunkReconfig>()
+            {
+                let sack = pending_sack.get_or_insert_with(|| self.create_selective_ack_chunk());
+                let wire_size = COMMON_HEADER_SIZE as usize
+                    + (CHUNK_HEADER_SIZE + packet.chunks[0].value_length()).next_multiple_of(4)
+                    + (CHUNK_HEADER_SIZE + sack.value_length()).next_multiple_of(4);
+                if wire_size <= self.mtu as usize {
+                    let mut buf = BytesMut::with_capacity(wire_size);
+                    if Packet::write_framed(
+                        &packet.common_header,
+                        [packet.chunks[0].as_ref(), sack as &dyn Chunk].into_iter(),
+                        &mut buf,
+                    )
+                    .is_ok()
+                    {
+                        raw_packets.push(buf.freeze());
+                        self.ack_state = AckState::Idle;
+                        pending_sack = None;
+                        continue;
+                    }
                 }
             }
+            if let Ok(raw) = packet.marshal() {
+                raw_packets.push(raw);
+            } else {
+                warn!("[{}] failed to serialize a control packet", self.side);
+            }
         }
-
-        let state = self.state();
+        if let Some(sack) = pending_sack {
+            // The complete gap/duplicate report did not fit beside RE-CONFIG.
+            // Send that already prepared SACK separately, without losing it or
+            // consuming duplicate TSNs a second time.
+            if let Ok(raw) = self.marshal_control_chunk(&sack) {
+                raw_packets.push(raw);
+                self.ack_state = AckState::Idle;
+            } else {
+                warn!("[{}] failed to serialize a SACK packet", self.side);
+            }
+        }
         match state {
             AssociationState::Established => {
                 raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
@@ -2258,6 +2551,7 @@ impl Association {
                 raw_packets = self.gather_data_packets_to_retransmit(raw_packets, now);
                 raw_packets = self.gather_outbound_fast_retransmission_packets(raw_packets, now);
                 raw_packets = self.gather_outbound_sack_packets(raw_packets);
+                raw_packets = self.gather_outbound_forward_tsn_packets(raw_packets);
                 self.gather_outbound_shutdown_packets(raw_packets, now)
             }
             AssociationState::ShutdownAckSent => {
@@ -2285,6 +2579,7 @@ impl Association {
         mut raw_packets: Vec<Bytes>,
         now: Instant,
     ) -> Vec<Bytes> {
+        self.resume_reset_query(now);
         // Pop unsent data chunks from the pending queue to send as much as
         // cwnd and rwnd allow.
         let (chunks, sis_to_reset) = self.pop_pending_data_chunks_to_send(now);
@@ -2297,64 +2592,9 @@ impl Association {
             self.bundle_data_chunks_into_packets(chunks, &mut raw_packets);
         }
 
-        if !sis_to_reset.is_empty() || self.will_retransmit_reconfig {
-            if self.will_retransmit_reconfig {
-                self.will_retransmit_reconfig = false;
-                debug!(
-                    "[{}] retransmit {} RECONFIG chunk(s)",
-                    self.side,
-                    self.reconfigs.len()
-                );
-                for c in self.reconfigs.values() {
-                    let p = self.create_packet(vec![Box::new(c.clone())]);
-                    if let Ok(raw) = p.marshal() {
-                        raw_packets.push(raw);
-                    } else {
-                        warn!(
-                            "[{}] failed to serialize a RECONFIG packet to be retransmitted",
-                            self.side,
-                        );
-                    }
-                }
-            }
-
-            if !sis_to_reset.is_empty() {
-                let rsn = self.generate_next_rsn();
-                let tsn = self.my_next_tsn - 1;
-                debug!(
-                    "[{}] sending RECONFIG: rsn={} tsn={} streams={:?}",
-                    self.side,
-                    rsn,
-                    self.my_next_tsn - 1,
-                    sis_to_reset
-                );
-
-                let c = ChunkReconfig {
-                    param_a: Some(Box::new(ParamOutgoingResetRequest {
-                        reconfig_request_sequence_number: rsn,
-                        sender_last_tsn: tsn,
-                        stream_identifiers: sis_to_reset,
-                        ..Default::default()
-                    })),
-                    ..Default::default()
-                };
-                self.reconfigs.insert(rsn, c.clone()); // store in the map for retransmission
-
-                let p = self.create_packet(vec![Box::new(c)]);
-                if let Ok(raw) = p.marshal() {
-                    raw_packets.push(raw);
-                } else {
-                    warn!(
-                        "[{}] failed to serialize a RECONFIG packet to be transmitted",
-                        self.side
-                    );
-                }
-            }
-
-            if !self.reconfigs.is_empty() {
-                self.timers
-                    .start(Timer::Reconfig, now, self.rto_mgr.get_rto());
-            }
+        self.emit_reconfig(now, &mut raw_packets);
+        if !sis_to_reset.is_empty() {
+            self.start_reconfig(now, sis_to_reset, &mut raw_packets);
         }
 
         raw_packets
@@ -2367,15 +2607,22 @@ impl Association {
     ) -> Vec<Bytes> {
         if self.will_retransmit_fast {
             self.will_retransmit_fast = false;
+            self.abandon_unretransmittable_messages(
+                now,
+                ChunkPayloadData::is_fast_retransmit_candidate,
+            );
 
             let mut to_fast_retrans: Vec<Box<dyn Chunk>> = vec![];
             let mut fast_retrans_size = COMMON_HEADER_SIZE;
 
             let mut i = 0;
             loop {
-                let tsn = self.cumulative_tsn_ack_point + i + 1;
+                let tsn = self
+                    .cumulative_tsn_ack_point
+                    .wrapping_add(i)
+                    .wrapping_add(1);
                 if let Some(c) = self.inflight_queue.get_mut(tsn) {
-                    if c.acked || c.abandoned() || c.nsent > 1 || c.miss_indicator < 3 {
+                    if !c.is_fast_retransmit_candidate() {
                         i += 1;
                         continue;
                     }
@@ -2407,13 +2654,6 @@ impl Association {
                 }
 
                 if let Some(c) = self.inflight_queue.get_mut(tsn) {
-                    Association::check_partial_reliability_status(
-                        c,
-                        now,
-                        self.use_forward_tsn,
-                        self.side,
-                        &self.streams,
-                    );
                     to_fast_retrans.push(Box::new(c.clone()));
                     trace!(
                         "[{}] fast-retransmit: tsn={} sent={} htna={}",
@@ -2535,6 +2775,9 @@ impl Association {
     /// get_data_packets_to_retransmit is called when T3-rtx is timed out and retransmit outstanding data chunks
     /// that are not acked or abandoned yet.
     fn get_data_packets_to_retransmit(&mut self, now: Instant, raw_packets: &mut Vec<Bytes>) {
+        // T3 may have marked this DATA before its lifetime elapsed, while the
+        // send window deferred the actual retransmission (RFC 3758 TR4).
+        self.abandon_unretransmittable_messages(now, |c| c.retransmit);
         let awnd = std::cmp::min(self.cwnd, self.rwnd);
         let mut chunks = vec![];
         let mut bytes_to_send = 0;
@@ -2545,7 +2788,10 @@ impl Association {
         // so the next gather_outbound still scans.
         let mut chunks_remaining = false;
         while !done {
-            let tsn = self.cumulative_tsn_ack_point + i + 1;
+            let tsn = self
+                .cumulative_tsn_ack_point
+                .wrapping_add(i)
+                .wrapping_add(1);
             if let Some(c) = self.inflight_queue.get_mut(tsn) {
                 if !c.retransmit {
                     i += 1;
@@ -2572,14 +2818,6 @@ impl Association {
             }
 
             if let Some(c) = self.inflight_queue.get_mut(tsn) {
-                Association::check_partial_reliability_status(
-                    c,
-                    now,
-                    self.use_forward_tsn,
-                    self.side,
-                    &self.streams,
-                );
-
                 trace!(
                     "[{}] retransmitting tsn={} ssn={} sent={}",
                     self.side, c.tsn, c.stream_sequence_number, c.nsent
@@ -2597,111 +2835,233 @@ impl Association {
         self.bundle_data_chunks_into_packets(chunks, raw_packets);
     }
 
-    /// Whether the message at the head of the pending queue has outlived the
-    /// timed-reliability lifetime configured on its stream.
-    ///
-    /// Gated on `use_forward_tsn` for the same reason as
-    /// `check_partial_reliability_status`: when the peer did not negotiate
-    /// Forward-TSN the association falls back to reliable delivery, and partial
-    /// reliability must be off everywhere rather than in half the code.
-    ///
-    /// Restricted to unordered messages: an ordered one has already consumed a
-    /// stream sequence number in `packetize`, so abandoning it before it is ever
-    /// transmitted would leave a gap that only a ForwardTSN carrying that SSN can
-    /// close. Restricted to a beginning fragment so a partially drained message is
-    /// never truncated mid-run.
-    ///
-    /// Only the head of the queue is inspected, so an expired message sitting
-    /// behind a fresh one keeps its buffered bytes until it reaches the head. It
-    /// is still never transmitted: it is re-checked once it gets there.
-    fn pending_message_expired(&self, c: &ChunkPayloadData, now: Instant) -> bool {
+    fn release_stream_buffers(&mut self, bytes_acked_per_stream: &FxHashMap<u16, i64>) {
+        for (si, n_bytes_acked) in bytes_acked_per_stream {
+            if *n_bytes_acked > 0 {
+                // Report the exact bytes released for this stream (acknowledged OR
+                // abandoned — both funnel through bytes_acked_per_stream) so upper
+                // layers can decrement their own send-buffer accounting. Unlike the
+                // edge-triggered BufferedAmountLow advisory below, this fires on
+                // every release with the byte delta.
+                self.events
+                    .push_back(Event::Stream(StreamEvent::BufferedAmountReleased {
+                        id: *si,
+                        n_bytes: *n_bytes_acked as usize,
+                    }));
+            }
+            if let Some(s) = self.streams.get_mut(si)
+                && s.on_buffer_released(*n_bytes_acked)
+            {
+                trace!("StreamEvent::BufferedAmountLow");
+                self.events
+                    .push_back(Event::Stream(StreamEvent::BufferedAmountLow { id: *si }))
+            }
+        }
+    }
+
+    /// RFC 3758 section 3.5 C2-C4. Retain the stream map until the peer catches up.
+    fn advance_peer_ack_point(&mut self) {
+        let mut tsn = self.advanced_peer_tsn_ack_point.wrapping_add(1);
+        while let Some(c) = self.inflight_queue.get(tsn) {
+            // A late FORWARD-TSN carrying old SSNs must be stale after RX reset.
+            // Bound its global TSN until the reset result retires those SSNs;
+            // unrelated DATA still flows. Otherwise another stream's TSN can
+            // make the old control chunk look new in a reused SID's SSN space.
+            if self
+                .outgoing_reset
+                .as_ref()
+                .is_some_and(|reset| sna32gt(tsn, reset.request.sender_last_tsn))
+            {
+                break;
+            }
+            if !c.abandoned() {
+                break;
+            }
+            let (unordered, si, ssn) = (c.unordered, c.stream_identifier, c.stream_sequence_number);
+            // Local SID reuse says nothing about the peer's SSN space. Old
+            // SSNs remain necessary until its outgoing reset is confirmed.
+            let current_ssn_space = self
+                .confirmed_reset_tsns
+                .get(&si)
+                .is_none_or(|last_reset_tsn| sna32gt(tsn, *last_reset_tsn));
+            self.advanced_peer_tsn_ack_point = tsn;
+            if current_ssn_space {
+                self.note_abandoned_for_forward_tsn(unordered, si, ssn);
+            }
+            tsn = tsn.wrapping_add(1);
+        }
+        if sna32gt(
+            self.advanced_peer_tsn_ack_point,
+            self.cumulative_tsn_ack_point,
+        ) {
+            self.will_send_forward_tsn = true;
+        } else {
+            self.fwd_tsn_stream_map.clear();
+        }
+    }
+
+    fn timed_data_expired(&self, c: &ChunkPayloadData, now: Instant) -> bool {
+        self.use_forward_tsn
+            && c.reliability
+                .deadline()
+                .is_some_and(|deadline| now >= deadline)
+    }
+
+    fn is_current_stream_data(&self, c: &ChunkPayloadData) -> bool {
+        self.streams
+            .get(&c.stream_identifier)
+            .is_some_and(|s| s.generation == c.stream_generation)
+    }
+
+    /// A positive deadline can expire at any time. Timed(0) and Rexmit limits
+    /// instead apply when this particular DATA is considered for retransmission.
+    fn retransmission_policy_exhausted(
+        &self,
+        c: &ChunkPayloadData,
+        now: Instant,
+        is_candidate: bool,
+    ) -> bool {
         if !self.use_forward_tsn {
             return false;
         }
-
-        // `packetize` forces `unordered = false` for DCEP, so the ordering test
-        // already excludes it; the explicit check keeps that non-obvious coupling
-        // from becoming load-bearing.
-        if !c.unordered
-            || !c.beginning_fragment
-            || c.payload_type == PayloadProtocolIdentifier::Dcep
-        {
-            return false;
-        }
-
-        let Some(s) = self.streams.get(&c.stream_identifier) else {
-            return false;
-        };
-
-        // A zero lifetime keeps its established meaning â transmit once, never
-        // retransmit â rather than silently becoming "never transmit at all".
-        if s.reliability_type != ReliabilityType::Timed || s.reliability_value == 0 {
-            return false;
-        }
-
-        let Some(created_at) = c.created_at else {
-            return false;
-        };
-
-        now.saturating_duration_since(created_at).as_millis() as u32 >= s.reliability_value
-    }
-
-    /// Drop every fragment of the message at the head of the pending queue and
-    /// release the bytes it was holding in the stream's send buffer.
-    ///
-    /// Only called for an unordered message whose first fragment is at the head,
-    /// so the whole fragment run is contiguous: `send_payload_data` appends a
-    /// message's chunks without anything else interleaving. Running out before
-    /// the ending fragment would leave `PendingQueue` selected on an empty queue
-    /// and stall every later send, so that case asserts in debug builds and is
-    /// reported rather than silently tolerated.
-    fn abandon_pending_message(&mut self) {
-        let mut beginning_fragment = true;
-        let mut released = 0usize;
-        let mut stream_identifier = None;
-        let mut completed = false;
-
-        while let Some(c) = self.pending_queue.pop(beginning_fragment, true) {
-            beginning_fragment = false;
-            released += c.user_data.len();
-            stream_identifier = Some(c.stream_identifier);
-            if c.ending_fragment {
-                completed = true;
-                break;
+        match c.reliability {
+            MessageReliability::Reliable => false,
+            MessageReliability::Timed { deadline } => now >= deadline,
+            // RFC 7496 3.1: the limit excludes the first transmission and counts
+            // both fast and timer-based retries. nsent includes that first send.
+            MessageReliability::Rexmit { max_retransmits } => {
+                is_candidate && c.nsent > max_retransmits
             }
         }
+    }
 
-        if !completed {
-            debug_assert!(
-                false,
-                "pending queue ran out mid-message while abandoning an expired message"
-            );
-            error!(
-                "[{}] abandoned an incomplete fragment run; pending queue selection is now stale",
-                self.side
-            );
+    /// Select identities without changing ACK, retry or buffer state. Only a
+    /// fragment selected for recovery can exhaust that message's retry budget.
+    fn unretransmittable_messages(
+        &self,
+        now: Instant,
+        is_candidate: impl Fn(&ChunkPayloadData) -> bool,
+    ) -> Vec<MessageToAbandon> {
+        let mut messages = vec![];
+        let mut selected = rustc_hash::FxHashSet::default();
+        for &tsn in &self.inflight_queue.sorted {
+            let c = self.inflight_queue.get(tsn).unwrap();
+            if c.is_outstanding()
+                && self.retransmission_policy_exhausted(c, now, is_candidate(c))
+                && let Some(id) = c.message_id
+                && selected.insert(id)
+            {
+                messages.push(MessageToAbandon {
+                    id,
+                    sent_tsn: Some(tsn),
+                });
+            }
         }
+        messages
+    }
 
-        let (Some(si), true) = (stream_identifier, released > 0) else {
-            return;
-        };
-
-        trace!(
-            "[{}] abandoned {} pending bytes on stream {} (maxPacketLifeTime)",
-            self.side, released, si
+    /// RFC 3758 A2/A3: abandon all fragments by identity, including Gap-ACKed
+    /// siblings and an unsent tail. Each payload is released at most once.
+    /// FORWARD TSN and timers are updated after the complete operation.
+    fn abandon_message(&mut self, message: MessageToAbandon) -> bool {
+        let whole_tsn = message.sent_tsn.filter(|&tsn| {
+            self.inflight_queue.get(tsn).is_some_and(|c| {
+                c.message_id == Some(message.id) && c.beginning_fragment && c.ending_fragment
+            })
+        });
+        let mut inflight = whole_tsn.map_or_else(
+            || self.inflight_queue.message_tsns(message.id),
+            |tsn| vec![tsn],
         );
+        let mut released_per_stream = FxHashMap::default();
+        let mut changed = false;
+        let tail = self.pending_queue.drain_message(message.id);
+        // If a sent prefix was cumulatively acknowledged, merely forwarding its
+        // old TSN is ineffective (RFC 3758 3.6). Reserve one terminal TSN for the
+        // entire unsent tail so FORWARD TSN discards any incomplete peer state.
+        // This is bookkeeping only: abandoned DATA is never marshalled.
+        if let Some(first) = tail.first().filter(|c| !c.beginning_fragment) {
+            let mut terminal = first.clone();
+            terminal.stream_sequence_number = self
+                .transmit_streams
+                .get_mut(&first.stream_identifier)
+                .unwrap()
+                .abandon_tail(message.id);
+            terminal.tsn = self.generate_next_tsn();
+            terminal.ending_fragment = true;
+            terminal.user_data = Bytes::new();
+            terminal.buffer_released = true;
+            terminal.mark_abandoned();
+            inflight.push(terminal.tsn);
+            self.inflight_queue.push_no_check(terminal);
+        }
+        for c in tail {
+            if self.is_current_stream_data(&c) {
+                *released_per_stream.entry(c.stream_identifier).or_default() +=
+                    c.user_data.len() as i64;
+            }
+            changed = true;
+        }
+        for tsn in inflight {
+            if let Some(c) = self.inflight_queue.get_mut(tsn) {
+                let (si, generation) = (c.stream_identifier, c.stream_generation);
+                let (abandoned, released) = self.inflight_queue.abandon(tsn);
+                changed |= abandoned;
+                let released = released as i64;
+                if released > 0
+                    && self
+                        .streams
+                        .get(&si)
+                        .is_some_and(|s| s.generation == generation)
+                {
+                    *released_per_stream.entry(si).or_default() += released;
+                }
+            }
+        }
+        self.release_stream_buffers(&released_per_stream);
+        changed
+    }
 
-        self.events
-            .push_back(Event::Stream(StreamEvent::BufferedAmountReleased {
-                id: si,
-                n_bytes: released,
-            }));
+    fn on_messages_abandoned(&mut self, now: Instant) {
+        self.advance_peer_ack_point();
+        // RFC 3758 C5: recovery must continue even with no DATA left to retry.
+        if sna32gt(
+            self.advanced_peer_tsn_ack_point,
+            self.cumulative_tsn_ack_point,
+        ) {
+            self.timers
+                .restart_if_stale(Timer::T3RTX, now, self.rto_mgr.get_rto());
+        }
+    }
 
-        if let Some(s) = self.streams.get_mut(&si)
-            && s.on_buffer_released(released as i64)
-        {
-            self.events
-                .push_back(Event::Stream(StreamEvent::BufferedAmountLow { id: si }))
+    fn abandon_unretransmittable_messages(
+        &mut self,
+        now: Instant,
+        is_candidate: impl Fn(&ChunkPayloadData) -> bool,
+    ) {
+        let mut changed = false;
+        for message in self.unretransmittable_messages(now, is_candidate) {
+            changed |= self.abandon_message(message);
+        }
+        if changed {
+            self.on_messages_abandoned(now);
+        }
+    }
+
+    /// An unstarted message has consumed neither SSN nor TSN. Timed(0) is
+    /// captured as Rexmit(0), preserving its first-transmission API contract.
+    fn pending_message_expired(&self, c: &ChunkPayloadData, now: Instant) -> bool {
+        self.timed_data_expired(c, now)
+    }
+
+    fn pending_message_to_abandon(&self) -> MessageToAbandon {
+        MessageToAbandon {
+            id: self
+                .pending_queue
+                .peek()
+                .and_then(|c| c.message_id)
+                .expect("outbound DATA has a message identity"),
+            sent_tsn: None,
         }
     }
 
@@ -2710,10 +3070,22 @@ impl Association {
     fn pop_pending_data_chunks_to_send(
         &mut self,
         now: Instant,
-    ) -> (Vec<ChunkPayloadData>, Vec<u16>) {
+    ) -> (Vec<ChunkPayloadData>, Vec<ResetMarker>) {
         let mut chunks = vec![];
         let mut sis_to_reset = vec![]; // stream identifiers to reset
         if !self.pending_queue.is_empty() {
+            // No reconfiguration result can arrive during this queue drain.
+            // Evaluate recovery gates once, not once per DATA fragment.
+            // Common header + RE-CONFIG header + fixed outgoing-reset parameter.
+            // Round the variable SID list down to a multiple of four wire bytes.
+            let max_reset_streams = (self
+                .mtu
+                .min(COMMON_HEADER_SIZE + u16::MAX as u32)
+                .saturating_sub(COMMON_HEADER_SIZE + 20)
+                / 4
+                * 2)
+            .max(1) as usize;
+            let can_start_reconfig = self.can_start_reconfig();
             // RFC 4960 sec 6.1.  Transmission of DATA Chunks
             //   A) At any given time, the data sender MUST NOT transmit new data to
             //      any destination transport address if its peer's rwnd indicates
@@ -2722,25 +3094,27 @@ impl Association {
             //      is 0), the data sender can always have one DATA chunk in flight to
             //      the receiver if allowed by cwnd (see rule B, below).
 
-            while let Some(c) = self.pending_queue.peek() {
-                let (beginning_fragment, unordered, data_len, stream_identifier) = (
-                    c.beginning_fragment,
-                    c.unordered,
-                    c.user_data.len(),
-                    c.stream_identifier,
-                );
-
-                if data_len == 0 {
-                    sis_to_reset.push(stream_identifier);
-                    if self
-                        .pending_queue
-                        .pop(beginning_fragment, unordered)
-                        .is_none()
-                    {
-                        error!("[{}] failed to pop from pending queue", self.side);
+            loop {
+                // RFC 6525 5.1.1: only one request may be in flight. Reset
+                // markers live outside DATA queues, so other streams can send.
+                if can_start_reconfig {
+                    while sis_to_reset.len() < max_reset_streams {
+                        let Some(reset) = self.pending_queue.pop_ready_reset() else {
+                            break;
+                        };
+                        sis_to_reset.push(reset);
                     }
-                    continue;
                 }
+                // Freeze Sender's Last Assigned TSN before any later DATA,
+                // including a zero-window probe (RFC 6525 5.1.2 A3).
+                if !sis_to_reset.is_empty() {
+                    break;
+                }
+                let Some(c) = self.pending_queue.peek() else {
+                    break;
+                };
+                let (beginning_fragment, unordered, data_len) =
+                    (c.beginning_fragment, c.unordered, c.user_data.len());
 
                 // RFC 3758 timed reliability: a message whose lifetime has run
                 // out must be abandoned even if it was never transmitted. Doing
@@ -2748,11 +3122,14 @@ impl Association {
                 // allocated, means there is no gap for the peer to reconcile and
                 // no ForwardTSN to send.
                 if self.pending_message_expired(c, now) {
-                    self.abandon_pending_message();
+                    let message = self.pending_message_to_abandon();
+                    if self.abandon_message(message) {
+                        self.on_messages_abandoned(now);
+                    }
                     continue;
                 }
 
-                if self.inflight_queue.get_num_bytes() + data_len > self.cwnd as usize {
+                if self.inflight_queue.outstanding_bytes() + data_len > self.cwnd as usize {
                     break; // would exceeds cwnd
                 }
 
@@ -2772,7 +3149,7 @@ impl Association {
             }
 
             // the data sender can always have one DATA chunk in flight to the receiver
-            if chunks.is_empty() && self.inflight_queue.is_empty() {
+            if chunks.is_empty() && sis_to_reset.is_empty() && self.inflight_queue.is_empty() {
                 // Send zero window probe
                 if let Some(c) = self.pending_queue.peek() {
                     let (beginning_fragment, unordered) = (c.beginning_fragment, c.unordered);
@@ -2782,6 +3159,7 @@ impl Association {
                         unordered,
                         now,
                     ) {
+                        self.zero_window_probe = Some(chunk.tsn);
                         chunks.push(chunk);
                     }
                 }
@@ -2874,70 +3252,15 @@ impl Association {
     /// generate_next_tsn returns the my_next_tsn and increases it. The caller should hold the lock.
     fn generate_next_tsn(&mut self) -> u32 {
         let tsn = self.my_next_tsn;
-        self.my_next_tsn += 1;
+        self.my_next_tsn = self.my_next_tsn.wrapping_add(1);
         tsn
     }
 
     /// generate_next_rsn returns the my_next_rsn and increases it. The caller should hold the lock.
     fn generate_next_rsn(&mut self) -> u32 {
         let rsn = self.my_next_rsn;
-        self.my_next_rsn += 1;
+        self.my_next_rsn = self.my_next_rsn.wrapping_add(1);
         rsn
-    }
-
-    fn check_partial_reliability_status(
-        c: &mut ChunkPayloadData,
-        now: Instant,
-        use_forward_tsn: bool,
-        side: Side,
-        streams: &FxHashMap<u16, StreamState>,
-    ) {
-        if !use_forward_tsn {
-            return;
-        }
-
-        // draft-ietf-rtcweb-data-protocol-09.txt section 6
-        //	6.  Procedures
-        //		All Data Channel Establishment TransportProtocol messages MUST be sent using
-        //		ordered delivery and reliable transmission.
-        //
-        if c.payload_type == PayloadProtocolIdentifier::Dcep {
-            return;
-        }
-
-        // PR-SCTP
-        if let Some(s) = streams.get(&c.stream_identifier) {
-            let reliability_type: ReliabilityType = s.reliability_type;
-            let reliability_value = s.reliability_value;
-
-            if reliability_type == ReliabilityType::Rexmit {
-                if c.nsent >= reliability_value {
-                    c.set_abandoned(true);
-                    trace!(
-                        "[{}] marked as abandoned: tsn={} ppi={} (remix: {})",
-                        side, c.tsn, c.payload_type, c.nsent
-                    );
-                }
-            } else if reliability_type == ReliabilityType::Timed {
-                // Age is measured from when the message was queued, not from its
-                // most recent transmission: `since` is the RTT baseline and is
-                // reassigned on every (re)transmission.
-                if let Some(queued_at) = c.created_at.as_ref().or(c.since.as_ref()) {
-                    let elapsed = now.saturating_duration_since(*queued_at);
-                    if elapsed.as_millis() as u32 >= reliability_value {
-                        c.set_abandoned(true);
-                        trace!(
-                            "[{}] marked as abandoned: tsn={} ppi={} (timed: {:?})",
-                            side, c.tsn, c.payload_type, elapsed
-                        );
-                    }
-                } else {
-                    error!("[{}] chunk has neither created_at nor since", side);
-                }
-            }
-        } else {
-            error!("[{}] stream {} not found)", side, c.stream_identifier);
-        }
     }
 
     fn create_selective_ack_chunk(&mut self) -> ChunkSelectiveAck {
@@ -2950,7 +3273,7 @@ impl Association {
     }
 
     /// Record an abandoned chunk into the forward-TSN stream map (RFC 3758 C4),
-    /// called from the two C2 loops as `advanced_peer_tsn_ack_point` advances
+    /// called from the C2 walk as `advanced_peer_tsn_ack_point` advances
     /// over each newly-abandoned in-flight chunk. Only *ordered* streams are
     /// tracked: the receiver ignores the per-stream SSN list for unordered
     /// chunks (it advances purely by `new_cumulative_tsn`). Keeps the greatest
@@ -2990,7 +3313,7 @@ impl Association {
         // RFC 3758 Sec 3.5 C4: report, once per ordered stream, the greatest
         // stream-sequence-number among abandoned chunks in the forward-TSN
         // window. This is maintained incrementally in `fwd_tsn_stream_map` (see
-        // its declaration and the two C2 loops that feed it), so we no longer
+        // its declaration and the C2 walk that feeds it), so we no longer
         // rescan `(cumulative_tsn_ack_point, advanced_peer_tsn_ack_point]` with
         // a per-TSN hashmap probe on every FORWARD-TSN — that scan was O(rwnd)
         // (~1000 probes/call for a 1 MB window) and dominated the send profile.
@@ -3024,25 +3347,15 @@ impl Association {
         now: Instant,
     ) -> Option<ChunkPayloadData> {
         if let Some(mut c) = self.pending_queue.pop(beginning_fragment, unordered) {
-            // Mark all fragements are in-flight now
-            if c.ending_fragment {
-                c.set_all_inflight();
-            }
-
-            // Assign TSN
+            self.transmit_streams
+                .entry(c.stream_identifier)
+                .or_default()
+                .assign_ssn(&mut c);
             c.tsn = self.generate_next_tsn();
 
-            // RTT baseline only; maxPacketLifeTime measures from `created_at`.
+            // RTT baseline only; the message's reliability deadline is immutable.
             c.since = Some(now);
             c.nsent = 1; // being sent for the first time
-
-            Association::check_partial_reliability_status(
-                &mut c,
-                now,
-                self.use_forward_tsn,
-                self.side,
-                &self.streams,
-            );
 
             trace!(
                 "[{}] sending ppi={} tsn={} ssn={} sent={} len={} ({},{})",
@@ -3067,33 +3380,41 @@ impl Association {
 
     /// Queues the outgoing stream-reset chunk (RFC 6525).
     ///
-    /// `now` is when the caller asked for the reset; threaded from `Stream::stop` and recorded
-    /// on the EOS chunk so every locally created chunk carries its queueing instant.
+    /// Reset markers carry a stream boundary and RX epoch; their timer starts when the
+    /// immutable request is actually emitted by poll_transmit.
     pub(crate) fn send_reset_request(
         &mut self,
-        now: Instant,
+        _now: Instant,
         stream_identifier: StreamId,
     ) -> Result<()> {
         let state = self.state();
         if state != AssociationState::Established {
             return Err(Error::ErrResetPacketInStateNotExist);
         }
+        if !self.peer_supports_reconfig {
+            return Err(Error::Other(
+                "peer does not support SCTP stream reconfiguration".into(),
+            ));
+        }
 
-        // Create DATA chunk which only contains valid stream identifier with
-        // nil userData and use it as a EOS from the stream.
-        let c = ChunkPayloadData {
-            created_at: Some(now),
-            stream_identifier,
-            beginning_fragment: true,
-            ending_fragment: true,
-            user_data: Bytes::new(),
-            ..Default::default()
-        };
-
-        self.pending_queue.push(c);
-        self.awake_write_loop();
-
+        self.queue_reset_request(stream_identifier);
         Ok(())
+    }
+
+    fn queue_reset_request(&mut self, stream_identifier: StreamId) {
+        if !self.peer_supports_reconfig {
+            return;
+        }
+        let receive_epoch = self
+            .receive_streams
+            .entry(stream_identifier)
+            .or_insert_with(|| ReceiveQueue::new(stream_identifier))
+            .note_outgoing_reset();
+        self.pending_queue.push_reset(ResetMarker {
+            stream_identifier,
+            receive_epoch,
+        });
+        self.awake_write_loop();
     }
 
     /// send_payload_data sends the data chunks.
@@ -3106,8 +3427,13 @@ impl Association {
             return Err(Error::ErrPayloadDataStateNotExist);
         }
 
-        // Push the chunks into the pending queue first.
-        for c in chunks {
+        let id = MessageId::new(self.next_message_id);
+        self.next_message_id = self
+            .next_message_id
+            .checked_add(1)
+            .expect("association message identity exhausted");
+        for mut c in chunks {
+            c.message_id = Some(id);
             self.pending_queue.push(c);
         }
 
@@ -3118,7 +3444,7 @@ impl Association {
     /// buffered_amount returns total amount (in bytes) of currently buffered user data.
     /// This is used only by testing.
     pub(crate) fn buffered_amount(&self) -> usize {
-        self.pending_queue.get_num_bytes() + self.inflight_queue.get_num_bytes()
+        self.pending_queue.get_num_bytes() + self.inflight_queue.buffered_bytes()
     }
 
     fn awake_write_loop(&self) {
@@ -3142,7 +3468,7 @@ impl Association {
         self.awake_write_loop();
     }
 
-    fn on_retransmission_timeout(&mut self, timer_id: Timer, n_rtos: usize) {
+    fn on_retransmission_timeout(&mut self, timer_id: Timer, n_rtos: usize, now: Instant) {
         match timer_id {
             Timer::T1Init => {
                 if let Err(err) = self.send_init() {
@@ -3183,6 +3509,9 @@ impl Association {
 
             Timer::T3RTX => {
                 self.stats.inc_t3timeouts();
+                self.rto_mgr.backoff();
+                // Refresh before C2 or mark_all_to_retrasmit reads abandoned().
+                self.abandon_unretransmittable_messages(now, ChunkPayloadData::is_outstanding);
 
                 // RFC 4960 sec 6.3.3
                 //  E1)  For the destination address for which the timer expires, adjust
@@ -3194,14 +3523,16 @@ impl Association {
                 //      ssthresh = max(cwnd/2, 4*MTU)
                 //      cwnd = 1*MTU
 
-                self.ssthresh = std::cmp::max(self.cwnd / 2, 4 * self.mtu);
-                self.cwnd = self.mtu;
+                if self.zero_window_probe.is_none() {
+                    self.ssthresh = std::cmp::max(self.cwnd / 2, 4 * self.mtu);
+                    self.cwnd = self.mtu;
+                }
                 trace!(
                     "[{}] updated cwnd={} ssthresh={} inflight={} (RTO)",
                     self.side,
                     self.cwnd,
                     self.ssthresh,
-                    self.inflight_queue.get_num_bytes()
+                    self.inflight_queue.outstanding_bytes()
                 );
 
                 // RFC 3758 sec 3.5
@@ -3209,40 +3540,7 @@ impl Association {
                 //  SHOULD try to advance the "Advanced.Peer.Ack.Point" by following
                 //  the procedures outlined in C2 - C5.
                 if self.use_forward_tsn {
-                    // RFC 3758 Sec 3.5 C2
-                    let mut i = self.advanced_peer_tsn_ack_point + 1;
-                    while let Some((abandoned, unordered, si, ssn)) =
-                        self.inflight_queue.get(i).map(|c| {
-                            (
-                                c.abandoned(),
-                                c.unordered,
-                                c.stream_identifier,
-                                c.stream_sequence_number,
-                            )
-                        })
-                    {
-                        if !abandoned {
-                            break;
-                        }
-                        self.advanced_peer_tsn_ack_point = i;
-                        self.note_abandoned_for_forward_tsn(unordered, si, ssn);
-                        i += 1;
-                    }
-
-                    // RFC 3758 Sec 3.5 C3
-                    if sna32gt(
-                        self.advanced_peer_tsn_ack_point,
-                        self.cumulative_tsn_ack_point,
-                    ) {
-                        self.will_send_forward_tsn = true;
-                        debug!(
-                            "[{}] on_retransmission_timeout {}: sna32GT({}, {})",
-                            self.side,
-                            self.will_send_forward_tsn,
-                            self.advanced_peer_tsn_ack_point,
-                            self.cumulative_tsn_ack_point
-                        );
-                    }
+                    self.advance_peer_ack_point();
                 }
 
                 debug!(
@@ -3285,26 +3583,32 @@ impl Association {
             }
 
             Timer::T3RTX => {
-                // T3-rtx timer will not fail by design
-                // Justifications:
-                //  * ICE would fail if the connectivity is lost
-                //  * WebRTC spec is not clear how this incident should be reported to ULP
+                // A configured finite recovery budget must end the association,
+                // not leave reliable DATA stranded with no timer (RFC 9260 8.1).
                 error!("[{}] retransmission failure: T3-rtx (DATA)", self.side);
+                let _ = self.close(AssociationError::TimedOut);
+            }
+
+            Timer::Reconfig => {
+                error!("[{}] retransmission failure: RE-CONFIG", self.side);
+                // A request without a timer would block all subsequent resets.
+                self.outgoing_reset = None;
+                self.will_retransmit_reconfig = false;
+                let _ = self.close(AssociationError::TimedOut);
             }
 
             _ => {}
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn expected_reset_sequence(&self) -> u32 {
+        self.incoming_resets.next_expected_rsn()
+    }
+
     /// Whether no timers are running
     #[cfg(test)]
     pub(crate) fn is_idle(&self) -> bool {
-        Timer::VALUES
-            .iter()
-            //.filter(|&&t| t != Timer::KeepAlive && t != Timer::PushNewCid)
-            .filter_map(|&t| Some((t, self.timers.get(t)?)))
-            .min_by_key(|&(_, time)| time)
-            //.map_or(true, |(timer, _)| timer == Timer::Idle)
-            .is_none()
+        self.poll_timeout().is_none()
     }
 }

--- a/rtc-sctp/src/association/mod.rs
+++ b/rtc-sctp/src/association/mod.rs
@@ -40,6 +40,7 @@ use crate::queue::{
     payload_queue::{GapAck, PayloadQueue},
     pending_queue::{PendingQueue, ResetMarker},
     receive_queue::{DeferredReceive, ReceiveQueue},
+    receive_tsn_queue::ReceiveTsnQueue,
 };
 use crate::shared::{AssociationEventInner, AssociationId, EndpointEvent, EndpointEventInner};
 use crate::util::{constant_time_eq, sna16lt, sna32gt, sna32gte, sna32lt, sna32lte};
@@ -220,7 +221,7 @@ pub struct Association {
     my_max_num_outbound_streams: u16,
     my_cookie: Option<ParamStateCookie>,
 
-    pub(crate) payload_queue: PayloadQueue,
+    pub(crate) payload_queue: ReceiveTsnQueue,
     inflight_queue: PayloadQueue,
     /// Absolute, inclusive ranges from the last validated SACK. Comparing
     /// ranges detects reneging without visiting every outstanding DATA chunk.
@@ -338,7 +339,7 @@ impl Default for Association {
             my_max_num_outbound_streams: 0,
             my_cookie: None,
 
-            payload_queue: PayloadQueue::default(),
+            payload_queue: ReceiveTsnQueue::default(),
             inflight_queue: PayloadQueue::default(),
             peer_gap_ack_ranges: Vec::new(),
             pending_queue: PendingQueue::default(),
@@ -763,7 +764,7 @@ impl Association {
             self.pending_queue = PendingQueue::new();
             self.inflight_queue = PayloadQueue::default();
             self.peer_gap_ack_ranges.clear();
-            self.payload_queue = PayloadQueue::default();
+            self.payload_queue = ReceiveTsnQueue::default();
             self.incoming_resets = IncomingResetQueue::new(0);
             self.fwd_tsn_stream_map.clear();
             self.confirmed_reset_tsns.clear();
@@ -1376,13 +1377,13 @@ impl Association {
         );
         self.stats.inc_datas();
 
-        let can_push = self.payload_queue.can_push(d, self.peer_last_tsn);
+        let can_push = self.payload_queue.can_push(d.tsn, self.peer_last_tsn);
         let mut stream_handle_data = false;
         if can_push {
             if d.stream_identifier < self.my_max_num_inbound_streams {
                 if self.get_my_receiver_window_credit() > 0 {
                     // Pass the new chunk to stream level as soon as it arrives
-                    self.payload_queue.push(d.clone(), self.peer_last_tsn);
+                    self.payload_queue.push(d.tsn, self.peer_last_tsn);
                     stream_handle_data = true;
                 } else {
                     // Receive buffer is full. Two kinds of chunk are still worth taking,
@@ -1425,7 +1426,7 @@ impl Association {
                             d.tsn,
                             d.stream_sequence_number
                         );
-                        self.payload_queue.push(d.clone(), self.peer_last_tsn);
+                        self.payload_queue.push(d.tsn, self.peer_last_tsn);
                         stream_handle_data = true;
                     } else {
                         debug!(
@@ -1538,7 +1539,10 @@ impl Association {
         if let Some(probe) = self.zero_window_probe {
             let window_still_closed = self.inflight_queue.get(probe).is_some_and(|chunk| {
                 chunk.is_outstanding()
-                    && (d.advertised_receiver_window_credit as usize) < chunk.user_data.len()
+                    && self
+                        .inflight_queue
+                        .payload_len(probe)
+                        .is_some_and(|len| (d.advertised_receiver_window_credit as usize) < len)
             });
             if !window_still_closed {
                 self.zero_window_probe = None;
@@ -1665,11 +1669,7 @@ impl Association {
         //   chunk,
 
         // Advance peer_last_tsn
-        while let Some(&tsn) = self.payload_queue.sorted.front()
-            && sna32lte(tsn, c.new_cumulative_tsn)
-        {
-            self.payload_queue.pop(tsn);
-        }
+        self.payload_queue.discard_through(c.new_cumulative_tsn);
         self.peer_last_tsn = c.new_cumulative_tsn;
 
         // RX sequence state exists independently of API stream registration.
@@ -1948,7 +1948,7 @@ impl Association {
                     delivery_credit,
                 } = self
                     .inflight_queue
-                    .acknowledge(tsn)
+                    .acknowledge(tsn, self.use_forward_tsn)
                     .ok_or(Error::ErrTsnRequestNotExist)?
                 else {
                     continue;

--- a/rtc-sctp/src/association/model_test.rs
+++ b/rtc-sctp/src/association/model_test.rs
@@ -1,0 +1,249 @@
+//! Protocol properties exercised through real endpoint handshakes and public API.
+
+use std::time::Instant;
+
+use crate::fuzzing_state::{CloseKind, Model, Policy, run};
+
+#[test]
+fn model_reliability_fragment_loss_matrix() {
+    for ordered in [false, true] {
+        for length in [32, 1200, 4000] {
+            for policy in [
+                Policy::Reliable,
+                Policy::Timed(100),
+                Policy::Rexmit(0),
+                Policy::Rexmit(1),
+            ] {
+                let mut model = Model::new(Instant::now());
+                assert!(model.open(0, 1));
+                let lost = model.send(0, 1, ordered, policy, length).unwrap();
+                model.poll();
+                model.drop_packet(0);
+                // Hold the surviving fragments until expiry too: delivering
+                // their Gap SACKs first could legitimately fast-retransmit the
+                // missing head before its deadline.
+                model.advance(1100);
+                model.deliver_all();
+                model.finish();
+                if matches!(policy, Policy::Reliable | Policy::Rexmit(1)) {
+                    assert!(model.received(lost), "{ordered} {length} {policy:?}");
+                } else {
+                    assert!(!model.received(lost), "{ordered} {length} {policy:?}");
+                }
+                let next = model.send(0, 1, ordered, Policy::Reliable, 64).unwrap();
+                model.poll();
+                model.finish();
+                assert!(model.received(next));
+            }
+        }
+    }
+}
+
+#[test]
+fn model_checks_deadline_at_transmission_not_arrival() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    let message = model.send(0, 1, true, Policy::Timed(100), 32).unwrap();
+    model.poll();
+    // The first packet was emitted before its lifetime. It is allowed to arrive
+    // after it, even though a new transmission at that time would be forbidden.
+    model.advance(101);
+    model.deliver_all();
+    model.read(1);
+    assert!(model.received(message));
+    model.finish();
+}
+
+#[test]
+fn model_duplicate_reordered_data_and_ack_release_once() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    let first = model.send(0, 1, true, Policy::Reliable, 4000).unwrap();
+    let second = model.send(0, 1, true, Policy::Reliable, 32).unwrap();
+    model.poll();
+    model.duplicate(0);
+    model.deliver(model.wire_len() - 1);
+    model.deliver(model.wire_len() - 1);
+    model.finish();
+    assert!(model.received(first));
+    assert!(model.received(second));
+    assert_eq!(model.buffered(0, 1), Some(0));
+}
+
+#[test]
+fn model_timed_pending_reset_and_reuse_matrix() {
+    for ordered in [false, true] {
+        for close in [CloseKind::Stop, CloseKind::Close] {
+            let mut model = Model::new(Instant::now());
+            assert!(model.open(0, 1));
+            model.send(0, 1, ordered, Policy::Timed(100), 8000).unwrap();
+            model.poll();
+            model.drop_packet(0);
+            model.deliver_all();
+            model.advance(1100);
+            model.close(0, 1, close);
+            model.poll();
+            // Duplicates and inversion can put a reset request before the TSN
+            // advancement that allows the receiver to finish it.
+            model.duplicate(0);
+            model.deliver(model.wire_len().saturating_sub(1));
+            model.finish();
+            // The fair exchange includes the peer's reciprocal reset and reads
+            // all old messages, so both directions have finished, also for stop.
+            assert!(
+                model.open(0, 1),
+                "completed bidirectional reset did not release SID"
+            );
+            let fresh = model.send(0, 1, true, Policy::Reliable, 64).unwrap();
+            model.poll();
+            model.finish();
+            assert!(model.received(fresh));
+        }
+    }
+}
+
+#[test]
+fn model_stop_preserves_writable_half_before_reciprocal_reset() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    let first = model.send(0, 1, true, Policy::Reliable, 32).unwrap();
+    model.poll();
+    model.finish();
+    assert!(model.received(first));
+    model.close(0, 1, CloseKind::Stop);
+    let after_stop = model
+        .send(0, 1, true, Policy::Reliable, 64)
+        .expect("stop must leave the writable half usable before the peer's reset");
+    model.poll();
+    model.finish();
+    assert!(model.received(after_stop));
+}
+
+#[test]
+fn model_forward_tsn_before_receiver_stream_exists() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    // No DATA from this SID has reached the receiver when FORWARD-TSN arrives.
+    model.send(0, 1, true, Policy::Timed(100), 32).unwrap();
+    model.poll();
+    model.drop_packet(0);
+    model.advance(1100);
+    model.finish();
+    let next = model.send(0, 1, true, Policy::Reliable, 64).unwrap();
+    model.poll();
+    model.finish();
+    assert!(model.received(next));
+}
+
+#[test]
+fn model_stopped_reader_does_not_block_reciprocal_reset() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    assert!(model.open(1, 1));
+    model.close(0, 1, CloseKind::Stop);
+    model.poll();
+    // The peer has not seen our stop yet. These bytes can be discarded by our
+    // application, but must not make reset wait for a now-forbidden read call.
+    model.send(1, 1, true, Policy::Reliable, 1200).unwrap();
+    model.poll();
+    model.finish();
+    assert!(model.open(0, 1));
+    assert!(model.open(1, 1));
+}
+
+#[test]
+fn model_old_sack_does_not_release_reused_sid_buffer() {
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 1));
+    model.send(0, 1, true, Policy::Reliable, 32).unwrap();
+    model.poll();
+    model.deliver_all();
+    model.read(1);
+    model.advance(200);
+    assert_eq!(model.wire_len(), 1, "hold the receiver's delayed SACK");
+    model.close(0, 1, CloseKind::Close);
+    model.poll();
+    // Deliver the complete reset exchange while its earlier cumulative SACK
+    // stays at the front of the wire queue.
+    for _ in 0..32 {
+        if model.wire_len() == 1 {
+            break;
+        }
+        model.deliver(1);
+    }
+    assert_eq!(
+        model.wire_len(),
+        1,
+        "reset did not finish around the held SACK"
+    );
+    assert!(
+        model.open(0, 1),
+        "completed reset must allow reuse before old SACK"
+    );
+    let fresh = model.send(0, 1, true, Policy::Reliable, 16).unwrap();
+    model.poll();
+    assert_eq!(model.buffered(0, 1), Some(16));
+    model.deliver(0);
+    assert_eq!(
+        model.buffered(0, 1),
+        Some(16),
+        "old SACK released the new object's bytes"
+    );
+    model.finish();
+    assert!(model.received(fresh));
+}
+
+#[test]
+fn model_fair_drain_reads_both_delivery_generations() {
+    // Minimized from seed 46. Both messages and both reset directions finish on
+    // the wire before the reader drains the old generation. Reading that old
+    // message exposes the next generation only after its close event is polled.
+    let mut model = Model::new(Instant::now());
+    assert!(model.open(0, 2));
+    assert!(model.open(1, 2));
+    let old = model.send(1, 2, true, Policy::Rexmit(2), 4000).unwrap();
+    model.poll();
+    model.close(1, 2, CloseKind::Stop);
+    model.poll();
+    let new = model.send(1, 2, false, Policy::Reliable, 1200).unwrap();
+    model.poll();
+    model.finish();
+    assert!(model.received(old));
+    assert!(model.received(new));
+}
+
+/// Also provides a subprocess entry for delta reduction without changing a
+/// process-global panic hook while the normal suite runs tests in parallel.
+#[test]
+fn model_replay_input() {
+    let input = std::env::var("RTC_SCTP_MODEL_INPUT").unwrap_or_default();
+    assert!(
+        input.len().is_multiple_of(8),
+        "input must contain whole four-byte actions"
+    );
+    let input: Vec<_> = input
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|byte| u8::from_str_radix(std::str::from_utf8(byte).unwrap(), 16).unwrap())
+        .collect();
+    run(&input, Instant::now());
+}
+
+#[test]
+fn model_seeded_event_sequences() {
+    for seed in 0..48_u64 {
+        let mut state = seed + 1;
+        let mut input = [0; 192];
+        for byte in &mut input {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *byte = state as u8;
+        }
+        let result = std::panic::catch_unwind(|| run(&input, Instant::now()));
+        assert!(
+            result.is_ok(),
+            "stateful scenario seed={seed}, input={input:02x?}"
+        );
+    }
+}

--- a/rtc-sctp/src/association/receive_tracking_test.rs
+++ b/rtc-sctp/src/association/receive_tracking_test.rs
@@ -1,0 +1,133 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackedReceivePayload {
+    data: Vec<u8>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for TrackedReceivePayload {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl Drop for TrackedReceivePayload {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn assert_receive_sack(
+    receiver: &mut Association,
+    cumulative_tsn: u32,
+    gaps: &[(u16, u16)],
+    window: u32,
+) {
+    let sack = receiver.create_selective_ack_chunk();
+    assert_eq!(sack.cumulative_tsn_ack, cumulative_tsn);
+    assert_eq!(sack.advertised_receiver_window_credit, window);
+    assert_eq!(
+        sack.gap_ack_blocks
+            .iter()
+            .map(|gap| (gap.start, gap.end))
+            .collect::<Vec<_>>(),
+        gaps
+    );
+}
+
+#[test]
+fn reading_unordered_messages_releases_backing_before_gap_is_filled() -> Result<()> {
+    const PAYLOAD_SIZE: usize = 1024;
+    const RECEIVE_WINDOW: u32 = (2 * PAYLOAD_SIZE) as u32;
+
+    let mut receiver = timed_test_association();
+    receiver.peer_last_tsn = 0;
+    receiver.max_receive_buffer_size = RECEIVE_WINDOW;
+    let dropped = Arc::new(AtomicUsize::new(0));
+
+    // Leave TSN 1 missing. Each later DATA is a complete unordered message,
+    // so the application can read it without advancing the cumulative ACK.
+    for (tsn, byte) in [(2, 0x41), (3, 0x42)] {
+        let data = ChunkPayloadData {
+            tsn,
+            stream_identifier: 1,
+            unordered: true,
+            beginning_fragment: true,
+            ending_fragment: true,
+            payload_type: PayloadProtocolIdentifier::Binary,
+            user_data: Bytes::from_owner(TrackedReceivePayload {
+                data: vec![byte; PAYLOAD_SIZE],
+                dropped: Arc::clone(&dropped),
+            }),
+            ..Default::default()
+        };
+        receiver.handle_data(&data)?;
+    }
+    // The incoming DATA values are gone; unread delivery owns the backing.
+    assert_eq!(dropped.load(Ordering::SeqCst), 0);
+    assert_receive_sack(&mut receiver, 0, &[(2, 3)], 0);
+
+    for (index, byte) in [0x41, 0x42].into_iter().enumerate() {
+        let message = receiver.stream(1)?.read_sctp()?.unwrap();
+        assert_eq!(message.ppi, PayloadProtocolIdentifier::Binary);
+        assert_eq!(
+            &message.to_payload(PAYLOAD_SIZE)?[..],
+            &[byte; PAYLOAD_SIZE]
+        );
+        drop(message);
+        assert_eq!(
+            receiver.get_my_receiver_window_credit(),
+            ((index + 1) * PAYLOAD_SIZE) as u32
+        );
+    }
+    assert!(receiver.stream(1)?.read_sctp()?.is_none());
+    receiver.assert_receive_accounting();
+    assert_receive_sack(&mut receiver, 0, &[(2, 3)], RECEIVE_WINDOW);
+    let dropped_after_read = dropped.load(Ordering::SeqCst);
+
+    // A duplicate uses independent backing. Receipt metadata must still
+    // suppress redelivery after the original payload has been released.
+    let duplicate = ChunkPayloadData {
+        tsn: 2,
+        stream_identifier: 1,
+        unordered: true,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: PayloadProtocolIdentifier::Binary,
+        user_data: Bytes::from(vec![0x41; PAYLOAD_SIZE]),
+        ..Default::default()
+    };
+    receiver.handle_data(&duplicate)?;
+    assert!(receiver.stream(1)?.read_sctp()?.is_none());
+    assert_receive_sack(&mut receiver, 0, &[(2, 3)], RECEIVE_WINDOW);
+    assert_eq!(dropped.load(Ordering::SeqCst), dropped_after_read);
+
+    // Filling the hole must cumulatively acknowledge the already-read TSNs
+    // without delivering them again. This also proves the tracked owners
+    // belong to receipt tracking if they survived the earlier reads.
+    receiver.handle_data(&ChunkPayloadData {
+        tsn: 1,
+        user_data: Bytes::from_static(b"gap"),
+        ..duplicate.clone()
+    })?;
+    assert_eq!(
+        &receiver
+            .stream(1)?
+            .read_sctp()?
+            .unwrap()
+            .to_payload(PAYLOAD_SIZE)?[..],
+        b"gap"
+    );
+    assert!(receiver.stream(1)?.read_sctp()?.is_none());
+    assert_receive_sack(&mut receiver, 3, &[], RECEIVE_WINDOW);
+    receiver.handle_data(&duplicate)?;
+    assert!(receiver.stream(1)?.read_sctp()?.is_none());
+    assert_receive_sack(&mut receiver, 3, &[], RECEIVE_WINDOW);
+    assert_eq!(dropped.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        dropped_after_read, 2,
+        "receipt tracking must release already-read payload backing before a lower TSN gap closes"
+    );
+    Ok(())
+}

--- a/rtc-sctp/src/association/reliability_reset_test.rs
+++ b/rtc-sctp/src/association/reliability_reset_test.rs
@@ -1,0 +1,393 @@
+//! Regression tests for partial reliability, recovery, and stream reset.
+
+use super::*;
+
+#[test]
+fn test_extension_negotiation_for_init_and_init_ack() -> Result<()> {
+    for is_ack in [false, true] {
+        for (legacy_pr, listed_pr, reconfig) in [
+            (false, false, false),
+            (true, false, false),
+            (false, true, false),
+            (false, false, true),
+            (true, true, true),
+        ] {
+            let mut a = create_association(TransportConfig::default());
+            let mut params: Vec<Box<dyn Param>> = vec![];
+            if is_ack {
+                params.push(Box::new(ParamStateCookie::new()));
+            }
+            if legacy_pr {
+                params.push(Box::new(ParamForwardTsnSupported {}));
+            }
+            let mut chunk_types = vec![];
+            if listed_pr {
+                chunk_types.push(CT_FORWARD_TSN);
+            }
+            if reconfig {
+                chunk_types.push(CT_RECONFIG);
+            }
+            params.push(Box::new(ParamSupportedExtensions { chunk_types }));
+            let init = ChunkInit {
+                is_ack,
+                initiate_tag: 123,
+                advertised_receiver_window_credit: 65536,
+                num_outbound_streams: 10,
+                num_inbound_streams: 10,
+                initial_tsn: 1,
+                params,
+            };
+            let packet = Packet {
+                common_header: CommonHeader {
+                    verification_tag: if is_ack { a.my_verification_tag } else { 0 },
+                    source_port: a.destination_port,
+                    destination_port: a.source_port,
+                },
+                chunks: vec![],
+            };
+            if is_ack {
+                a.set_state(AssociationState::CookieWait);
+                a.handle_init_ack(&packet, &init, Instant::now())?;
+            } else {
+                let response = a.handle_init(&packet, &init)?;
+                let ack = response[0].chunks[0]
+                    .as_any()
+                    .downcast_ref::<ChunkInit>()
+                    .unwrap();
+                assert!(
+                    ack.params
+                        .iter()
+                        .any(|p| p.as_any().is::<ParamForwardTsnSupported>())
+                );
+            }
+            assert_eq!(a.use_forward_tsn, legacy_pr || listed_pr);
+            assert_eq!(a.peer_supports_reconfig, reconfig);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_unsupported_reset_leaves_both_api_halves_usable() -> Result<()> {
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut a = timed_test_association();
+    a.peer_supports_reconfig = false;
+    let mut stream = a.open_stream(1, ppi)?;
+    assert!(stream.close(now).is_err());
+    assert!(stream.is_readable());
+    assert!(stream.is_writable());
+    stream.write_sctp(now, &Bytes::from_static(b"still usable"), ppi)?;
+    let packets = a.gather_outbound(now).0;
+    assert!(reset_requests(&packets).is_empty());
+    assert_eq!(transmitted_data(&packets).len(), 1);
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+    Ok(())
+}
+
+#[test]
+fn test_incoming_reset_without_peer_advertisement_gets_response_only() -> Result<()> {
+    let now = Instant::now();
+    let mut a = timed_test_association();
+    a.peer_supports_reconfig = false;
+    a.open_stream(1, PayloadProtocolIdentifier::Binary)?;
+    let request = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: a.my_next_rsn.wrapping_sub(1),
+        sender_last_tsn: a.peer_last_tsn,
+        stream_identifiers: vec![1],
+    };
+    assert_eq!(
+        reconfig_results(&a.handle_reconfig(now, &reset_config(&request))?),
+        [ReconfigResult::SuccessPerformed],
+    );
+    assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+    assert!(a.timers.get(Timer::Reconfig).is_none());
+    assert!(a.stream(1).is_err());
+    Ok(())
+}
+
+#[test]
+fn test_retired_stream_handle_cannot_stop_next_delivery() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let first = ChunkPayloadData {
+        tsn: a.peer_last_tsn.wrapping_add(1),
+        stream_identifier: 1,
+        stream_sequence_number: 0,
+        beginning_fragment: true,
+        ending_fragment: true,
+        payload_type: PayloadProtocolIdentifier::Binary,
+        user_data: Bytes::from_static(b"old"),
+        ..Default::default()
+    };
+    a.handle_data(&first)?;
+    let request = ParamOutgoingResetRequest {
+        reconfig_request_sequence_number: 1,
+        reconfig_response_sequence_number: a.my_next_rsn.wrapping_sub(1),
+        sender_last_tsn: first.tsn,
+        stream_identifiers: vec![1],
+    };
+    a.handle_reconfig(now, &reset_config(&request))?;
+    let reciprocal = reset_requests(&a.gather_outbound(now).0).remove(0);
+    receive_reset_response(&mut a, now, &reciprocal, ReconfigResult::SuccessPerformed)?;
+    a.handle_data(&ChunkPayloadData {
+        tsn: first.tsn.wrapping_add(1),
+        user_data: Bytes::from_static(b"new"),
+        ..first
+    })?;
+    {
+        let mut old = a.stream(1)?;
+        assert_eq!(old.read()?.unwrap().len(), 3);
+        old.stop(now)?;
+    }
+    while a.poll().is_some() {}
+    assert_eq!(a.stream(1)?.read()?.unwrap().len(), 3);
+    Ok(())
+}
+
+#[test]
+fn test_window_reopening_restores_t3_congestion_response() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.cwnd = 4 * a.mtu;
+    a.open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"fill"), ppi)?;
+    let filled = transmitted_data(&a.gather_outbound(now).0).remove(0);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: filled.tsn,
+            advertised_receiver_window_credit: 0,
+            ..Default::default()
+        },
+        now,
+    )?;
+    a.stream(1)?
+        .write_sctp(now, &Bytes::from_static(b"probe"), ppi)?;
+    let probe = transmitted_data(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(a.zero_window_probe, Some(probe.tsn));
+    // Probe is lost. The peer application drains the earlier payload and
+    // advertises an open window without acknowledging the missing probe.
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: filled.tsn,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        now,
+    )?;
+    a.stream(1)?.write_sctp(
+        now,
+        &Bytes::from_static(b"ordinary data in reopened window"),
+        ppi,
+    )?;
+    assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 1);
+    assert!(a.inflight_queue.len() > 1);
+    assert!(a.cwnd > a.mtu);
+    let at = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(at);
+    assert_eq!(
+        a.cwnd, a.mtu,
+        "ordinary T3 loss after the window reopened must reduce cwnd"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_responsive_small_positive_window_does_not_exhaust_t3() -> Result<()> {
+    let mut a = timed_test_association();
+    let mut now = Instant::now();
+    let ppi = PayloadProtocolIdentifier::Binary;
+    // RFC 9260 6.1 A treats an rwnd smaller than the next DATA as closed,
+    // including a positive but insufficient advertised receiver window.
+    a.rwnd = 2;
+    a.open_stream(1, ppi)?
+        .write_sctp(now, &Bytes::from_static(b"probe"), ppi)?;
+    let probe = transmitted_data(&a.gather_outbound(now).0).remove(0);
+    assert_eq!(a.zero_window_probe, Some(probe.tsn));
+    for _ in 0..9 {
+        a.handle_sack(
+            &ChunkSelectiveAck {
+                cumulative_tsn_ack: probe.tsn.wrapping_sub(1),
+                advertised_receiver_window_credit: 2,
+                ..Default::default()
+            },
+            now,
+        )?;
+        now = a.timers.get(Timer::T3RTX).unwrap();
+        a.handle_timeout(now);
+        assert!(
+            !a.is_closed(),
+            "a responsive peer with a too-small positive window is not a failed path"
+        );
+        a.gather_outbound(now);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_rfc3758_forward_tsn_parameter_negotiates_partial_reliability() -> Result<()> {
+    let mut a = create_association(TransportConfig::default());
+    let init = ChunkInit {
+        initiate_tag: 123,
+        advertised_receiver_window_credit: 65536,
+        num_outbound_streams: 10,
+        num_inbound_streams: 10,
+        initial_tsn: 1,
+        params: vec![Box::new(
+            crate::param::param_forward_tsn_supported::ParamForwardTsnSupported {},
+        )],
+        ..Default::default()
+    };
+    let packet = Packet {
+        common_header: CommonHeader {
+            verification_tag: 0,
+            source_port: a.destination_port,
+            destination_port: a.source_port,
+        },
+        chunks: vec![],
+    };
+    let _reply = a.handle_init(&packet, &init)?;
+    assert!(
+        a.use_forward_tsn,
+        "RFC 3758 0xc000 advertisement must negotiate partial reliability"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_local_open_cannot_relabel_saved_receiver() -> Result<()> {
+    for unordered in [false, true] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        let mut data = ChunkPayloadData {
+            tsn: a.peer_last_tsn.wrapping_add(1),
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: true,
+            ending_fragment: true,
+            unordered,
+            payload_type: PayloadProtocolIdentifier::Binary,
+            ..Default::default()
+        };
+        let mut last_reciprocal = a.my_next_rsn.wrapping_sub(1);
+        for (sequence, payload) in [b"old".as_slice(), b"middle".as_slice()]
+            .into_iter()
+            .enumerate()
+        {
+            data.user_data = Bytes::copy_from_slice(payload);
+            a.handle_data(&data)?;
+            let request = ParamOutgoingResetRequest {
+                reconfig_request_sequence_number: sequence as u32 + 1,
+                reconfig_response_sequence_number: last_reciprocal,
+                sender_last_tsn: data.tsn,
+                stream_identifiers: vec![1],
+            };
+            assert_eq!(
+                reconfig_results(&a.handle_reconfig(now, &reset_config(&request))?),
+                [ReconfigResult::SuccessPerformed],
+            );
+            let reciprocals = reset_requests(&a.gather_outbound(now).0);
+            assert_eq!(reciprocals.len(), 1);
+            last_reciprocal = reciprocals[0].reconfig_request_sequence_number;
+            receive_reset_response(
+                &mut a,
+                now,
+                &reciprocals[0],
+                ReconfigResult::SuccessPerformed,
+            )?;
+            data.tsn = data.tsn.wrapping_add(1);
+        }
+
+        data.user_data = Bytes::from_static(b"current");
+        a.handle_data(&data)?;
+        let old = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&old[..], b"old");
+        {
+            assert!(matches!(
+                a.open_stream(1, PayloadProtocolIdentifier::Binary),
+                Err(Error::ErrStreamAlreadyExist)
+            ));
+            let mut middle = a
+                .accept_stream()
+                .expect("saved receiver has its own API epoch");
+            assert!(!middle.is_writable());
+            assert!(middle.is_readable());
+            middle.stop(now)?;
+        }
+        assert!(reset_requests(&a.gather_outbound(now).0).is_empty());
+        while a.poll().is_some() {}
+        assert!(a.stream(1)?.is_writable());
+        let current = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&current[..], b"current");
+        data.tsn = data.tsn.wrapping_add(1);
+        data.stream_sequence_number = if unordered { 0 } else { 1 };
+        data.user_data = Bytes::from_static(b"later in current");
+        a.handle_data(&data)?;
+        let later = a.stream(1)?.read_sctp()?.unwrap().to_payload(100)?;
+        assert_eq!(&later[..], b"later in current");
+        assert_eq!(a.receive_streams[&1].get_num_bytes(), 0);
+
+        let request = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: 3,
+            reconfig_response_sequence_number: last_reciprocal,
+            sender_last_tsn: data.tsn,
+            stream_identifiers: vec![1],
+        };
+        a.handle_reconfig(now, &reset_config(&request))?;
+        let reciprocals = reset_requests(&a.gather_outbound(now).0);
+        assert_eq!(
+            reciprocals.len(),
+            1,
+            "the current wire epoch still needs its own reciprocal reset"
+        );
+        assert_eq!(reciprocals[0].stream_identifiers, [1]);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_accept_stream_publishes_next_saved_delivery_without_poll_event() -> Result<()> {
+    let mut a = timed_test_association();
+    let now = Instant::now();
+    let mut last_reciprocal = a.my_next_rsn.wrapping_sub(1);
+    for sequence in 1..=2 {
+        let data = ChunkPayloadData {
+            tsn: a.peer_last_tsn.wrapping_add(1),
+            stream_identifier: 1,
+            stream_sequence_number: 0,
+            beginning_fragment: true,
+            ending_fragment: true,
+            payload_type: PayloadProtocolIdentifier::Binary,
+            user_data: Bytes::from(vec![sequence as u8]),
+            ..Default::default()
+        };
+        a.handle_data(&data)?;
+        let request = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: sequence,
+            reconfig_response_sequence_number: last_reciprocal,
+            sender_last_tsn: data.tsn,
+            stream_identifiers: vec![1],
+        };
+        a.handle_reconfig(now, &reset_config(&request))?;
+        let reciprocal = reset_requests(&a.gather_outbound(now).0).remove(0);
+        last_reciprocal = reciprocal.reconfig_request_sequence_number;
+        receive_reset_response(&mut a, now, &reciprocal, ReconfigResult::SuccessPerformed)?;
+    }
+    let first = a
+        .accept_stream()
+        .expect("first accepted stream")
+        .read_sctp()?
+        .unwrap()
+        .to_payload(8)?;
+    assert_eq!(first.as_ref(), &[1]);
+    let second = a
+        .accept_stream()
+        .expect("accept_stream itself must expose the next saved receiver")
+        .read_sctp()?
+        .unwrap()
+        .to_payload(8)?;
+    assert_eq!(second.as_ref(), &[2]);
+    Ok(())
+}

--- a/rtc-sctp/src/association/reset.rs
+++ b/rtc-sctp/src/association/reset.rs
@@ -1,0 +1,214 @@
+//! One outgoing reset procedure owns its immutable wire request and result.
+//! Receipt (RFC 6525 E1) does not commit a new SSN space (H4).
+
+use super::*;
+
+#[derive(Debug, Copy, Clone)]
+pub(super) enum RequestPhase {
+    Active,
+    ReceiptOnly {
+        retry_at: Instant,
+        in_progress: bool,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct OutgoingReset {
+    pub(super) request: ParamOutgoingResetRequest,
+    pub(super) phase: RequestPhase,
+    streams: Vec<ResetMarker>,
+}
+
+impl OutgoingReset {
+    fn to_chunk(&self) -> ChunkReconfig {
+        ChunkReconfig {
+            param_a: Some(Box::new(self.request.clone())),
+            ..Default::default()
+        }
+    }
+}
+
+impl Association {
+    pub(super) fn acknowledge_reconfig(&mut self, sequence: u32, now: Instant) {
+        let Some(reset) = &mut self.outgoing_reset else {
+            return;
+        };
+        if reset.request.reconfig_request_sequence_number != sequence
+            || !matches!(reset.phase, RequestPhase::Active)
+            || self.timers.get(Timer::Reconfig).is_none()
+        {
+            return;
+        }
+        reset.phase = RequestPhase::ReceiptOnly {
+            retry_at: now + Duration::from_millis(self.rto_mgr.get_rto()),
+            in_progress: self.timers.is_reconfig_in_progress(),
+        };
+        self.timers.stop(Timer::Reconfig);
+        self.will_retransmit_reconfig = false;
+    }
+
+    pub(super) fn handle_reset_response(&mut self, now: Instant, response: &ParamReconfigResponse) {
+        let Some(reset) = &self.outgoing_reset else {
+            return;
+        };
+        // H1: an old result cannot affect a newer request, or commit a request
+        // whose timer E1 already stopped. A query reactivates this same RSN.
+        if reset.request.reconfig_request_sequence_number
+            != response.reconfig_response_sequence_number
+            || !matches!(reset.phase, RequestPhase::Active)
+            || self.timers.get(Timer::Reconfig).is_none()
+        {
+            return;
+        }
+        self.timers.stop(Timer::Reconfig);
+        self.will_retransmit_reconfig = false;
+        if response.result == ReconfigResult::InProgress {
+            self.timers
+                .restart_reconfig_in_progress(now, self.rto_mgr.get_rto());
+            return;
+        }
+        if matches!(
+            response.result,
+            ReconfigResult::ErrorBadSequenceNumber | ReconfigResult::Unknown
+        ) {
+            // An unknown old result proves neither success nor refusal. The
+            // stronger serialization prevents history eviction by our N+1/N+2;
+            // if the peer cannot resolve N, terminate instead of guessing SSNs.
+            let abort = self.create_packet(vec![Box::new(ChunkAbort::default())]);
+            let _ = self.close(AssociationError::TransportError);
+            self.control_queue.push_back(abort);
+            return;
+        }
+        let reset = self.outgoing_reset.take().unwrap();
+        let performed = matches!(
+            response.result,
+            ReconfigResult::SuccessPerformed | ReconfigResult::SuccessNop
+        );
+        let OutgoingReset {
+            request, streams, ..
+        } = reset;
+        let mut refused_reciprocal = false;
+        for stream in streams {
+            let si = stream.stream_identifier;
+            if performed {
+                // The sole commit point for the TX direction's SSN space.
+                self.transmit_streams.entry(si).or_default().reset();
+                self.fwd_tsn_stream_map.remove(&si);
+                if sna32gt(request.sender_last_tsn, self.cumulative_tsn_ack_point) {
+                    self.confirmed_reset_tsns
+                        .insert(si, request.sender_last_tsn);
+                }
+                if let Some(received) = self.receive_streams.get_mut(&si) {
+                    received.complete_outgoing_reset(stream.receive_epoch);
+                }
+            }
+            self.pending_queue.complete_reset(si);
+            if !performed
+                && !self.pending_queue.is_resetting(si)
+                && let Some(received) = self.receive_streams.get_mut(&si)
+            {
+                refused_reciprocal |= received.refuse_outgoing_reset();
+            }
+        }
+        if refused_reciprocal {
+            // H3 leaves TX SSNs unchanged. When RX already closed, this API
+            // cannot finish the data-channel close after the last TX refusal.
+            // Fail the association explicitly instead of silently allowing reuse.
+            let abort = self.create_packet(vec![Box::new(ChunkAbort::default())]);
+            let _ = self.close(AssociationError::TransportError);
+            self.control_queue.push_back(abort);
+            return;
+        }
+        if performed && sna32gt(request.sender_last_tsn, self.cumulative_tsn_ack_point) {
+            // Completion is serialized; these TSN boundaries are nondecreasing.
+            self.reset_tsn_ack_queue
+                .push_back((request.sender_last_tsn, request.stream_identifiers));
+        }
+        if self.use_forward_tsn {
+            self.advance_peer_ack_point();
+        }
+    }
+
+    pub(super) fn can_start_reconfig(&self) -> bool {
+        // A stronger local serialization than E1 requires keeps N in even a
+        // one-result peer cache until an explicit outcome establishes TX SSNs.
+        self.outgoing_reset.is_none()
+    }
+
+    pub(super) fn next_reconfig_result_retry(&self) -> Option<(u32, Instant)> {
+        if self.state() != AssociationState::Established {
+            return None;
+        }
+        let reset = self.outgoing_reset.as_ref()?;
+        match reset.phase {
+            RequestPhase::ReceiptOnly { retry_at, .. } => {
+                Some((reset.request.reconfig_request_sequence_number, retry_at))
+            }
+            RequestPhase::Active => None,
+        }
+    }
+
+    pub(super) fn resume_reset_query(&mut self, now: Instant) {
+        let Some(reset) = &mut self.outgoing_reset else {
+            return;
+        };
+        if let RequestPhase::ReceiptOnly {
+            retry_at,
+            in_progress,
+        } = reset.phase
+            && retry_at <= now
+        {
+            reset.phase = RequestPhase::Active;
+            if in_progress {
+                self.timers
+                    .restart_reconfig_in_progress(now, self.rto_mgr.get_rto());
+            } else {
+                self.timers
+                    .start(Timer::Reconfig, now, self.rto_mgr.get_rto());
+            }
+            self.will_retransmit_reconfig = true;
+        }
+    }
+
+    pub(super) fn emit_reconfig(&mut self, now: Instant, packets: &mut Vec<Bytes>) {
+        if !std::mem::take(&mut self.will_retransmit_reconfig) {
+            return;
+        }
+        if let Some(reset) = &self.outgoing_reset
+            && matches!(reset.phase, RequestPhase::Active)
+        {
+            if let Ok(raw) = self.marshal_control_chunk(&reset.to_chunk()) {
+                packets.push(raw);
+            }
+            self.timers
+                .start(Timer::Reconfig, now, self.rto_mgr.get_rto());
+        }
+    }
+
+    pub(super) fn start_reconfig(
+        &mut self,
+        now: Instant,
+        streams: Vec<ResetMarker>,
+        packets: &mut Vec<Bytes>,
+    ) {
+        debug_assert!(self.can_start_reconfig());
+        let request = ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: self.generate_next_rsn(),
+            // A4 always acknowledges the most recently accepted request, even
+            // when several queued reciprocal resets are bundled together.
+            reconfig_response_sequence_number: self.incoming_resets.last_received_rsn(),
+            sender_last_tsn: self.my_next_tsn.wrapping_sub(1),
+            stream_identifiers: streams
+                .iter()
+                .map(|stream| stream.stream_identifier)
+                .collect(),
+        };
+        self.outgoing_reset = Some(OutgoingReset {
+            request,
+            phase: RequestPhase::Active,
+            streams,
+        });
+        self.will_retransmit_reconfig = true;
+        self.emit_reconfig(now, packets);
+    }
+}

--- a/rtc-sctp/src/association/reset_receive.rs
+++ b/rtc-sctp/src/association/reset_receive.rs
@@ -1,0 +1,702 @@
+//! Accepted incoming reset procedures and a bounded replay history.
+//!
+//! RFC 6525 §§5.2.1–5.2.2 requires retransmissions to retain their result and
+//! deferred requests to resume at their TSN boundary. An accepted procedure is
+//! consequently independent of the small history used for completed duplicates.
+//! The original wire request is immutable; an empty SID list is resolved
+//! separately as incoming streams become known before application of the reset.
+//!
+//! E1 acknowledgement/timer handling, E3 RX mutation, E4 held DATA, and E5–E6
+//! response packet construction belong to the association, not this container.
+
+use std::collections::{BTreeSet, VecDeque};
+
+use crate::param::param_outgoing_reset_request::ParamOutgoingResetRequest;
+use crate::param::param_reconfig_response::ReconfigResult;
+use crate::util::{sna32gt, sna32lte};
+
+// Administrative admission limits permitted by RFC 6525 §5.2.1. The SID budget
+// counts immutable wire lists plus resolved SID sets. An all-stream request
+// reserves its negotiated maximum immediately, so later observe_stream calls
+// cannot grow accepted state beyond the admission budget.
+const MAX_PENDING_REQUESTS: usize = 32;
+const MAX_PENDING_STREAM_IDS: usize = 65_536;
+const REPLAY_RESULTS: usize = 2;
+// A parameter has a u16 wire length, including its 16-byte fixed fields.
+const MAX_WIRE_STREAM_IDS: usize = (u16::MAX as usize - 16) / 2;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum ReceiveResetAction {
+    /// Newly accepted request; apply it if ready, otherwise answer InProgress.
+    New,
+    /// Exact duplicate of an accepted request which still awaits application.
+    Pending,
+    /// A completed duplicate or an administrative/sequence rejection.
+    Reply(ReconfigResult),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct IncomingReset {
+    original: ParamOutgoingResetRequest,
+    streams: ResetStreams,
+    max_inbound: u16,
+    reserved_stream_ids: usize,
+}
+
+/// A one-SID reset needs no tree allocation. Larger selections retain the
+/// BTreeSet's sorted, deduplicated traversal and logarithmic insert/lookup.
+#[derive(Debug, Clone, Default)]
+pub(super) struct ResetStreams {
+    first: Option<u16>,
+    remaining: BTreeSet<u16>,
+}
+
+impl ResetStreams {
+    fn insert(&mut self, sid: u16) -> bool {
+        match self.first {
+            None => {
+                self.first = Some(sid);
+                true
+            }
+            Some(first) if sid == first => false,
+            Some(first) if sid < first => {
+                self.remaining.insert(first);
+                self.first = Some(sid);
+                true
+            }
+            Some(_) => self.remaining.insert(sid),
+        }
+    }
+
+    fn contains(&self, sid: &u16) -> bool {
+        self.first.as_ref() == Some(sid) || self.remaining.contains(sid)
+    }
+
+    fn len(&self) -> usize {
+        usize::from(self.first.is_some()) + self.remaining.len()
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = &u16> {
+        self.first.iter().chain(self.remaining.iter())
+    }
+}
+
+impl FromIterator<u16> for ResetStreams {
+    fn from_iter<T: IntoIterator<Item = u16>>(iter: T) -> Self {
+        let mut iter = iter.into_iter();
+        let Some(first) = iter.next() else {
+            return Self::default();
+        };
+        let Some(second) = iter.next() else {
+            return Self {
+                first: Some(first),
+                remaining: BTreeSet::new(),
+            };
+        };
+        // Preserve the BTreeSet bulk-build path for larger incoming requests.
+        let mut remaining: BTreeSet<_> = [first, second].into_iter().chain(iter).collect();
+        Self {
+            first: remaining.pop_first(),
+            remaining,
+        }
+    }
+}
+
+impl IncomingReset {
+    #[cfg(test)]
+    pub(super) fn original(&self) -> &ParamOutgoingResetRequest {
+        &self.original
+    }
+
+    /// Stable, deduplicated selection, separate from the original wire SID list.
+    #[cfg(test)]
+    pub(super) fn streams(&self) -> impl Iterator<Item = &u16> {
+        self.streams.iter()
+    }
+
+    fn affects(&self, sid: u16) -> bool {
+        sid < self.max_inbound
+            && (self.original.stream_identifiers.is_empty() || self.streams.contains(&sid))
+    }
+}
+
+#[derive(Debug)]
+struct CompletedReset {
+    original: ParamOutgoingResetRequest,
+    result: ReconfigResult,
+}
+
+#[derive(Debug)]
+pub(super) struct IncomingResetQueue {
+    next_expected_rsn: u32,
+    // Arrival order is RSN order, including wrapping from u32::MAX to zero.
+    pending: VecDeque<IncomingReset>,
+    // Ordered by request RSN, not by completion time. Completion of an older
+    // deferred request must not evict the result of the latest received one.
+    completed: VecDeque<CompletedReset>,
+    reserved_stream_ids: usize,
+}
+
+impl IncomingResetQueue {
+    pub(super) fn new(peer_initial_tsn: u32) -> Self {
+        Self {
+            next_expected_rsn: peer_initial_tsn,
+            pending: VecDeque::new(),
+            completed: VecDeque::new(),
+            reserved_stream_ids: 0,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn next_expected_rsn(&self) -> u32 {
+        self.next_expected_rsn
+    }
+
+    /// Value used by an independently initiated outgoing request's A4 field.
+    pub(super) fn last_received_rsn(&self) -> u32 {
+        self.next_expected_rsn.wrapping_sub(1)
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn history_len(&self) -> usize {
+        self.completed.len()
+    }
+
+    pub(super) fn get(&self, sequence: u32) -> Option<&IncomingReset> {
+        self.pending
+            .iter()
+            .find(|p| p.original.reconfig_request_sequence_number == sequence)
+    }
+
+    /// Admission consumes an expected RSN exactly once, including a definitive
+    /// administrative refusal. Exact pending/completed duplicates reuse their
+    /// prior state. Changed payloads using the same RSN never execute a reset.
+    pub(super) fn accept(
+        &mut self,
+        request: &ParamOutgoingResetRequest,
+        known_sids: impl IntoIterator<Item = u16>,
+        max_inbound: u16,
+    ) -> ReceiveResetAction {
+        let sequence = request.reconfig_request_sequence_number;
+        if let Some(pending) = self.get(sequence) {
+            return if pending.original == *request {
+                ReceiveResetAction::Pending
+            } else {
+                ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+            };
+        }
+        if let Some(completed) = self
+            .completed
+            .iter()
+            .find(|p| p.original.reconfig_request_sequence_number == sequence)
+        {
+            return ReceiveResetAction::Reply(if completed.original == *request {
+                completed.result
+            } else {
+                ReconfigResult::ErrorBadSequenceNumber
+            });
+        }
+        if sequence != self.next_expected_rsn {
+            return ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber);
+        }
+        // Such a value cannot be produced by the wire decoder. Do not retain an
+        // unbounded synthetic request if another internal caller constructs one.
+        if request.stream_identifiers.len() > MAX_WIRE_STREAM_IDS {
+            return ReceiveResetAction::Reply(ReconfigResult::Denied);
+        }
+        self.next_expected_rsn = self.next_expected_rsn.wrapping_add(1);
+        let all_streams = request.stream_identifiers.is_empty();
+        let streams: ResetStreams = if all_streams {
+            known_sids
+                .into_iter()
+                .filter(|sid| *sid < max_inbound)
+                .collect()
+        } else {
+            request.stream_identifiers.iter().copied().collect()
+        };
+        let reserved_stream_ids = request.stream_identifiers.len()
+            + if all_streams {
+                usize::from(max_inbound)
+            } else {
+                streams.len()
+            };
+        if streams.iter().any(|sid| *sid >= max_inbound)
+            || self.pending.len() >= MAX_PENDING_REQUESTS
+            || reserved_stream_ids > MAX_PENDING_STREAM_IDS - self.reserved_stream_ids
+        {
+            self.remember(request.clone(), ReconfigResult::Denied);
+            return ReceiveResetAction::Reply(ReconfigResult::Denied);
+        }
+        self.reserved_stream_ids += reserved_stream_ids;
+        self.pending.push_back(IncomingReset {
+            original: request.clone(),
+            streams,
+            max_inbound,
+            reserved_stream_ids,
+        });
+        ReceiveResetAction::New
+    }
+
+    /// Add an incoming stream discovered while an all-stream reset is deferred.
+    /// This is also safe for DATA beyond the boundary: E2 holds its payload until
+    /// reset, so resetting its freshly created RX state precedes DATA delivery.
+    pub(super) fn observe_stream(&mut self, sid: u16) {
+        for pending in &mut self.pending {
+            if pending.original.stream_identifiers.is_empty() && sid < pending.max_inbound {
+                pending.streams.insert(sid);
+            }
+        }
+    }
+
+    /// First reset affecting this SID. Hold DATA beyond this boundary per E2,
+    /// then look again after completion to find a subsequent accepted reset.
+    /// All-stream requests match valid SIDs even before their first DATA exists.
+    pub(super) fn boundary(&self, sid: u16) -> Option<u32> {
+        self.pending
+            .iter()
+            .find(|p| p.affects(sid))
+            .map(|p| p.original.sender_last_tsn)
+    }
+
+    /// Requests ready for application, in acceptance/RSN order. The caller must
+    /// apply and complete each request before applying the next returned RSN.
+    /// A valid sender's Last Assigned TSN cannot move backwards across requests;
+    /// retaining this prefix order also avoids reordering overlapping resets if
+    /// an inconsistent peer supplies a later, smaller boundary.
+    pub(super) fn ready(&self, peer_last_tsn: u32) -> Vec<u32> {
+        self.pending
+            .iter()
+            .take_while(|p| sna32lte(p.original.sender_last_tsn, peer_last_tsn))
+            .map(|p| p.original.reconfig_request_sequence_number)
+            .collect()
+    }
+
+    /// Test membership in the same ready prefix without allocating its RSN list.
+    pub(super) fn is_ready(&self, sequence: u32, peer_last_tsn: u32) -> bool {
+        self.pending
+            .iter()
+            .take_while(|p| sna32lte(p.original.sender_last_tsn, peer_last_tsn))
+            .any(|p| p.original.reconfig_request_sequence_number == sequence)
+    }
+
+    /// Remove only this completed procedure. Its result history is bounded,
+    /// while other accepted requests retain their original selection and TSN.
+    /// InProgress is a continuation and must not remove the accepted procedure.
+    pub(super) fn complete(
+        &mut self,
+        sequence: u32,
+        result: ReconfigResult,
+    ) -> Option<ResetStreams> {
+        if result == ReconfigResult::InProgress {
+            return None;
+        }
+        let index = self
+            .pending
+            .iter()
+            .position(|p| p.original.reconfig_request_sequence_number == sequence)?;
+        let IncomingReset {
+            original,
+            streams,
+            reserved_stream_ids,
+            ..
+        } = self.pending.remove(index)?;
+        self.reserved_stream_ids -= reserved_stream_ids;
+        // The wire request lives only in replay history after completion. The
+        // caller applies the separately resolved selection, including all-SID
+        // expansion, so retaining a second wire SID allocation is unnecessary.
+        self.remember(original, result);
+        Some(streams)
+    }
+
+    fn remember(&mut self, original: ParamOutgoingResetRequest, result: ReconfigResult) {
+        let sequence = original.reconfig_request_sequence_number;
+        let index = self
+            .completed
+            .iter()
+            .position(|p| sna32gt(p.original.reconfig_request_sequence_number, sequence))
+            .unwrap_or(self.completed.len());
+        self.completed
+            .insert(index, CompletedReset { original, result });
+        if self.completed.len() > REPLAY_RESULTS {
+            self.completed.pop_front();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_stream_selection_preserves_sorted_set_semantics() {
+        for input in [vec![], vec![7], vec![7, 7], vec![9, 1, 7, 1, 3]] {
+            let mut selection: ResetStreams = input.iter().copied().collect();
+            let mut expected: BTreeSet<_> = input.into_iter().collect();
+            for sid in [7, 0, 12, 3, 0, 7] {
+                assert_eq!(selection.insert(sid), expected.insert(sid));
+                assert_eq!(selection.len(), expected.len());
+                assert_eq!(
+                    selection.iter().copied().collect::<Vec<_>>(),
+                    expected.iter().copied().collect::<Vec<_>>()
+                );
+                for probe in [0, 1, 7, 12, 13] {
+                    assert_eq!(selection.contains(&probe), expected.contains(&probe));
+                }
+            }
+        }
+        let single: ResetStreams = [7].into_iter().collect();
+        assert!(single.remaining.is_empty());
+        let mut copied = single.clone();
+        copied.insert(1);
+        assert_eq!(single.iter().copied().collect::<Vec<_>>(), [7]);
+        assert_eq!(copied.iter().copied().collect::<Vec<_>>(), [1, 7]);
+    }
+
+    fn request(sequence: u32, boundary: u32, streams: &[u16]) -> ParamOutgoingResetRequest {
+        ParamOutgoingResetRequest {
+            reconfig_request_sequence_number: sequence,
+            reconfig_response_sequence_number: 90,
+            sender_last_tsn: boundary,
+            stream_identifiers: streams.to_vec(),
+        }
+    }
+
+    #[test]
+    fn sequence_and_tsn_boundaries_wrap() {
+        let mut resets = IncomingResetQueue::new(u32::MAX);
+        assert_eq!(resets.last_received_rsn(), u32::MAX - 1);
+        assert_eq!(
+            resets.accept(&request(u32::MAX, u32::MAX, &[1]), [], 4),
+            ReceiveResetAction::New
+        );
+        assert_eq!(
+            resets.accept(&request(0, 0, &[2]), [], 4),
+            ReceiveResetAction::New
+        );
+        assert_eq!(resets.ready(u32::MAX - 1), []);
+        assert_eq!(resets.ready(u32::MAX), [u32::MAX]);
+        assert_eq!(resets.ready(0), [u32::MAX, 0]);
+        assert_eq!(resets.next_expected_rsn(), 1);
+        assert_eq!(resets.last_received_rsn(), 0);
+    }
+
+    #[test]
+    fn individual_readiness_preserves_the_accepted_prefix_barrier() {
+        let mut resets = IncomingResetQueue::new(u32::MAX);
+        resets.accept(&request(u32::MAX, 100, &[1]), [], 4);
+        // Even an inconsistent later request with an earlier TSN must not pass
+        // the still deferred prefix, including when the RSN wraps through zero.
+        resets.accept(&request(0, 90, &[2]), [], 4);
+        for boundary in [89, 90, 99, 100] {
+            let ready = resets.ready(boundary);
+            for sequence in [u32::MAX, 0, 1] {
+                assert_eq!(
+                    resets.is_ready(sequence, boundary),
+                    ready.contains(&sequence)
+                );
+            }
+        }
+        assert!(!resets.is_ready(0, 90));
+        resets.complete(u32::MAX, ReconfigResult::SuccessPerformed);
+        assert!(resets.is_ready(0, 100));
+        assert!(!resets.is_ready(u32::MAX, 100));
+    }
+
+    #[test]
+    fn completion_moves_the_wire_selection_into_replay_history() {
+        for wire_sids in [vec![2, 1, 2], vec![]] {
+            let mut resets = IncomingResetQueue::new(10);
+            let original = request(10, 100, &wire_sids);
+            resets.accept(&original, [1, 2], 4);
+            let saved_wire = resets.get(10).unwrap().original();
+            let allocation = saved_wire.stream_identifiers.as_ptr();
+            let completed = resets
+                .complete(10, ReconfigResult::SuccessPerformed)
+                .unwrap();
+            assert_eq!(completed.iter().copied().collect::<Vec<_>>(), [1, 2]);
+            let history = &resets.completed.back().unwrap().original;
+            assert_eq!(history, &original);
+            assert_eq!(history.stream_identifiers.as_ptr(), allocation);
+            assert_eq!(
+                resets.accept(&original, [], 4),
+                ReceiveResetAction::Reply(ReconfigResult::SuccessPerformed)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_skipped_rsn_without_consuming_it() {
+        let mut resets = IncomingResetQueue::new(10);
+        assert_eq!(
+            resets.accept(&request(11, 9, &[1]), [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+        assert_eq!(resets.next_expected_rsn(), 10);
+        assert_eq!(
+            resets.accept(&request(10, 9, &[1]), [], 4),
+            ReceiveResetAction::New
+        );
+    }
+
+    #[test]
+    fn all_streams_selection_is_separate_from_immutable_wire_request() {
+        let mut resets = IncomingResetQueue::new(10);
+        let original = request(10, 100, &[]);
+        assert_eq!(
+            resets.accept(&original, [1, 2, 2, 9], 8),
+            ReceiveResetAction::New
+        );
+        assert_eq!(
+            &resets
+                .get(10)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([1, 2])
+        );
+        assert_eq!(resets.boundary(7), Some(100));
+        assert_eq!(resets.boundary(8), None);
+        resets.observe_stream(3);
+        resets.observe_stream(8);
+        assert_eq!(
+            &resets
+                .get(10)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([1, 2, 3])
+        );
+        assert_eq!(resets.get(10).unwrap().original(), &original);
+        // A retry does not replace the resolved list with a new snapshot.
+        assert_eq!(
+            resets.accept(&original, [4], 8),
+            ReceiveResetAction::Pending
+        );
+        assert_eq!(
+            &resets
+                .get(10)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn explicit_selection_validates_negotiated_max_and_deduplicates() {
+        let mut resets = IncomingResetQueue::new(10);
+        assert_eq!(
+            resets.accept(&request(10, 9, &[u16::MAX - 1]), [], u16::MAX),
+            ReceiveResetAction::New
+        );
+        let invalid = request(11, 9, &[u16::MAX]);
+        assert_eq!(
+            resets.accept(&invalid, [], u16::MAX),
+            ReceiveResetAction::Reply(ReconfigResult::Denied)
+        );
+        assert_eq!(
+            resets.accept(&invalid, [], u16::MAX),
+            ReceiveResetAction::Reply(ReconfigResult::Denied)
+        );
+        assert_eq!(resets.next_expected_rsn(), 12);
+        assert_eq!(
+            resets.accept(&request(12, 9, &[1, 1, 2]), [], 4),
+            ReceiveResetAction::New
+        );
+        assert_eq!(
+            &resets
+                .get(12)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([1, 2])
+        );
+    }
+
+    #[test]
+    fn duplicate_with_changed_payload_never_reexecutes() {
+        let mut resets = IncomingResetQueue::new(10);
+        let original = request(10, 100, &[1, 2]);
+        assert_eq!(resets.accept(&original, [], 4), ReceiveResetAction::New);
+        let mut changed = original.clone();
+        changed.sender_last_tsn += 1;
+        assert_eq!(
+            resets.accept(&changed, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+        assert_eq!(resets.get(10).unwrap().original(), &original);
+        resets
+            .complete(10, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        changed = original.clone();
+        changed.stream_identifiers = vec![3];
+        assert_eq!(
+            resets.accept(&changed, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+        changed = original.clone();
+        changed.reconfig_response_sequence_number += 1;
+        assert_eq!(
+            resets.accept(&changed, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+        assert_eq!(
+            resets.accept(&original, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::SuccessPerformed)
+        );
+        assert!(resets.is_empty());
+    }
+
+    #[test]
+    fn history_eviction_never_cancels_an_accepted_multistream_request() {
+        let mut resets = IncomingResetQueue::new(10);
+        let original = request(10, 100, &[1, 2]);
+        assert_eq!(resets.accept(&original, [], 4), ReceiveResetAction::New);
+        for sequence in 11..=13 {
+            assert_eq!(
+                resets.accept(&request(sequence, 100, &[1]), [], 4),
+                ReceiveResetAction::New
+            );
+            resets
+                .complete(sequence, ReconfigResult::SuccessPerformed)
+                .unwrap();
+        }
+        // Inventory-level check: completion callbacks for newer operations may
+        // evict history but must not mutate any still accepted operation.
+        assert_eq!(resets.accept(&original, [], 4), ReceiveResetAction::Pending);
+        assert_eq!(resets.get(10).unwrap().original(), &original);
+        assert_eq!(
+            &resets
+                .get(10)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([1, 2])
+        );
+        assert_eq!(resets.ready(100), [10]);
+        resets
+            .complete(10, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        // An old completion must not displace the last two RSNs' results.
+        assert_eq!(
+            resets.accept(&request(12, 100, &[1]), [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::SuccessPerformed)
+        );
+        assert_eq!(
+            resets.accept(&request(13, 100, &[1]), [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::SuccessPerformed)
+        );
+        assert_eq!(
+            resets.accept(&original, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+    }
+
+    #[test]
+    fn history_keeps_last_two_results_across_rsn_wrap() {
+        let mut resets = IncomingResetQueue::new(u32::MAX - 1);
+        for sequence in [u32::MAX - 1, u32::MAX, 0] {
+            let request = request(sequence, 9, &[1]);
+            assert_eq!(resets.accept(&request, [], 4), ReceiveResetAction::New);
+            resets
+                .complete(sequence, ReconfigResult::SuccessPerformed)
+                .unwrap();
+        }
+        assert_eq!(
+            resets.accept(&request(u32::MAX - 1, 9, &[1]), [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::ErrorBadSequenceNumber)
+        );
+        for sequence in [u32::MAX, 0] {
+            assert_eq!(
+                resets.accept(&request(sequence, 9, &[1]), [], 4),
+                ReceiveResetAction::Reply(ReconfigResult::SuccessPerformed)
+            );
+        }
+    }
+
+    #[test]
+    fn in_progress_and_boundary_lookup_retain_the_procedure() {
+        let mut resets = IncomingResetQueue::new(10);
+        resets.accept(&request(10, 100, &[1]), [], 4);
+        resets.accept(&request(11, 110, &[1, 2]), [], 4);
+        assert_eq!(resets.boundary(1), Some(100));
+        assert_eq!(resets.boundary(2), Some(110));
+        assert_eq!(resets.boundary(3), None);
+        assert!(resets.complete(10, ReconfigResult::InProgress).is_none());
+        assert_eq!(resets.ready(105), [10]);
+        resets
+            .complete(10, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        assert_eq!(resets.boundary(1), Some(110));
+        assert_eq!(resets.ready(105), []);
+        assert_eq!(resets.ready(110), [11]);
+    }
+
+    #[test]
+    fn admission_count_limit_is_definitive_and_replayable() {
+        let mut resets = IncomingResetQueue::new(0);
+        for sequence in 0..MAX_PENDING_REQUESTS as u32 {
+            assert_eq!(
+                resets.accept(&request(sequence, 100, &[1]), [], 4),
+                ReceiveResetAction::New
+            );
+        }
+        let denied = request(MAX_PENDING_REQUESTS as u32, 100, &[1]);
+        assert_eq!(
+            resets.accept(&denied, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::Denied)
+        );
+        resets
+            .complete(0, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        assert_eq!(
+            resets.accept(&denied, [], 4),
+            ReceiveResetAction::Reply(ReconfigResult::Denied)
+        );
+        assert_eq!(
+            resets.accept(&request(MAX_PENDING_REQUESTS as u32 + 1, 100, &[1]), [], 4),
+            ReceiveResetAction::New
+        );
+    }
+
+    #[test]
+    fn all_stream_reservation_bounds_future_stream_discovery() {
+        let mut resets = IncomingResetQueue::new(0);
+        assert_eq!(
+            resets.accept(&request(0, 100, &[]), [], u16::MAX),
+            ReceiveResetAction::New
+        );
+        assert_eq!(resets.reserved_stream_ids, usize::from(u16::MAX));
+        assert_eq!(
+            resets.accept(&request(1, 100, &[]), [], u16::MAX),
+            ReceiveResetAction::Reply(ReconfigResult::Denied)
+        );
+        resets.observe_stream(u16::MAX - 1);
+        assert_eq!(
+            &resets
+                .get(0)
+                .unwrap()
+                .streams()
+                .copied()
+                .collect::<BTreeSet<_>>(),
+            &BTreeSet::from([u16::MAX - 1])
+        );
+        resets
+            .complete(0, ReconfigResult::SuccessPerformed)
+            .unwrap();
+        assert_eq!(resets.reserved_stream_ids, 0);
+        assert_eq!(
+            resets.accept(&request(2, 100, &[]), [], u16::MAX),
+            ReceiveResetAction::New
+        );
+    }
+}

--- a/rtc-sctp/src/association/sack_recovery_test.rs
+++ b/rtc-sctp/src/association/sack_recovery_test.rs
@@ -1,0 +1,274 @@
+use super::*;
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+
+fn recovery_sender(
+    first_tsn: u32,
+    count: usize,
+) -> Result<(Association, Instant, Vec<ChunkPayloadData>)> {
+    let now = Instant::now();
+    let mut a = timed_test_association();
+    a.my_next_tsn = first_tsn;
+    a.cumulative_tsn_ack_point = first_tsn.wrapping_sub(1);
+    a.advanced_peer_tsn_ack_point = first_tsn.wrapping_sub(1);
+    a.cwnd = 65536;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    for index in 0..count {
+        stream.write_sctp(now, &Bytes::from(vec![index as u8; 8]), ppi)?;
+    }
+    let sent = transmitted_data(&a.gather_outbound(now).0);
+    assert_eq!(sent.len(), count);
+    Ok((a, now, sent))
+}
+
+fn report(
+    a: &mut Association,
+    now: Instant,
+    cumulative_tsn_ack: u32,
+    gaps: &[(u16, u16)],
+) -> Result<Vec<ChunkPayloadData>> {
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack,
+            advertised_receiver_window_credit: 65536,
+            gap_ack_blocks: gaps
+                .iter()
+                .map(|&(start, end)| GapAckBlock { start, end })
+                .collect(),
+            ..Default::default()
+        },
+        now,
+    )?;
+    Ok(transmitted_data(&a.gather_outbound(now).0))
+}
+
+fn assert_retries(actual: &[ChunkPayloadData], original: &[ChunkPayloadData], indices: &[usize]) {
+    assert_eq!(
+        actual
+            .iter()
+            .map(|c| (c.tsn, c.user_data.clone()))
+            .collect::<Vec<_>>(),
+        indices
+            .iter()
+            .map(|&index| (original[index].tsn, original[index].user_data.clone()))
+            .collect::<Vec<_>>(),
+        "recovery must retransmit only the missing DATA, with its retained bytes"
+    );
+}
+
+fn finish(a: &mut Association, now: Instant, sent: &[ChunkPayloadData]) -> Result<()> {
+    assert!(report(a, now, sent.last().unwrap().tsn, &[])?.is_empty());
+    assert!(a.inflight_queue.is_empty());
+    assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+    assert!(a.poll_timeout().is_none());
+    Ok(())
+}
+
+#[test]
+fn repeated_gap_ack_does_not_count_as_new_missing_evidence() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 8)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        for _ in 0..4 {
+            assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        }
+        assert!(report(&mut a, now, cumulative, &[(2, 3)])?.is_empty());
+        let retried = report(&mut a, now, cumulative, &[(2, 4)])?;
+        // RFC 9260 7.2.4: the first TSN has three reports, while the untouched
+        // tail above HTNA has none. Repeated SACKs do not provide new evidence.
+        assert_retries(&retried, &sent, &[0]);
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn revoked_gap_above_htna_contributes_one_missing_report() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 4)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(3, 3)])?.is_empty());
+        // TSN 3 disappears while newly acknowledged TSN 2 determines HTNA.
+        // D(iii)'s revocation report still applies to TSN 3 above that bound.
+        assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        for _ in 0..4 {
+            assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        }
+        assert_retries(
+            &report(&mut a, now, cumulative, &[(2, 2), (4, 4)])?,
+            &sent,
+            &[0],
+        );
+        // A cumulative advance in Fast Recovery supplies TSN 3's third
+        // report. Without the earlier revocation report it would stall on T3.
+        assert_retries(
+            &report(&mut a, now, sent[0].tsn, &[(1, 1), (3, 3)])?,
+            &sent,
+            &[2],
+        );
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn revoked_gap_below_htna_is_not_counted_twice() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 5)?;
+        assert!(report(&mut a, now, first.wrapping_sub(1), &[(2, 2)])?.is_empty());
+        // The same SACK both revokes TSN 2 and puts it below HTNA=TSN 3.
+        assert!(report(&mut a, now, sent[0].tsn, &[(2, 2)])?.is_empty());
+        assert!(report(&mut a, now, sent[0].tsn, &[(2, 3)])?.is_empty());
+        assert_retries(&report(&mut a, now, sent[0].tsn, &[(2, 4)])?, &sent, &[1]);
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn fast_recovery_counts_revocation_and_cumulative_progress_separately() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 8)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        assert!(report(&mut a, now, cumulative, &[(2, 3)])?.is_empty());
+        assert_retries(&report(&mut a, now, cumulative, &[(2, 4)])?, &sent, &[0]);
+        assert!(a.in_fast_recovery);
+
+        // In Fast Recovery with no cumulative progress, this newly ACKed TSN
+        // 5 must not add a second report on top of the revocation of TSN 3.
+        for _ in 0..4 {
+            assert!(report(&mut a, now, cumulative, &[(2, 2), (4, 5)])?.is_empty());
+        }
+        // The remaining gap blocks are unchanged in absolute TSNs. HTNA is
+        // now only the cumulative ACK, but the Fast Recovery rule still adds
+        // reports to the missing TSN 3 on each cumulative advance.
+        assert!(report(&mut a, now, sent[0].tsn, &[(1, 1), (3, 4)])?.is_empty());
+        assert_retries(&report(&mut a, now, sent[1].tsn, &[(2, 3)])?, &sent, &[2]);
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn sack_exiting_fast_recovery_does_not_report_the_newer_flight_missing() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, mut sent) = recovery_sender(first, 4)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(2, 2)])?.is_empty());
+        assert!(report(&mut a, now, cumulative, &[(2, 3)])?.is_empty());
+        assert_retries(&report(&mut a, now, cumulative, &[(2, 4)])?, &sent, &[0]);
+
+        // DATA sent after entry is beyond this recovery window. The SACK
+        // leaving recovery provides no evidence of loss in that newer flight.
+        let ppi = PayloadProtocolIdentifier::Binary;
+        for index in 4..8 {
+            a.stream(1)?
+                .write_sctp(now, &Bytes::from(vec![index; 8]), ppi)?;
+        }
+        let newer = transmitted_data(&a.gather_outbound(now).0);
+        assert_eq!(newer.len(), 4);
+        sent.extend(newer);
+        let exit = sent[3].tsn;
+        for _ in 0..4 {
+            assert!(report(&mut a, now, exit, &[])?.is_empty());
+        }
+        assert!(!a.in_fast_recovery);
+        assert!(report(&mut a, now, exit, &[(2, 2)])?.is_empty());
+        assert!(report(&mut a, now, exit, &[(2, 3)])?.is_empty());
+        assert_retries(&report(&mut a, now, exit, &[(2, 4)])?, &sent, &[4]);
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn cumulative_progress_prunes_old_gap_prefix_without_revoking_retained_gaps() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 5)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(2, 5)])?.is_empty());
+        // Equivalent split blocks must preserve the same advisory ACKs.
+        assert!(report(&mut a, now, cumulative, &[(2, 3), (4, 5)])?.is_empty());
+        assert!(report(&mut a, now, sent[1].tsn, &[(1, 1), (2, 3)])?.is_empty());
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+        assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+
+        // Only TSN 5 is revoked. Earlier cumulative DATA must never return,
+        // while the remaining gap ACKs still exclude TSNs 3 and 4 from T3.
+        assert!(report(&mut a, now, sent[1].tsn, &[(1, 2)])?.is_empty());
+        assert_eq!(
+            a.inflight_queue.outstanding_bytes(),
+            sent[4].user_data.len()
+        );
+        let timeout = a.poll_timeout().expect("revoked DATA needs T3");
+        a.handle_timeout(timeout);
+        assert_retries(
+            &transmitted_data(&a.gather_outbound(timeout).0),
+            &sent,
+            &[4],
+        );
+        finish(&mut a, timeout, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn older_cumulative_sack_cannot_replace_current_gap_evidence() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        let (mut a, now, sent) = recovery_sender(first, 6)?;
+        let cumulative = first.wrapping_sub(1);
+        assert!(report(&mut a, now, cumulative, &[(3, 4)])?.is_empty());
+        assert!(report(&mut a, now, sent[0].tsn, &[(2, 3)])?.is_empty());
+        for _ in 0..4 {
+            assert!(report(&mut a, now, cumulative, &[])?.is_empty());
+        }
+        assert!(report(&mut a, now, sent[0].tsn, &[(2, 4)])?.is_empty());
+        assert_retries(&report(&mut a, now, sent[0].tsn, &[(2, 5)])?, &sent, &[1]);
+        finish(&mut a, now, &sent)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn abandoned_gap_acked_fragment_never_returns_to_outstanding() -> Result<()> {
+    for first in [12345, u32::MAX] {
+        let mut a = timed_test_association();
+        let now = Instant::now();
+        a.my_next_tsn = first;
+        a.cumulative_tsn_ack_point = first.wrapping_sub(1);
+        a.advanced_peer_tsn_ack_point = first.wrapping_sub(1);
+        a.cwnd = 65536;
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let mut stream = a.open_stream(1, ppi)?;
+        stream.set_reliability_params(true, ReliabilityType::Timed, 100)?;
+        stream.write_sctp(now, &Bytes::from(vec![42; 2000]), ppi)?;
+        let sent = transmitted_data(&a.gather_outbound(now).0);
+        assert_eq!(sent.len(), 2);
+        assert!(report(&mut a, now, first.wrapping_sub(1), &[(2, 2)])?.is_empty());
+
+        let timeout = a.poll_timeout().unwrap();
+        assert!(timeout >= now + Duration::from_millis(100));
+        a.handle_timeout(timeout);
+        assert!(transmitted_data(&a.gather_outbound(timeout).0).is_empty());
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+        assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+        // RFC 3758's whole-message abandonment includes the previously
+        // Gap-ACKed tail. A later missing gap cannot undo that decision.
+        for _ in 0..3 {
+            assert!(report(&mut a, timeout, first.wrapping_sub(1), &[])?.is_empty());
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+        }
+        finish(&mut a, timeout, &sent)?;
+        let mut released = 0;
+        while let Some(event) = a.poll() {
+            if let Event::Stream(StreamEvent::BufferedAmountReleased { n_bytes, .. }) = event {
+                released += n_bytes;
+            }
+        }
+        assert_eq!(released, 2000, "payload credit is released exactly once");
+    }
+    Ok(())
+}

--- a/rtc-sctp/src/association/send_retention_test.rs
+++ b/rtc-sctp/src/association/send_retention_test.rs
@@ -1,0 +1,571 @@
+//! Sender payload ownership must remain independent of advisory ACK and recovery state.
+
+use super::*;
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const WINDOW: u32 = 65536;
+const PAYLOAD_SIZE: usize = 64;
+
+struct TrackedPayload {
+    data: Vec<u8>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for TrackedPayload {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl Drop for TrackedPayload {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn sender(first_tsn: u32) -> Association {
+    let mut a = timed_test_association();
+    a.my_next_tsn = first_tsn;
+    a.cumulative_tsn_ack_point = first_tsn.wrapping_sub(1);
+    a.advanced_peer_tsn_ack_point = first_tsn.wrapping_sub(1);
+    a.cwnd = WINDOW;
+    a
+}
+
+fn write_reliable_hole(
+    a: &mut Association,
+    now: Instant,
+    payload: &'static [u8],
+) -> Result<ChunkPayloadData> {
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.open_stream(2, ppi)?
+        .write_sctp(now, &Bytes::from_static(payload), ppi)?;
+    // Assign its TSN before an unordered message can take queue priority.
+    let mut sent = transmitted_data(&a.gather_outbound(now).0);
+    assert_eq!(sent.len(), 1);
+    Ok(sent.remove(0))
+}
+
+fn write_tracked(
+    a: &mut Association,
+    now: Instant,
+    sid: u16,
+    ppi: PayloadProtocolIdentifier,
+    size: usize,
+) -> Result<Arc<AtomicUsize>> {
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let payload = Bytes::from_owner(TrackedPayload {
+        data: vec![0x5a; size],
+        dropped: Arc::clone(&dropped),
+    });
+    a.stream(sid)?.write_chunk_with_ppi(now, &payload, ppi)?;
+    Ok(dropped)
+}
+
+fn sack(cumulative_tsn_ack: u32, gaps: &[(u16, u16)]) -> ChunkSelectiveAck {
+    ChunkSelectiveAck {
+        cumulative_tsn_ack,
+        advertised_receiver_window_credit: WINDOW,
+        gap_ack_blocks: gaps
+            .iter()
+            .map(|&(start, end)| GapAckBlock { start, end })
+            .collect(),
+        ..Default::default()
+    }
+}
+
+fn releases(a: &mut Association, sid: u16) -> (usize, usize) {
+    let (mut bytes, mut low) = (0, 0);
+    while let Some(event) = a.poll() {
+        match event {
+            Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) if id == sid => {
+                bytes += n_bytes;
+            }
+            Event::Stream(StreamEvent::BufferedAmountLow { id }) if id == sid => low += 1,
+            _ => {}
+        }
+    }
+    (bytes, low)
+}
+
+#[test]
+fn gap_ack_frees_exhausted_rexmit_backing_without_abandoning() -> Result<()> {
+    for first in [12345, u32::MAX] {
+        for unordered in [false, true] {
+            let mut a = sender(first);
+            let now = Instant::now();
+            let ppi = PayloadProtocolIdentifier::Binary;
+            write_reliable_hole(&mut a, now, b"x")?;
+            a.open_stream(1, ppi)?
+                .set_reliability_params(unordered, ReliabilityType::Rexmit, 0)?;
+            let dropped = write_tracked(&mut a, now, 1, ppi, 1024)?;
+            // Decoding wire DATA creates separate backing, so it cannot keep the
+            // application's tracked allocation alive.
+            let sent = transmitted_data(&a.gather_outbound(now).0);
+            assert_eq!(sent.len(), 1);
+            let tsn = first.wrapping_add(1);
+            let c = a.inflight_queue.get(tsn).unwrap();
+            let identity = (
+                c.message_id,
+                c.stream_identifier,
+                c.stream_generation,
+                c.stream_sequence_number,
+                c.since,
+            );
+            assert_eq!(dropped.load(Ordering::SeqCst), 0);
+            let ack = sack(first.wrapping_sub(1), &[(2, 2)]);
+            a.handle_sack(&ack, now + Duration::from_millis(10))?;
+
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            let c = a.inflight_queue.get(tsn).unwrap();
+            assert!(c.user_data.is_empty());
+            assert!(c.acknowledged && c.buffer_released && c.delivery_credited);
+            assert!(!c.abandoned && !c.retransmit);
+            assert_eq!((c.nsent, c.miss_indicator), (1, 0));
+            assert_eq!(c.unordered, unordered);
+            assert!(c.beginning_fragment && c.ending_fragment);
+            assert_eq!(
+                (
+                    c.message_id,
+                    c.stream_identifier,
+                    c.stream_generation,
+                    c.stream_sequence_number,
+                    c.since,
+                ),
+                identity
+            );
+            assert_eq!(a.inflight_queue.get_num_bytes(), 1);
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+            assert_eq!(a.inflight_queue.buffered_bytes(), 1);
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+            assert_eq!(releases(&mut a, 1), (1024, 1));
+            assert_eq!(a.advanced_peer_tsn_ack_point, first.wrapping_sub(1));
+            assert!(!a.will_send_forward_tsn);
+
+            let deadline = a.poll_timeout();
+            let cwnd = a.cwnd;
+            for delay in [11, 12, 13] {
+                a.handle_sack(&ack, now + Duration::from_millis(delay))?;
+                assert_eq!(a.poll_timeout(), deadline);
+                assert_eq!(a.cwnd, cwnd);
+                assert_eq!(a.inflight_queue.get(first).unwrap().miss_indicator, 1);
+                assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+                assert_eq!(a.inflight_queue.get_num_bytes(), 1);
+                assert_eq!(releases(&mut a, 1), (0, 0));
+                assert!(!a.inflight_queue.get(tsn).unwrap().abandoned);
+            }
+            assert!(
+                transmitted_data(&a.gather_outbound(now + Duration::from_millis(14)).0).is_empty()
+            );
+            a.handle_sack(&sack(tsn, &[]), now + Duration::from_millis(20))?;
+            assert!(a.inflight_queue.is_empty());
+            assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+            assert_eq!(releases(&mut a, 1), (0, 0));
+            assert!(a.poll_timeout().is_none());
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn gap_ack_eviction_respects_captured_policy_and_pr_negotiation() -> Result<()> {
+    let binary = PayloadProtocolIdentifier::Binary;
+    for (policy, limit, ppi) in [
+        (ReliabilityType::Reliable, 0, binary),
+        (ReliabilityType::Rexmit, 0, binary),
+        (ReliabilityType::Rexmit, 1, binary),
+        (ReliabilityType::Timed, 10000, binary),
+        (ReliabilityType::Timed, 0, binary),
+        (ReliabilityType::Rexmit, 0, PayloadProtocolIdentifier::Dcep),
+    ] {
+        for negotiated in [false, true] {
+            let first = 12345;
+            let mut a = sender(first);
+            a.use_forward_tsn = negotiated;
+            let now = Instant::now();
+            write_reliable_hole(&mut a, now, b"x")?;
+            a.open_stream(1, ppi)?
+                .set_reliability_params(true, policy, limit)?;
+            let dropped = write_tracked(&mut a, now, 1, ppi, PAYLOAD_SIZE)?;
+            assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 1);
+            // A later stream setting must not alter already captured policy.
+            a.stream(1)?
+                .set_reliability_params(false, ReliabilityType::Reliable, 0)?;
+
+            let evict = negotiated
+                && ppi != PayloadProtocolIdentifier::Dcep
+                && limit == 0
+                && matches!(policy, ReliabilityType::Rexmit | ReliabilityType::Timed);
+            a.handle_sack(&sack(first - 1, &[(2, 2)]), now + Duration::from_millis(10))?;
+            let c = a.inflight_queue.get(first + 1).unwrap();
+            assert_eq!(
+                c.user_data.is_empty(),
+                evict,
+                "policy={policy:?}, limit={limit}, ppi={ppi:?}, negotiated={negotiated}"
+            );
+            assert_eq!(dropped.load(Ordering::SeqCst), usize::from(evict));
+            assert!(c.acknowledged && !c.abandoned);
+            assert_eq!(releases(&mut a, 1), (PAYLOAD_SIZE, 1));
+
+            // Direct cumulative removal after revocation exercises pop's debt
+            // accounting even when the queue no longer retains payload bytes.
+            a.handle_sack(&sack(first - 1, &[]), now + Duration::from_millis(11))?;
+            assert_eq!(a.inflight_queue.outstanding_bytes(), PAYLOAD_SIZE + 1);
+            assert_eq!(a.rwnd, WINDOW - PAYLOAD_SIZE as u32 - 1);
+            assert!(!a.inflight_queue.get(first + 1).unwrap().abandoned);
+            a.handle_sack(&sack(first + 1, &[]), now + Duration::from_millis(12))?;
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+            assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+            assert_eq!(a.inflight_queue.buffered_bytes(), 0);
+            assert_eq!(releases(&mut a, 1), (0, 0));
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn evicted_gap_ack_revoke_and_reack_restore_debt_without_repeating_credit() -> Result<()> {
+    for first in [12345, u32::MAX - 1] {
+        let mut a = sender(first);
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        write_reliable_hole(&mut a, now, b"x")?;
+        a.open_stream(1, ppi)?
+            .set_reliability_params(true, ReliabilityType::Rexmit, 0)?;
+        let dropped = write_tracked(&mut a, now, 1, ppi, PAYLOAD_SIZE)?;
+        assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 1);
+        a.stream(2)?
+            .write_sctp(now, &Bytes::from(vec![7; PAYLOAD_SIZE]), ppi)?;
+        assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 1);
+        let tsn = first.wrapping_add(1);
+        let ack = sack(first.wrapping_sub(1), &[(2, 2)]);
+        a.handle_sack(&ack, now + Duration::from_millis(10))?;
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        assert_eq!(releases(&mut a, 1), (PAYLOAD_SIZE, 1));
+        assert_eq!(a.inflight_queue.get_num_bytes(), PAYLOAD_SIZE + 1);
+
+        for delay in [11, 12] {
+            a.handle_sack(
+                &sack(first.wrapping_sub(1), &[]),
+                now + Duration::from_millis(delay),
+            )?;
+            let c = a.inflight_queue.get(tsn).unwrap();
+            assert!(c.user_data.is_empty() && !c.acknowledged && !c.abandoned);
+            assert!(c.buffer_released && c.delivery_credited);
+            assert_eq!(c.miss_indicator, 1, "duplicate revocation adds no report");
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 2 * PAYLOAD_SIZE + 1);
+            assert_eq!(a.rwnd, WINDOW - (2 * PAYLOAD_SIZE + 1) as u32);
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+            assert_eq!(releases(&mut a, 1), (0, 0));
+        }
+        a.handle_sack(&ack, now + Duration::from_millis(13))?;
+        assert_eq!(a.inflight_queue.outstanding_bytes(), PAYLOAD_SIZE + 1);
+        assert_eq!(a.rwnd, WINDOW - (PAYLOAD_SIZE + 1) as u32);
+        assert_eq!(releases(&mut a, 1), (0, 0));
+        a.handle_sack(
+            &sack(first.wrapping_sub(1), &[]),
+            now + Duration::from_millis(14),
+        )?;
+
+        // Pending work makes slow-start credit visible. This SACK newly
+        // acknowledges only the one-byte hole; re-ACKing the evicted DATA must
+        // not add its 64 bytes a second time.
+        a.stream(2)?
+            .write_sctp(now, &Bytes::from_static(b"pending"), ppi)?;
+        a.cwnd = 4096;
+        a.ssthresh = WINDOW;
+        a.handle_sack(&sack(first, &[(1, 1)]), now + Duration::from_millis(15))?;
+        assert_eq!(a.cwnd, 4097);
+        assert_eq!(a.inflight_queue.outstanding_bytes(), PAYLOAD_SIZE);
+        assert_eq!(a.inflight_queue.get_num_bytes(), PAYLOAD_SIZE);
+        assert_eq!(releases(&mut a, 1), (0, 0));
+        a.handle_sack(
+            &sack(first.wrapping_add(2), &[]),
+            now + Duration::from_millis(16),
+        )?;
+        assert!(a.inflight_queue.is_empty());
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+        assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+        let last = transmitted_data(&a.gather_outbound(now + Duration::from_millis(16)).0);
+        assert_eq!(last.len(), 1);
+        assert_eq!(last[0].user_data.as_ref(), b"pending");
+        a.handle_sack(&sack(last[0].tsn, &[]), now + Duration::from_millis(17))?;
+        assert_eq!(a.stream(2)?.buffered_amount()?, 0);
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        assert!(a.poll_timeout().is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn retained_payload_retries_unchanged_and_exhausted_rexmit_one_can_then_evict() -> Result<()> {
+    let binary = PayloadProtocolIdentifier::Binary;
+    for (policy, limit, ppi, negotiated) in [
+        (ReliabilityType::Reliable, 0, binary, true),
+        (ReliabilityType::Rexmit, 1, binary, true),
+        (ReliabilityType::Rexmit, 0, binary, false),
+        (ReliabilityType::Timed, 10000, binary, true),
+        (
+            ReliabilityType::Rexmit,
+            0,
+            PayloadProtocolIdentifier::Dcep,
+            true,
+        ),
+    ] {
+        let first = 12345;
+        let mut a = sender(first);
+        a.use_forward_tsn = negotiated;
+        let now = Instant::now();
+        let mut sent = vec![write_reliable_hole(&mut a, now, b"x")?];
+        a.open_stream(1, ppi)?
+            .set_reliability_params(true, policy, limit)?;
+        let dropped = write_tracked(&mut a, now, 1, ppi, PAYLOAD_SIZE)?;
+        sent.extend(transmitted_data(&a.gather_outbound(now).0));
+        assert_eq!(sent.len(), 2);
+        let ack = sack(first - 1, &[(2, 2)]);
+        a.handle_sack(&ack, now + Duration::from_millis(10))?;
+        assert_eq!(dropped.load(Ordering::SeqCst), 0);
+        assert_eq!(releases(&mut a, 1), (PAYLOAD_SIZE, 1));
+        a.handle_sack(&sack(first - 1, &[]), now + Duration::from_millis(11))?;
+        let timeout = a.poll_timeout().unwrap();
+        a.handle_timeout(timeout);
+        let retry = transmitted_data(&a.gather_outbound(timeout).0);
+        assert_eq!(retry.len(), 2);
+        assert_eq!(
+            retry
+                .iter()
+                .map(|c| (c.tsn, c.user_data.clone()))
+                .collect::<Vec<_>>(),
+            sent.iter()
+                .map(|c| (c.tsn, c.user_data.clone()))
+                .collect::<Vec<_>>(),
+            "reneging must preserve the exact wire payload of allowed retries"
+        );
+        assert_eq!(a.inflight_queue.get(first + 1).unwrap().nsent, 2);
+        assert_eq!(dropped.load(Ordering::SeqCst), 0);
+
+        let mut at = timeout + Duration::from_millis(10);
+        a.handle_sack(&ack, at)?;
+        let exhausted = policy == ReliabilityType::Rexmit && limit == 1;
+        assert_eq!(dropped.load(Ordering::SeqCst), usize::from(exhausted));
+        assert_eq!(releases(&mut a, 1), (0, 0));
+        if exhausted {
+            a.handle_sack(&sack(first - 1, &[]), at + Duration::from_millis(1))?;
+            assert_eq!(a.inflight_queue.outstanding_bytes(), PAYLOAD_SIZE + 1);
+            assert!(!a.inflight_queue.get(first + 1).unwrap().abandoned);
+            at = a.poll_timeout().unwrap();
+            a.handle_timeout(at);
+            let later = transmitted_data(&a.gather_outbound(at).0);
+            assert_eq!(later.len(), 1);
+            assert_eq!(later[0].tsn, first);
+            assert_eq!(later[0].user_data.as_ref(), b"x");
+            assert!(a.inflight_queue.get(first + 1).unwrap().abandoned);
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+            assert_eq!(releases(&mut a, 1), (0, 0));
+        }
+        a.handle_sack(&sack(first + 1, &[]), at + Duration::from_millis(20))?;
+        assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+        assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    }
+    Ok(())
+}
+
+#[test]
+fn evicted_rexmit_zero_waits_for_fast_or_t3_candidate_after_revocation() -> Result<()> {
+    for first in [12345, u32::MAX - 2] {
+        for fast in [false, true] {
+            let mut a = sender(first);
+            let now = Instant::now();
+            let ppi = PayloadProtocolIdentifier::Binary;
+            write_reliable_hole(&mut a, now, b"received")?;
+            a.open_stream(1, ppi)?
+                .set_reliability_params(true, ReliabilityType::Rexmit, 0)?;
+            let dropped = write_tracked(&mut a, now, 1, ppi, PAYLOAD_SIZE)?;
+            assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 1);
+            for _ in 0..3 {
+                a.stream(2)?
+                    .write_sctp(now, &Bytes::from_static(b"reliable"), ppi)?;
+            }
+            assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), 3);
+            let tsn = first.wrapping_add(1);
+            a.handle_sack(
+                &sack(first.wrapping_sub(1), &[(2, 2)]),
+                now + Duration::from_millis(10),
+            )?;
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert_eq!(releases(&mut a, 1), (PAYLOAD_SIZE, 1));
+            for delay in [11, 12, 13] {
+                a.handle_sack(&sack(first, &[]), now + Duration::from_millis(delay))?;
+                let c = a.inflight_queue.get(tsn).unwrap();
+                assert!(c.user_data.is_empty() && !c.acknowledged && !c.abandoned);
+                assert_eq!(c.miss_indicator, 1);
+                assert_eq!(a.inflight_queue.outstanding_bytes(), PAYLOAD_SIZE + 24);
+                assert_eq!(a.advanced_peer_tsn_ack_point, first);
+                assert!(!a.will_send_forward_tsn);
+                assert_eq!(releases(&mut a, 1), (0, 0));
+            }
+
+            let at = if fast {
+                a.handle_sack(&sack(first, &[(2, 2)]), now + Duration::from_millis(14))?;
+                assert_eq!(a.inflight_queue.get(tsn).unwrap().miss_indicator, 2);
+                assert!(!a.inflight_queue.get(tsn).unwrap().abandoned);
+                assert!(
+                    transmitted_data(&a.gather_outbound(now + Duration::from_millis(14)).0)
+                        .is_empty()
+                );
+                let at = now + Duration::from_millis(15);
+                let cwnd = a.cwnd;
+                a.handle_sack(&sack(first, &[(2, 3)]), at)?;
+                assert_eq!(a.inflight_queue.get(tsn).unwrap().miss_indicator, 3);
+                assert!(!a.inflight_queue.get(tsn).unwrap().abandoned);
+                assert!(a.in_fast_recovery && a.will_retransmit_fast);
+                assert_eq!(a.cwnd, (cwnd / 2).max(4 * a.mtu));
+                at
+            } else {
+                let at = a.poll_timeout().unwrap();
+                a.handle_timeout(at);
+                assert_eq!(a.cwnd, a.mtu);
+                at
+            };
+            let data = transmitted_data(&a.gather_outbound(at).0);
+            assert_eq!(data.len(), if fast { 0 } else { 3 });
+            assert!(data.iter().all(|c| c.user_data.as_ref() == b"reliable"));
+            let c = a.inflight_queue.get(tsn).unwrap();
+            assert!(c.abandoned && !c.acknowledged && c.user_data.is_empty());
+            assert!(!c.retransmit);
+            assert_eq!(
+                c.nsent, 1,
+                "the evicted fragment must never be serialized again"
+            );
+            assert_eq!(
+                a.inflight_queue.outstanding_bytes(),
+                if fast { 8 } else { 24 }
+            );
+            assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+            assert_eq!(releases(&mut a, 1), (0, 0));
+            a.handle_sack(
+                &sack(first.wrapping_add(4), &[]),
+                at + Duration::from_millis(10),
+            )?;
+            assert!(a.inflight_queue.is_empty());
+            assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+            assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+            assert_eq!(dropped.load(Ordering::SeqCst), 1);
+            assert!(a.poll_timeout().is_none());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn evicted_fragment_ack_preserves_pending_tail_until_whole_message_abandonment() -> Result<()> {
+    for unordered in [false, true] {
+        let first = u32::MAX - 2;
+        let mut a = sender(first);
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let fragment_size = a.max_payload_size as usize;
+        let size = 4 * fragment_size + 37;
+        a.cwnd = (2 * fragment_size + 1) as u32;
+        write_reliable_hole(&mut a, now, b"x")?;
+        a.open_stream(1, ppi)?
+            .set_reliability_params(unordered, ReliabilityType::Rexmit, 0)?;
+        let dropped = write_tracked(&mut a, now, 1, ppi, size)?;
+        let sent = transmitted_data(&a.gather_outbound(now).0);
+        assert_eq!(sent.len(), 2);
+        let one = first.wrapping_add(1);
+        let two = first.wrapping_add(2);
+        let next = a.my_next_tsn;
+        let id = a.inflight_queue.get(one).unwrap().message_id.unwrap();
+        let pending_bytes = size - 2 * fragment_size;
+        assert_eq!(a.pending_queue.get_num_bytes(), pending_bytes);
+        assert_eq!(dropped.load(Ordering::SeqCst), 0);
+
+        let mut ack = sack(first.wrapping_sub(1), &[(2, 2)]);
+        // Keep the remaining first transmissions pending while ACKs are handled.
+        ack.advertised_receiver_window_credit = 0;
+        a.handle_sack(&ack, now + Duration::from_millis(10))?;
+        assert!(a.inflight_queue.get(one).unwrap().user_data.is_empty());
+        assert_eq!(
+            a.inflight_queue.get(two).unwrap().user_data.len(),
+            fragment_size
+        );
+        assert_eq!(releases(&mut a, 1), (fragment_size, 0));
+        ack.gap_ack_blocks = vec![GapAckBlock { start: 2, end: 3 }];
+        a.handle_sack(&ack, now + Duration::from_millis(11))?;
+        assert_eq!(releases(&mut a, 1), (fragment_size, 0));
+        for tsn in [one, two] {
+            let c = a.inflight_queue.get(tsn).unwrap();
+            assert!(c.acknowledged && !c.abandoned && c.user_data.is_empty());
+            assert_eq!(c.message_id, Some(id));
+        }
+        assert_eq!(a.inflight_queue.get_num_bytes(), 1);
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+        assert_eq!(a.pending_queue.get_num_bytes(), pending_bytes);
+        assert_eq!(a.stream(1)?.buffered_amount()?, pending_bytes);
+        assert_eq!(
+            a.my_next_tsn, next,
+            "eviction must not reserve a terminal TSN"
+        );
+        assert_eq!(a.advanced_peer_tsn_ack_point, first.wrapping_sub(1));
+        assert_eq!(
+            dropped.load(Ordering::SeqCst),
+            0,
+            "the unsent tail still owns the backing"
+        );
+        assert!(transmitted_data(&a.gather_outbound(now + Duration::from_millis(12)).0).is_empty());
+
+        // Revoke one evicted fragment while its sibling remains Gap-ACKed.
+        // Only the next recovery event may abandon them and their unsent tail.
+        ack.gap_ack_blocks = vec![GapAckBlock { start: 3, end: 3 }];
+        a.handle_sack(&ack, now + Duration::from_millis(13))?;
+        assert_eq!(a.inflight_queue.outstanding_bytes(), fragment_size + 1);
+        assert_eq!(a.inflight_queue.get(one).unwrap().miss_indicator, 1);
+        assert!(!a.inflight_queue.get(one).unwrap().abandoned);
+        assert_eq!(a.pending_queue.get_num_bytes(), pending_bytes);
+        assert_eq!(releases(&mut a, 1), (0, 0));
+        let timeout = a.poll_timeout().unwrap();
+        a.handle_timeout(timeout);
+        let retry = transmitted_data(&a.gather_outbound(timeout).0);
+        assert_eq!(retry.len(), 1);
+        assert_eq!(retry[0].tsn, first);
+        assert_eq!(retry[0].user_data.as_ref(), b"x");
+        assert!(a.pending_queue.is_empty());
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        assert_eq!(a.stream(1)?.buffered_amount()?, 0);
+        assert_eq!(releases(&mut a, 1), (pending_bytes, 1));
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 1);
+        assert_eq!(a.inflight_queue.get_num_bytes(), 1);
+        let terminal = next;
+        for tsn in [one, two, terminal] {
+            let c = a.inflight_queue.get(tsn).unwrap();
+            assert_eq!(c.message_id, Some(id));
+            assert!(c.abandoned && c.buffer_released && c.user_data.is_empty());
+        }
+        assert!(a.inflight_queue.get(terminal).unwrap().ending_fragment);
+        assert_eq!(a.inflight_queue.get(terminal).unwrap().nsent, 0);
+
+        a.handle_sack(&sack(first, &[]), timeout + Duration::from_millis(10))?;
+        let forward = a.create_forward_tsn();
+        assert_eq!(forward.new_cumulative_tsn, terminal);
+        assert_eq!(forward.streams.len(), usize::from(!unordered));
+        if !unordered {
+            assert_eq!(forward.streams[0].identifier, 1);
+            assert_eq!(forward.streams[0].sequence, sent[0].stream_sequence_number);
+        }
+        a.handle_sack(&sack(terminal, &[]), timeout + Duration::from_millis(20))?;
+        assert!(a.inflight_queue.is_empty());
+        assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+        assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+        assert_eq!(releases(&mut a, 1), (0, 0));
+        assert_eq!(dropped.load(Ordering::SeqCst), 1);
+        assert!(a.poll_timeout().is_none());
+    }
+    Ok(())
+}

--- a/rtc-sctp/src/association/stream.rs
+++ b/rtc-sctp/src/association/stream.rs
@@ -1,7 +1,9 @@
 use crate::association::Association;
 use crate::association::state::AssociationState;
-use crate::chunk::chunk_payload_data::{ChunkPayloadData, PayloadProtocolIdentifier};
-use crate::queue::reassembly_queue::{Chunks, ReassemblyQueue};
+use crate::chunk::chunk_payload_data::{
+    ChunkPayloadData, MessageReliability, PayloadProtocolIdentifier,
+};
+use crate::queue::reassembly_queue::Chunks;
 use crate::{ErrorCauseCode, Event, Side};
 use shared::error::{Error, Result};
 
@@ -9,7 +11,7 @@ use crate::util::{ByteSlice, BytesArray, BytesChunk, BytesSource};
 use bytes::Bytes;
 use log::{debug, error, trace};
 use std::fmt;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Identifier for a stream within a particular association
 pub type StreamId = u16;
@@ -128,10 +130,15 @@ impl Stream<'_> {
         if let Some(s) = self.association.streams.get_mut(&self.stream_identifier)
             && (s.state == RecvSendState::ReadWritable || s.state == RecvSendState::Readable)
         {
-            let chunks = s.reassembly_queue.read();
-            if !s.reassembly_queue.is_readable() {
+            let (chunks, finished) =
                 self.association
-                    .retry_deferred_resets(self.stream_identifier);
+                    .with_receive_queue(self.stream_identifier, |received| {
+                        let chunks = received.read();
+                        (chunks, !received.is_readable())
+                    });
+            if finished {
+                self.association
+                    .finish_stream_delivery(self.stream_identifier);
             }
             Ok(chunks)
         } else {
@@ -283,20 +290,32 @@ impl Stream<'_> {
     /// `now` is the instant the caller is acting at: resetting the stream queues an outgoing
     /// chunk, so it is on the same write path as [`write_sctp`](Self::write_sctp).
     pub fn stop(&mut self, now: Instant) -> Result<()> {
-        let mut reset = false;
-        if let Some(s) = self.association.streams.get_mut(&self.stream_identifier) {
-            if s.state == RecvSendState::Readable || s.state == RecvSendState::ReadWritable {
-                reset = true;
-            }
-            s.state = ((s.state as u8) & 0x2).into();
-        }
-
+        let Some(s) = self.association.streams.get(&self.stream_identifier) else {
+            // Reading the last saved message may already have retired this
+            // receiver. Its handle must not stop the next delivery on this SID.
+            return Ok(());
+        };
+        let reset = matches!(
+            s.state,
+            RecvSendState::Readable | RecvSendState::ReadWritable
+        ) && !s.incoming_reset;
         if reset {
-            // Reset the outgoing stream
-            // https://tools.ietf.org/html/rfc6525
+            // Check negotiated support before changing either API half or
+            // discarding unread messages (RFC 6525 5.1.1).
             self.association
                 .send_reset_request(now, self.stream_identifier)?;
         }
+        let s = self
+            .association
+            .streams
+            .get_mut(&self.stream_identifier)
+            .unwrap();
+        s.state = ((s.state as u8) & 0x2).into();
+
+        self.association
+            .with_receive_queue(self.stream_identifier, |received| received.stop());
+        self.association
+            .finish_stream_delivery(self.stream_identifier);
 
         Ok(())
     }
@@ -317,8 +336,8 @@ impl Stream<'_> {
     ///
     /// Resets the stream when both halves of this stream are shutdown.
     pub fn close(&mut self, now: Instant) -> Result<()> {
-        self.finish()?;
-        self.stop(now)
+        self.stop(now)?;
+        self.finish()
     }
 
     /// stream_identifier returns the Stream identifier associated to the stream.
@@ -448,9 +467,9 @@ pub struct StreamState {
     pub(crate) side: Side,
     pub(crate) max_payload_size: u32,
     pub(crate) stream_identifier: StreamId,
+    pub(crate) generation: u64,
+    pub(crate) incoming_reset: bool,
     pub(crate) default_payload_type: PayloadProtocolIdentifier,
-    pub(crate) reassembly_queue: ReassemblyQueue,
-    pub(crate) sequence_number: u16,
     pub(crate) state: RecvSendState,
     pub(crate) unordered: bool,
     pub(crate) reliability_type: ReliabilityType,
@@ -469,10 +488,10 @@ impl StreamState {
         StreamState {
             side,
             stream_identifier,
+            generation: 0,
+            incoming_reset: false,
             max_payload_size,
             default_payload_type,
-            reassembly_queue: ReassemblyQueue::new(stream_identifier),
-            sequence_number: 0,
             state: RecvSendState::ReadWritable,
             unordered: false,
             reliability_type: ReliabilityType::Reliable,
@@ -481,31 +500,6 @@ impl StreamState {
             buffered_amount_low: 0,
             buffered_amount_high: u32::MAX as usize,
         }
-    }
-
-    pub(crate) fn handle_data(&mut self, pd: &ChunkPayloadData) -> bool {
-        self.reassembly_queue.push(pd.clone())
-    }
-
-    pub(crate) fn handle_forward_tsn_for_ordered(&mut self, ssn: u16) {
-        if self.unordered {
-            return; // unordered chunks are handled by handleForwardUnordered method
-        }
-
-        // Remove all chunks older than or equal to the new TSN from
-        // the reassembly_queue.
-        self.reassembly_queue.forward_tsn_for_ordered(ssn);
-    }
-
-    pub(crate) fn handle_forward_tsn_for_unordered(&mut self, new_cumulative_tsn: u32) {
-        if !self.unordered {
-            return; // ordered chunks are handled by handleForwardTSNOrdered method
-        }
-
-        // Remove all chunks older than or equal to the new TSN from
-        // the reassembly_queue.
-        self.reassembly_queue
-            .forward_tsn_for_unordered(new_cumulative_tsn);
     }
 
     fn packetize(
@@ -521,11 +515,32 @@ impl StreamState {
         //   All Data Channel Establishment Protocol messages MUST be sent using
         //   ordered delivery and reliable transmission.
         let unordered = ppi != PayloadProtocolIdentifier::Dcep && self.unordered;
+        let reliability = if ppi == PayloadProtocolIdentifier::Dcep {
+            MessageReliability::Reliable
+        } else {
+            match self.reliability_type {
+                ReliabilityType::Reliable => MessageReliability::Reliable,
+                ReliabilityType::Rexmit => MessageReliability::Rexmit {
+                    max_retransmits: self.reliability_value,
+                },
+                // Preserve the existing API: Timed(0) permits first sends and
+                // abandons the whole message when any fragment needs a retry.
+                ReliabilityType::Timed if self.reliability_value == 0 => {
+                    MessageReliability::Rexmit { max_retransmits: 0 }
+                }
+                ReliabilityType::Timed => MessageReliability::Timed {
+                    deadline: now + Duration::from_millis(self.reliability_value as u64),
+                },
+            }
+        };
 
         let mut chunks = vec![];
+        // The message length already determines its fragment count. Avoid
+        // reserving four DATA records for every single-fragment write.
+        if self.max_payload_size != 0 {
+            chunks.reserve_exact(remaining.div_ceil(self.max_payload_size as usize));
+        }
 
-        let head_abandoned = false;
-        let head_all_inflight = false;
         while remaining != 0 {
             let fragment_size = std::cmp::min(self.max_payload_size as usize, remaining); //self.association.max_payload_size
 
@@ -536,7 +551,8 @@ impl StreamState {
             let chunk = ChunkPayloadData {
                 // Timed reliability measures a message's age from here, so that
                 // a long wait for cwnd or rwnd counts against maxPacketLifeTime.
-                created_at: Some(now),
+                reliability,
+                stream_generation: self.generation,
                 stream_identifier: self.stream_identifier,
                 user_data,
                 unordered,
@@ -544,9 +560,6 @@ impl StreamState {
                 ending_fragment: remaining - fragment_size == 0,
                 immediate_sack: false,
                 payload_type: ppi,
-                stream_sequence_number: self.sequence_number,
-                abandoned: head_abandoned, // all fragmented chunks use the same abandoned
-                all_inflight: head_all_inflight, // all fragmented chunks use the same all_inflight
                 ..Default::default()
             };
 
@@ -554,14 +567,6 @@ impl StreamState {
 
             remaining -= fragment_size;
             i += fragment_size;
-        }
-
-        // RFC 4960 Sec 6.6
-        // Note: When transmitting ordered and unordered data, an endpoint does
-        // not increment its Stream Sequence Number when transmitting a DATA
-        // chunk with U flag set to 1.
-        if !unordered {
-            self.sequence_number = self.sequence_number.wrapping_add(1);
         }
 
         let old_amount = self.buffered_amount;
@@ -607,10 +612,5 @@ impl StreamState {
         );
 
         old_amount > self.buffered_amount_low && new_amount <= self.buffered_amount_low
-    }
-
-    pub(crate) fn get_num_bytes_in_reassembly_queue(&self) -> usize {
-        // No lock is required as it reads the size with atomic load function.
-        self.reassembly_queue.get_num_bytes()
     }
 }

--- a/rtc-sctp/src/association/timer.rs
+++ b/rtc-sctp/src/association/timer.rs
@@ -116,15 +116,14 @@ impl TimerTable {
         self.data[timer as usize] = Some(time);
     }
 
-    /// Restarts the timer if the current instant is none or elapsed.
-    pub fn restart_if_stale(&mut self, timer: Timer, now: Instant, interval: u64) {
-        if let Some(current) = self.data[timer as usize]
-            && current >= now
-        {
-            return;
+    /// Start an idle timer without hiding an unhandled expiration. A due
+    /// deadline stays armed until timeout processing consumes it, unless an
+    /// explicit protocol restart first clears it (for T3, acknowledgment of
+    /// the earliest outstanding TSN under RFC 9260 section 6.3.2 R3).
+    pub fn start_if_idle(&mut self, timer: Timer, now: Instant, interval: u64) {
+        if self.data[timer as usize].is_none() {
+            self.start(timer, now, interval);
         }
-
-        self.start(timer, now, interval);
     }
 
     pub fn stop(&mut self, timer: Timer) {

--- a/rtc-sctp/src/association/timer.rs
+++ b/rtc-sctp/src/association/timer.rs
@@ -68,6 +68,8 @@ pub(crate) struct TimerTable {
     data: [Option<Instant>; TIMER_COUNT],
     retrans: [usize; TIMER_COUNT],
     max_retrans: [usize; TIMER_COUNT],
+    reconfig_interval: Option<u64>,
+    reconfig_in_progress: bool,
 }
 
 impl TimerTable {
@@ -98,7 +100,13 @@ impl TimerTable {
     }
 
     pub fn start(&mut self, timer: Timer, now: Instant, interval: u64) {
-        let interval = if timer == Timer::Ack {
+        // T3 uses the destination's current RTO, which already includes backoff.
+        // Successful DATA acknowledgments reset its error counter independently.
+        let interval = if timer == Timer::Reconfig {
+            // RFC 6525 5.1.1: double this request's own interval, independently
+            // of changes to the DATA RTO caused by T3 or fresh RTT measurements.
+            *self.reconfig_interval.get_or_insert(interval)
+        } else if matches!(timer, Timer::Ack | Timer::T3RTX) {
             interval
         } else {
             calculate_next_timeout(interval, self.retrans[timer as usize])
@@ -121,13 +129,36 @@ impl TimerTable {
 
     pub fn stop(&mut self, timer: Timer) {
         self.data[timer as usize] = None;
+        self.reset_retrans(timer);
+        if timer == Timer::Reconfig {
+            self.reconfig_interval = None;
+            self.reconfig_in_progress = false;
+        }
+    }
+
+    pub fn restart_reconfig_in_progress(&mut self, now: Instant, interval: u64) {
+        self.reset_retrans(Timer::Reconfig);
+        self.reconfig_in_progress = true;
+        self.start(Timer::Reconfig, now, interval);
+    }
+
+    pub fn is_reconfig_in_progress(&self) -> bool {
+        self.reconfig_in_progress
+    }
+
+    pub fn reset_retrans(&mut self, timer: Timer) {
         self.retrans[timer as usize] = 0;
     }
 
     pub fn is_expired(&mut self, timer: Timer, after: Instant) -> (bool, bool, usize) {
         let expired = self.data[timer as usize].is_some_and(|x| x <= after);
         let mut failure = false;
-        if expired {
+        if expired && timer == Timer::Reconfig {
+            self.reconfig_interval = self
+                .reconfig_interval
+                .map(|interval| calculate_next_timeout(interval, 1));
+        }
+        if expired && !(timer == Timer::Reconfig && self.reconfig_in_progress) {
             self.retrans[timer as usize] += 1;
             if self.retrans[timer as usize] > self.max_retrans[timer as usize] {
                 failure = true;
@@ -194,6 +225,13 @@ impl RtoManager {
         self.rto
     }
 
+    /// RFC 9260 6.3.3 E2: retain backoff until a new RTT measurement updates RTO.
+    pub(crate) fn backoff(&mut self) {
+        if !self.no_update {
+            self.rto = self.rto.saturating_mul(2).min(RTO_MAX);
+        }
+    }
+
     /// reset resets the RTO variables to the initial values.
     pub(crate) fn reset(&mut self) {
         if self.no_update {
@@ -228,6 +266,20 @@ fn calculate_next_timeout(rto: u64, n_rtos: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rto_backoff_respects_pinned_rto() {
+        let mut rto = RtoManager::new();
+        rto.set_rto(1000, true);
+        rto.backoff();
+        assert_eq!(1000, rto.get_rto());
+        rto.set_rto(1000, false);
+        rto.backoff();
+        assert_eq!(2000, rto.get_rto());
+        rto.set_rto(RTO_MAX - 1, false);
+        rto.backoff();
+        assert_eq!(RTO_MAX, rto.get_rto());
+    }
 
     #[test]
     fn rto_manager_uses_rfc9260_initial_rto() {

--- a/rtc-sctp/src/association/timer_deadline_test.rs
+++ b/rtc-sctp/src/association/timer_deadline_test.rs
@@ -1,0 +1,202 @@
+//! Incoming work must not erase a T3 expiration that the caller has yet to service.
+
+use super::*;
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+
+const PAYLOAD: &[u8] = &[0x5a; 1024];
+
+fn sent_messages(
+    count: usize,
+    reliability: ReliabilityType,
+) -> Result<(Association, Instant, u32)> {
+    let mut a = timed_test_association();
+    a.cwnd = 16 * 1024;
+    let now = Instant::now();
+    let first = a.my_next_tsn;
+    let ppi = PayloadProtocolIdentifier::Binary;
+    let mut stream = a.open_stream(1, ppi)?;
+    stream.set_reliability_params(true, reliability, 0)?;
+    for _ in 0..count {
+        stream.write_sctp(now, &Bytes::from_static(PAYLOAD), ppi)?;
+    }
+    assert_eq!(transmitted_data(&a.gather_outbound(now).0).len(), count);
+    Ok((a, now, first))
+}
+
+#[test]
+fn due_t3_is_not_postponed_by_duplicate_gap_ack() -> Result<()> {
+    let (mut a, now, first) = sent_messages(2, ReliabilityType::Rexmit)?;
+    let sack = ChunkSelectiveAck {
+        cumulative_tsn_ack: first.wrapping_sub(1),
+        advertised_receiver_window_credit: 65536,
+        gap_ack_blocks: vec![GapAckBlock { start: 2, end: 2 }],
+        ..Default::default()
+    };
+    a.handle_sack(&sack, now + Duration::from_millis(10))?;
+    assert_eq!(a.inflight_queue.get(first).unwrap().miss_indicator, 1);
+    assert!(!a.inflight_queue.get(first).unwrap().abandoned());
+    let deadline = a.timers.get(Timer::T3RTX).unwrap();
+
+    // A socket input can be serviced before an already-ready timeout. This
+    // repeated gap ACK acknowledges neither new DATA nor the earliest TSN.
+    let due = deadline + Duration::from_millis(1);
+    a.handle_sack(&sack, due)?;
+    assert_eq!(
+        a.timers.get(Timer::T3RTX),
+        Some(deadline),
+        "a duplicate SACK must leave the pending expiration actionable"
+    );
+    assert_eq!(a.stats.get_num_t3timeouts(), 0);
+    a.handle_timeout(due);
+    assert_eq!(a.stats.get_num_t3timeouts(), 1);
+    assert!(a.inflight_queue.get(first).unwrap().abandoned());
+    assert_eq!(
+        a.timers.get(Timer::T3RTX),
+        Some(due + Duration::from_millis(a.rto_mgr.get_rto())),
+        "timeout processing still starts the next recovery timer"
+    );
+    assert!(transmitted_data(&a.gather_outbound(due).0).is_empty());
+    Ok(())
+}
+
+#[test]
+fn due_t3_is_not_postponed_by_poll_transmit_of_new_data() -> Result<()> {
+    let (mut a, _, first) = sent_messages(1, ReliabilityType::Rexmit)?;
+    let deadline = a.timers.get(Timer::T3RTX).unwrap();
+    let due = deadline + Duration::from_millis(1);
+    let ppi = PayloadProtocolIdentifier::Binary;
+    a.stream(1)?
+        .write_sctp(due, &Bytes::from_static(PAYLOAD), ppi)?;
+    let outbound = a.poll_transmit(due).expect("new DATA is ready");
+    let Payload::RawEncode(raw) = outbound.message else {
+        panic!("outbound SCTP is already encoded");
+    };
+    let sent = transmitted_data(&raw);
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].tsn, first.wrapping_add(1));
+    assert_eq!(sent[0].user_data.as_ref(), PAYLOAD);
+    assert_eq!(a.inflight_queue.get(first).unwrap().nsent, 1);
+    assert!(!a.inflight_queue.get(first).unwrap().abandoned());
+    assert_eq!(
+        a.timers.get(Timer::T3RTX),
+        Some(deadline),
+        "a new first transmission must not erase the older DATA's due timer"
+    );
+
+    a.handle_timeout(due);
+    assert_eq!(a.stats.get_num_t3timeouts(), 1);
+    assert!(a.inflight_queue.get(first).unwrap().abandoned());
+    assert_eq!(
+        a.timers.get(Timer::T3RTX),
+        Some(due + Duration::from_millis(a.rto_mgr.get_rto()))
+    );
+    assert!(transmitted_data(&a.gather_outbound(due).0).is_empty());
+    Ok(())
+}
+
+#[test]
+fn earliest_ack_after_due_restarts_t3_for_remaining_data() -> Result<()> {
+    let (mut a, _, first) = sent_messages(3, ReliabilityType::Reliable)?;
+    let old_deadline = a.timers.get(Timer::T3RTX).unwrap();
+    let ack_at = old_deadline + Duration::from_millis(1);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: first,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        ack_at,
+    )?;
+    // R3 deliberately restarts on genuine progress for the earliest TSN,
+    // including when this ACK is serviced before an already-due timeout.
+    let next_deadline = ack_at + Duration::from_millis(a.rto_mgr.get_rto());
+    assert_eq!(a.timers.get(Timer::T3RTX), Some(next_deadline));
+    assert_eq!(a.inflight_queue.len(), 2);
+    a.handle_timeout(ack_at);
+    assert_eq!(a.stats.get_num_t3timeouts(), 0);
+    assert_eq!(
+        a.inflight_queue.get(first.wrapping_add(1)).unwrap().nsent,
+        1
+    );
+
+    a.handle_timeout(next_deadline);
+    assert_eq!(a.stats.get_num_t3timeouts(), 1);
+    let retried = transmitted_data(&a.gather_outbound(next_deadline).0);
+    assert!(!retried.is_empty());
+    assert_eq!(retried[0].tsn, first.wrapping_add(1));
+    assert_eq!(retried[0].user_data.as_ref(), PAYLOAD);
+    assert_eq!(
+        a.inflight_queue.get(first.wrapping_add(1)).unwrap().nsent,
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn due_t3_survives_forward_only_sack_and_same_instant_is_idempotent() -> Result<()> {
+    let (mut a, _, first) = sent_messages(1, ReliabilityType::Rexmit)?;
+    a.rto_mgr.set_rto(1000, false);
+    let first_timeout = a.timers.get(Timer::T3RTX).unwrap();
+    a.handle_timeout(first_timeout);
+    assert_eq!(a.stats.get_num_t3timeouts(), 1);
+    assert_eq!(a.rto_mgr.get_rto(), 2000);
+    assert_eq!(a.inflight_queue.outstanding_bytes(), 0);
+    assert_eq!(a.inflight_queue.get_num_bytes(), 0);
+    assert_eq!(a.inflight_queue.len(), 1);
+    assert!(a.inflight_queue.get(first).unwrap().abandoned());
+
+    let has_forward = |packets: &[Bytes]| {
+        packets.iter().any(|raw| {
+            Packet::unmarshal(raw).unwrap().chunks.iter().any(|chunk| {
+                chunk
+                    .as_any()
+                    .downcast_ref::<ChunkForwardTsn>()
+                    .is_some_and(|forward| forward.new_cumulative_tsn == first)
+            })
+        })
+    };
+    let packets = a.gather_outbound(first_timeout).0;
+    assert!(transmitted_data(&packets).is_empty());
+    assert!(has_forward(&packets));
+    let forward_deadline = a.timers.get(Timer::T3RTX).expect("RFC 3758 C5 timer");
+
+    // No DATA remains to retry. A duplicate SACK that has not confirmed the
+    // FORWARD TSN must still leave its due recovery timer intact.
+    let due = forward_deadline + Duration::from_millis(1);
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: first.wrapping_sub(1),
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        due,
+    )?;
+    assert_eq!(a.timers.get(Timer::T3RTX), Some(forward_deadline));
+    a.handle_timeout(due);
+    assert_eq!(a.stats.get_num_t3timeouts(), 2);
+    assert_eq!(a.rto_mgr.get_rto(), 4000);
+    let rearmed = a.timers.get(Timer::T3RTX);
+    assert_eq!(rearmed, Some(due + Duration::from_millis(4000)));
+    let packets = a.gather_outbound(due).0;
+    assert!(transmitted_data(&packets).is_empty());
+    assert!(has_forward(&packets));
+
+    // A caller may spuriously service the same instant again. The consumed
+    // expiration must neither fire twice nor double RTO a second time.
+    a.handle_timeout(due);
+    assert_eq!(a.stats.get_num_t3timeouts(), 2);
+    assert_eq!(a.rto_mgr.get_rto(), 4000);
+    assert_eq!(a.timers.get(Timer::T3RTX), rearmed);
+
+    a.handle_sack(
+        &ChunkSelectiveAck {
+            cumulative_tsn_ack: first,
+            advertised_receiver_window_credit: 65536,
+            ..Default::default()
+        },
+        due + Duration::from_millis(1),
+    )?;
+    assert!(a.inflight_queue.is_empty());
+    assert!(a.timers.get(Timer::T3RTX).is_none());
+    Ok(())
+}

--- a/rtc-sctp/src/association/transmit.rs
+++ b/rtc-sctp/src/association/transmit.rs
@@ -1,0 +1,49 @@
+//! Wire sequence state belongs to a direction, not to a local Stream handle.
+
+use crate::chunk::chunk_payload_data::{ChunkPayloadData, MessageId};
+
+#[derive(Debug, Default)]
+pub(crate) struct TransmitStream {
+    pub(crate) next_ssn: u16,
+    active_message: Option<(MessageId, u16)>,
+}
+
+impl TransmitStream {
+    /// Called only when a fragment receives a TSN. Messages waiting for a send
+    /// window or reset result have not consumed an SSN yet.
+    pub(crate) fn assign_ssn(&mut self, chunk: &mut ChunkPayloadData) {
+        let id = chunk.message_id.expect("queued message identity");
+        let ssn = if chunk.beginning_fragment {
+            debug_assert!(self.active_message.is_none());
+            let ssn = self.next_ssn;
+            if !chunk.unordered {
+                self.next_ssn = self.next_ssn.wrapping_add(1);
+            }
+            self.active_message = Some((id, ssn));
+            ssn
+        } else {
+            let (active, ssn) = self.active_message.expect("fragmentation in progress");
+            debug_assert_eq!(active, id);
+            ssn
+        };
+        chunk.stream_sequence_number = ssn;
+        if chunk.ending_fragment {
+            self.active_message = None;
+        }
+    }
+
+    /// RFC 6525 H4. A reset boundary follows all previously queued fragments.
+    pub(crate) fn reset(&mut self) {
+        debug_assert!(self.active_message.is_none());
+        self.next_ssn = 0;
+    }
+
+    pub(crate) fn abandon_tail(&mut self, id: MessageId) -> u16 {
+        let (active, ssn) = self
+            .active_message
+            .take()
+            .expect("fragmentation in progress");
+        debug_assert_eq!(active, id);
+        ssn
+    }
+}

--- a/rtc-sctp/src/chunk/chunk_init.rs
+++ b/rtc-sctp/src/chunk/chunk_init.rs
@@ -1,5 +1,8 @@
 use super::{chunk_header::*, chunk_type::*, *};
-use crate::param::param_supported_extensions::ParamSupportedExtensions;
+use crate::param::{
+    param_forward_tsn_supported::ParamForwardTsnSupported,
+    param_supported_extensions::ParamSupportedExtensions,
+};
 use crate::param::{param_header::*, *};
 use crate::util::get_padding_size;
 
@@ -280,10 +283,9 @@ impl Chunk for ChunkInit {
 
 impl ChunkInit {
     pub(crate) fn set_supported_extensions(&mut self) {
-        // RFC5061 https://tools.ietf.org/html/rfc6525#section-5.2
-        // An implementation supporting this (Supported Extensions Parameter)
-        // extension MUST list the ASCONF, the ASCONF-ACK, and the AUTH chunks
-        // in its INIT and INIT-ACK parameters.
+        // RFC 3758 3.3 and RFC 6525 5.1.1 use separate advertisements.
+        // Keep FORWARD-TSN in the chunk list for existing peers as well.
+        self.params.push(Box::new(ParamForwardTsnSupported {}));
         self.params.push(Box::new(ParamSupportedExtensions {
             chunk_types: vec![CT_RECONFIG, CT_FORWARD_TSN],
         }));

--- a/rtc-sctp/src/chunk/chunk_payload_data.rs
+++ b/rtc-sctp/src/chunk/chunk_payload_data.rs
@@ -2,6 +2,7 @@ use super::{chunk_header::*, chunk_type::*, *};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::fmt;
+use std::num::NonZeroU64;
 use std::time::Instant;
 
 pub(crate) const PAYLOAD_DATA_ENDING_FRAGMENT_BITMASK: u8 = 1;
@@ -61,6 +62,41 @@ impl From<u32> for PayloadProtocolIdentifier {
     }
 }
 
+/// Association-local identity, unrelated to TSN, SSN, SID reuse or time.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct MessageId(NonZeroU64);
+
+impl MessageId {
+    /// Encode a zero-based association sequence with a niche for decoded DATA,
+    /// which has no local identity. Option<MessageId> stays one machine word.
+    pub(crate) fn new(sequence: u64) -> Self {
+        Self(NonZeroU64::new(sequence.checked_add(1).expect("message identity exhausted")).unwrap())
+    }
+}
+
+/// Sender policy captured once per message and copied to every fragment.
+/// It remains valid after stream reset, SID reuse, or later policy changes.
+#[derive(Debug, Default, Copy, Clone)]
+pub(crate) enum MessageReliability {
+    #[default]
+    Reliable,
+    Rexmit {
+        max_retransmits: u32,
+    },
+    Timed {
+        deadline: Instant,
+    },
+}
+
+impl MessageReliability {
+    pub(crate) fn deadline(self) -> Option<Instant> {
+        match self {
+            Self::Timed { deadline } => Some(deadline),
+            _ => None,
+        }
+    }
+}
+
 /// ChunkPayloadData represents an SCTP Chunk of type DATA
 //
 // 0                   1                   2                   3
@@ -108,29 +144,31 @@ pub struct ChunkPayloadData {
     pub(crate) payload_type: PayloadProtocolIdentifier,
     pub(crate) user_data: Bytes,
 
-    /// Whether this data chunk was acknowledged (received by peer)
-    pub(crate) acked: bool,
+    /// Acknowledged by a peer SACK, independently of local payload release.
+    pub(crate) acknowledged: bool,
+    /// Application send-buffer credit has been returned (ACK or abandonment).
+    pub(crate) buffer_released: bool,
+    /// Congestion control credits delivery once, even if a gap ACK is revoked.
+    pub(crate) delivery_credited: bool,
     pub(crate) miss_indicator: u32,
 
     /// Partial-reliability parameters used only by sender.
     ///
     /// Reassigned on every (re)transmission, so it is the RTT baseline. It is
-    /// deliberately *not* the timed-reliability baseline: a message may wait in
-    /// the pending queue for a long time before it is first transmitted, and
-    /// `maxPacketLifeTime` has to cover that wait. See `created_at`.
+    /// independent of the immutable deadline in `reliability`: time spent in
+    /// the pending queue still counts against `maxPacketLifeTime`.
     pub(crate) since: Option<Instant>,
-    /// When the message this chunk belongs to was handed to the association.
-    ///
-    /// Set once, from the instant the caller passed to `Stream::write*`, and
-    /// never reassigned. This is the baseline for `ReliabilityType::Timed`.
-    pub(crate) created_at: Option<Instant>,
+    /// Sender identity shared by every fragment; absent on decoded peer DATA.
+    pub(crate) message_id: Option<MessageId>,
+    /// Reliability belongs to the queued message, independently of its stream.
+    pub(crate) reliability: MessageReliability,
+    /// Identifies the stream incarnation whose send buffer owns this DATA.
+    pub(crate) stream_generation: u64,
     /// number of transmission made for this chunk
     pub(crate) nsent: u32,
 
-    /// valid only with the first fragment
+    /// This fragment belongs to an atomically abandoned message.
     pub(crate) abandoned: bool,
-    /// valid only with the first fragment
-    pub(crate) all_inflight: bool,
 
     /// Retransmission flag set when T1-RTX timeout occurred and this
     /// chunk is still in the inflight queue
@@ -149,13 +187,16 @@ impl Default for ChunkPayloadData {
             stream_sequence_number: 0,
             payload_type: PayloadProtocolIdentifier::default(),
             user_data: Bytes::new(),
-            acked: false,
+            acknowledged: false,
+            buffer_released: false,
+            delivery_credited: false,
             miss_indicator: 0,
             since: None,
-            created_at: None,
+            message_id: None,
+            reliability: MessageReliability::Reliable,
+            stream_generation: 0,
             nsent: 0,
             abandoned: false,
-            all_inflight: false,
             retransmit: false,
         }
     }
@@ -232,13 +273,16 @@ impl Chunk for ChunkPayloadData {
             payload_type,
             user_data,
 
-            acked: false,
+            acknowledged: false,
+            buffer_released: false,
+            delivery_credited: false,
             miss_indicator: 0,
             since: None,
-            created_at: None,
+            message_id: None,
+            reliability: MessageReliability::Reliable,
+            stream_generation: 0,
             nsent: 0,
             abandoned: false,
-            all_inflight: false,
             retransmit: false,
         })
     }
@@ -272,16 +316,44 @@ impl Chunk for ChunkPayloadData {
 
 impl ChunkPayloadData {
     pub(crate) fn abandoned(&self) -> bool {
-        self.abandoned && self.all_inflight
+        self.abandoned
     }
 
-    pub(crate) fn set_abandoned(&mut self, abandoned: bool) {
-        self.abandoned = abandoned;
+    pub(crate) fn is_outstanding(&self) -> bool {
+        !self.acknowledged && !self.abandoned
     }
 
-    pub(crate) fn set_all_inflight(&mut self) {
-        if self.ending_fragment {
-            self.all_inflight = true;
+    pub(crate) fn is_fast_retransmit_candidate(&self) -> bool {
+        self.is_outstanding() && self.nsent == 1 && self.miss_indicator >= 3
+    }
+
+    /// Record peer progress without changing payload ownership.
+    pub(crate) fn acknowledge(&mut self) -> bool {
+        let newly_acknowledged = !self.acknowledged;
+        self.acknowledged = true;
+        self.retransmit = false;
+        self.miss_indicator = 0;
+        newly_acknowledged
+    }
+
+    pub(crate) fn release_buffer(&mut self) -> usize {
+        if std::mem::replace(&mut self.buffer_released, true) {
+            0
+        } else {
+            self.user_data.len()
         }
+    }
+
+    pub(crate) fn take_delivery_credit(&mut self) -> usize {
+        if std::mem::replace(&mut self.delivery_credited, true) || self.abandoned {
+            0
+        } else {
+            self.user_data.len()
+        }
+    }
+
+    pub(crate) fn mark_abandoned(&mut self) {
+        self.abandoned = true;
+        self.retransmit = false;
     }
 }

--- a/rtc-sctp/src/chunk/chunk_reconfig.rs
+++ b/rtc-sctp/src/chunk/chunk_reconfig.rs
@@ -89,7 +89,7 @@ impl Chunk for ChunkReconfig {
         self.header().marshal_to(writer)?;
 
         let param_a_value_length = if let Some(param_a) = &self.param_a {
-            writer.extend_from_slice(&param_a.marshal()?);
+            param_a.marshal_to(writer)?;
             param_a.value_length()
         } else {
             return Err(Error::ErrChunkReconfigInvalidParamA);
@@ -99,7 +99,7 @@ impl Chunk for ChunkReconfig {
             // Pad param A
             let padding = get_padding_size(PARAM_HEADER_LENGTH + param_a_value_length);
             writer.put_bytes(0, padding);
-            writer.extend_from_slice(&param_b.marshal()?);
+            param_b.marshal_to(writer)?;
         }
         Ok(writer.len())
     }

--- a/rtc-sctp/src/chunk/chunk_test.rs
+++ b/rtc-sctp/src/chunk/chunk_test.rs
@@ -293,6 +293,13 @@ fn test_chunk_reconfig_success() -> Result<()> {
         let actual = ChunkReconfig::unmarshal(binary)?;
         let b = actual.marshal()?;
         assert_eq!(*binary, b, "test {} not equal: {:?} vs {:?}", i, *binary, b);
+        // The codec must append identically inside an existing packet buffer.
+        // Fixtures include odd/even parameter lengths and inter-parameter pad.
+        let prefix = b"prefix";
+        let mut appended = BytesMut::from(&prefix[..]);
+        actual.marshal_to(&mut appended)?;
+        assert_eq!(&appended[..prefix.len()], prefix);
+        assert_eq!(&appended[prefix.len()..], &binary[..]);
     }
 
     Ok(())

--- a/rtc-sctp/src/endpoint/endpoint_test.rs
+++ b/rtc-sctp/src/endpoint/endpoint_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::association::Event;
+use crate::queue::receive_queue::ReceiveQueue;
 use shared::error::{Error, Result};
 
 use crate::AssociationError;
@@ -512,10 +513,9 @@ fn test_assoc_reliable_simple() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -642,10 +642,9 @@ fn test_assoc_reliable_ordered_reordered() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -706,10 +705,9 @@ fn test_assoc_reliable_ordered_fragmented_then_defragmented() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -770,10 +768,9 @@ fn test_assoc_reliable_unordered_fragmented_then_defragmented() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -860,10 +857,9 @@ fn test_assoc_reliable_unordered_ordered() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -931,10 +927,9 @@ fn test_assoc_reliable_retransmission() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -988,10 +983,9 @@ fn test_assoc_reliable_short_buffer() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -1072,10 +1066,9 @@ fn test_assoc_unreliable_rexmit_ordered_no_fragment() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -1232,10 +1225,9 @@ fn test_assoc_unreliable_rexmit_ordered_fragment() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -1310,10 +1302,9 @@ fn test_assoc_unreliable_rexmit_unordered_no_fragment() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -1386,20 +1377,14 @@ fn test_assoc_unreliable_rexmit_unordered_fragment() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
         assert_eq!(
             0,
-            q.unordered.len(),
-            "should be nothing in the unordered queue"
-        );
-        assert_eq!(
-            0,
-            q.unordered_chunks.len(),
-            "should be nothing in the unorderedChunks list"
+            q.get_num_bytes(),
+            "all reassembly and delivery bytes must be released"
         );
     }
 
@@ -1656,10 +1641,9 @@ fn test_assoc_unreliable_rexmit_timed_ordered() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
     }
 
@@ -1734,25 +1718,144 @@ fn test_assoc_unreliable_rexmit_timed_unordered() -> Result<()> {
     {
         let q = &pair
             .client_conn_mut(client_ch)
-            .streams
+            .receive_streams
             .get(&si)
-            .unwrap()
-            .reassembly_queue;
+            .unwrap();
         assert!(!q.is_readable(), "should no longer be readable");
         assert_eq!(
             0,
-            q.unordered.len(),
-            "should be nothing in the unordered queue"
-        );
-        assert_eq!(
-            0,
-            q.unordered_chunks.len(),
-            "should be nothing in the unorderedChunks list"
+            q.get_num_bytes(),
+            "all reassembly and delivery bytes must be released"
         );
     }
 
     close_association_pair(&mut pair, client_ch, server_ch, si);
 
+    Ok(())
+}
+
+// RFC 3758 section 4.1 TR4: expired DATA must not reach either retransmit path.
+#[test]
+fn test_assoc_timed_reliability_stops_retransmission() -> Result<()> {
+    for unordered in [false, true] {
+        for size in [32, 2000, 12000] {
+            let si = 9;
+            let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+            establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+            pair.client_stream(client_ch, si)?.set_reliability_params(
+                unordered,
+                ReliabilityType::Timed,
+                100,
+            )?;
+            pair.server_stream(server_ch, si)?.set_reliability_params(
+                unordered,
+                ReliabilityType::Timed,
+                100,
+            )?;
+            let now = pair.time;
+            pair.client_stream(client_ch, si)?.write_sctp(
+                now,
+                &Bytes::from(vec![0x55; size]),
+                PayloadProtocolIdentifier::Binary,
+            )?;
+            pair.drive_client();
+            assert!(!pair.server.inbound.is_empty());
+            pair.server.inbound.clear(); // Lose the first transmission.
+            pair.server_conn_mut(server_ch).stats.reset();
+
+            pair.time += Duration::from_millis(500);
+            pair.drive_client();
+            pair.time += Duration::from_millis(1500);
+            pair.drive_client();
+            let mut forwards = 0;
+            for (_, _, raw) in &pair.server.inbound {
+                for c in Packet::unmarshal(raw)?.chunks {
+                    assert!(
+                        !c.as_any().is::<ChunkPayloadData>(),
+                        "expired DATA was retransmitted: unordered={unordered}, size={size}"
+                    );
+                    forwards += usize::from(c.as_any().is::<ChunkForwardTsn>());
+                }
+            }
+            assert!(
+                forwards > 0,
+                "the receiver must be able to skip the message"
+            );
+            pair.drive_server();
+            pair.drive_client();
+            assert_eq!(0, pair.server_conn_mut(server_ch).stats.get_num_datas());
+            assert_eq!(0, pair.client_stream(client_ch, si)?.buffered_amount()?);
+            assert!(pair.client_conn_mut(client_ch).is_idle());
+
+            let now = pair.time;
+            let next = Bytes::from_static(b"still useful");
+            pair.client_stream(client_ch, si)?.write_sctp(
+                now,
+                &next,
+                PayloadProtocolIdentifier::Binary,
+            )?;
+            pair.drive();
+            let received = pair.server_stream(server_ch, si)?.read_sctp()?.unwrap();
+            let mut buf = vec![0; received.len()];
+            received.read(&mut buf)?;
+            assert_eq!(next.as_ref(), buf);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_assoc_timed_reliability_fast_retransmission() -> Result<()> {
+    for unordered in [false, true] {
+        for elapsed_ms in [50, 100, 500] {
+            let si = 9;
+            let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+            establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+            pair.client_stream(client_ch, si)?.set_reliability_params(
+                unordered,
+                ReliabilityType::Timed,
+                100,
+            )?;
+            let now = pair.time;
+            pair.client_stream(client_ch, si)?.write_sctp(
+                now,
+                &Bytes::from_static(b"lost"),
+                PayloadProtocolIdentifier::Binary,
+            )?;
+            pair.drive_client();
+            pair.server.inbound.clear();
+            pair.client_conn_mut(client_ch).stats.reset();
+            pair.time += Duration::from_millis(elapsed_ms);
+
+            // Three distinct gap reports trigger fast retransmit before T3.
+            for value in 1..=3 {
+                let now = pair.time;
+                pair.client_stream(client_ch, si)?.write_sctp(
+                    now,
+                    &Bytes::from(vec![value]),
+                    PayloadProtocolIdentifier::Binary,
+                )?;
+                pair.drive_client();
+                pair.drive_server();
+                pair.drive_client();
+            }
+            assert_eq!(
+                0,
+                pair.client_conn_mut(client_ch).stats.get_num_t3timeouts()
+            );
+            pair.drive();
+            let mut received = Vec::new();
+            while let Some(chunks) = pair.server_stream(server_ch, si)?.read_sctp()? {
+                let mut buf = vec![0; chunks.len()];
+                chunks.read(&mut buf)?;
+                received.push(buf);
+            }
+            assert_eq!(elapsed_ms < 100, received.contains(&b"lost".to_vec()));
+            received.retain(|msg| msg != b"lost");
+            assert_eq!(vec![vec![1], vec![2], vec![3]], received);
+            assert_eq!(0, pair.client_stream(client_ch, si)?.buffered_amount()?);
+        }
+    }
     Ok(())
 }
 
@@ -1814,10 +1917,9 @@ fn test_assoc_congestion_control_fast_retransmission() -> Result<()> {
         {
             let q = &pair
                 .server_conn_mut(server_ch)
-                .streams
+                .receive_streams
                 .get(&si)
-                .unwrap()
-                .reassembly_queue;
+                .unwrap();
             assert!(q.is_readable(), "should be readable at {}", i);
         }
 
@@ -1962,10 +2064,10 @@ fn test_assoc_congestion_control_congestion_avoidance() -> Result<()> {
         assert_eq!(
             0,
             pair.server_conn_mut(server_ch)
-                .streams
+                .receive_streams
                 .get(&si)
                 .unwrap()
-                .get_num_bytes_in_reassembly_queue(),
+                .get_num_bytes(),
             "reassembly queue should be empty"
         );
 
@@ -2018,10 +2120,11 @@ fn test_assoc_congestion_control_slow_reader() -> Result<()> {
     let mut rbuf = vec![0u8; 3000];
 
     // 1. First forward packets to receiver until rwnd becomes 0
-    // 2. Wait until the sender's cwnd becomes 1*MTU (RTO occurred)
+    // 2. Wait for a zero-window probe timeout (RFC 9260 6.1 A leaves cwnd intact)
     // 3. Stat reading a1's data
     let mut n_packets_received = 0u32;
     let mut has_rtoed = false;
+    let mut steps = 0;
     while pair.client_conn_mut(client_ch).buffered_amount() > 0
         && n_packets_received < n_packets_to_send
     {
@@ -2033,13 +2136,17 @@ fn test_assoc_congestion_control_slow_reader() -> Result<()> {
             n_packets_to_send
         );*/
 
+        steps += 1;
+        assert!(
+            steps < 1000,
+            "slow reader must resume after a bounded number of events"
+        );
         if !has_rtoed {
             let rwnd = pair
                 .server_conn_mut(server_ch)
                 .get_my_receiver_window_credit();
-            let cwnd = pair.client_conn_mut(client_ch).cwnd;
-            let cmtu = pair.client_conn_mut(client_ch).mtu;
-            if cwnd > cmtu || rwnd > 0 {
+            let timeouts = pair.client_conn_mut(client_ch).stats.get_num_t3timeouts();
+            if timeouts == 0 || rwnd > 0 {
                 // Do not read until a1.getMyReceiverWindowCredit() becomes zero
                 pair.step();
                 continue;
@@ -2074,10 +2181,10 @@ fn test_assoc_congestion_control_slow_reader() -> Result<()> {
     assert_eq!(
         0,
         pair.server_conn_mut(server_ch)
-            .streams
+            .receive_streams
             .get(&si)
             .unwrap()
-            .get_num_bytes_in_reassembly_queue(),
+            .get_num_bytes(),
         "reassembly queue should be empty"
     );
 
@@ -2150,10 +2257,10 @@ fn test_assoc_delayed_ack() -> Result<()> {
     assert_eq!(
         0,
         pair.server_conn_mut(server_ch)
-            .streams
+            .receive_streams
             .get(&si)
             .unwrap()
-            .get_num_bytes_in_reassembly_queue(),
+            .get_num_bytes(),
         "reassembly queue should be empty"
     );
 
@@ -2651,10 +2758,9 @@ fn test_old_rtx_on_regular_acks() -> Result<()> {
         {
             let q = &pair
                 .server_conn_mut(server_ch)
-                .streams
+                .receive_streams
                 .get(&si)
-                .unwrap()
-                .reassembly_queue;
+                .unwrap();
             //println!("q.is_readable()={}", q.is_readable());
             assert!(q.is_readable(), "should be readable at {}", i);
         }
@@ -3161,6 +3267,7 @@ fn kps_repro_816_bundled_data_and_reset_must_not_lose_data() -> Result<()> {
             a.destination_port,
         )
     };
+    let request_sequence = pair.server_conn_mut(server_ch).expected_reset_sequence();
     let packet = Packet {
         common_header: CommonHeader {
             source_port: sport,
@@ -3180,7 +3287,7 @@ fn kps_repro_816_bundled_data_and_reset_must_not_lose_data() -> Result<()> {
             }),
             Box::new(ChunkReconfig {
                 param_a: Some(Box::new(ParamOutgoingResetRequest {
-                    reconfig_request_sequence_number: 100,
+                    reconfig_request_sequence_number: request_sequence,
                     reconfig_response_sequence_number: 0,
                     sender_last_tsn: tsn,
                     stream_identifiers: vec![si],
@@ -3317,9 +3424,9 @@ fn kps_816_close_unregisters_streams_holding_unread_data() -> Result<()> {
     {
         let a = pair.server_conn_mut(server_ch);
         assert!(
-            a.streams
+            a.receive_streams
                 .get(&si)
-                .is_some_and(|s| s.reassembly_queue.is_readable()),
+                .is_some_and(ReceiveQueue::is_readable),
             "precondition: the server is holding a message the application never read"
         );
         a.close(AssociationError::LocallyClosed)?;
@@ -3406,5 +3513,142 @@ fn kps_816_deferred_reset_completes_when_the_application_drains() -> Result<()> 
         pair.server_conn_mut(server_ch).stream(si).is_err(),
         "once drained, the deferred reset must be performed"
     );
+    Ok(())
+}
+
+#[test]
+fn test_close_after_timed_expiry_recovers_lost_reciprocal_reset() -> Result<()> {
+    for unread in [false, true] {
+        let si = 9;
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 0)?;
+        establish_session_pair(&mut pair, client_ch, server_ch, si)?;
+        if unread {
+            let now = pair.time;
+            pair.client_stream(client_ch, si)?.write_sctp(
+                now,
+                &Bytes::from_static(b"keep"),
+                ppi,
+            )?;
+            pair.drive();
+        }
+        pair.client_stream(client_ch, si)?.set_reliability_params(
+            true,
+            ReliabilityType::Timed,
+            100,
+        )?;
+        let now = pair.time;
+        pair.client_stream(client_ch, si)?
+            .write_sctp(now, &Bytes::from_static(b"lost"), ppi)?;
+        pair.drive_client();
+        assert!(!pair.server.inbound.is_empty());
+        pair.server.inbound.clear();
+        pair.time += Duration::from_secs(2);
+        let now = pair.time;
+        pair.client_stream(client_ch, si)?.close(now)?;
+        pair.drive_client();
+
+        let mut packets: Vec<_> = pair.server.inbound.drain(..).collect();
+        assert_eq!(2, packets.len());
+        packets.sort_by_key(|(_, _, raw)| {
+            !Packet::unmarshal(raw)
+                .unwrap()
+                .chunks
+                .iter()
+                .any(|c| c.as_any().is::<ChunkReconfig>())
+        });
+        let forward = packets.pop().unwrap();
+        pair.server.inbound.extend(packets);
+        pair.drive_server();
+        pair.drive_client();
+        // The recommended SACK accompanying InProgress may request another
+        // FORWARD-TSN immediately. Keep the first one held to exercise ordering.
+        assert!(pair.server.inbound.iter().all(|(_, _, raw)| {
+            Packet::unmarshal(raw)
+                .unwrap()
+                .chunks
+                .iter()
+                .all(|c| !c.as_any().is::<ChunkPayloadData>())
+        }));
+        pair.server.inbound.clear();
+        pair.server.inbound.push_back(forward);
+        pair.drive_server();
+        if unread {
+            let chunks = pair
+                .server_stream(server_ch, si)?
+                .read_sctp()?
+                .expect("reset must wait for unread DATA");
+            let mut bytes = [0; 4];
+            chunks.read(&mut bytes)?;
+            assert_eq!(&bytes, b"keep");
+            pair.drive_server();
+        }
+        assert!(pair.server_conn_mut(server_ch).stream(si).is_err());
+
+        let mut lost = 0;
+        pair.client.inbound.retain(|(_, _, raw)| {
+            let reciprocal = Packet::unmarshal(raw).unwrap().chunks.iter().any(|c| {
+                c.as_any()
+                    .downcast_ref::<ChunkReconfig>()
+                    .and_then(|c| c.param_a.as_ref())
+                    .is_some_and(|p| p.as_any().is::<ParamOutgoingResetRequest>())
+            });
+            if reciprocal {
+                lost += 1;
+            }
+            !reciprocal
+        });
+        assert_eq!(
+            1, lost,
+            "lose only the reciprocal reset, deliver SACK and SuccessPerformed"
+        );
+        pair.drive();
+        pair.time += Duration::from_secs(120);
+        pair.drive();
+        assert!(
+            pair.client_conn_mut(client_ch).stream(si).is_err(),
+            "one lost reciprocal RE-CONFIG leaves the closing initiator's stream registered indefinitely"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_peer_close_with_full_unrelated_receive_queue() -> Result<()> {
+    for unordered in [false, true] {
+        let (mut pair, client_ch, server_ch) = create_association_pair(AckMode::NoDelay, 4096)?;
+        establish_session_pair(&mut pair, client_ch, server_ch, 1)?;
+        establish_session_pair(&mut pair, client_ch, server_ch, 2)?;
+        pair.server_stream(server_ch, 2)?.set_reliability_params(
+            unordered,
+            ReliabilityType::Reliable,
+            0,
+        )?;
+        let ppi = PayloadProtocolIdentifier::Binary;
+        let now = pair.time;
+        pair.server_stream(server_ch, 2)?
+            .write_sctp(now, &Bytes::from(vec![5; 4096]), ppi)?;
+        pair.drive();
+        // Leave a complete message on stream 2 unread: client a_rwnd is zero.
+        assert_eq!(0, pair.server_stream(server_ch, 2)?.buffered_amount()?);
+        let now = pair.time;
+        pair.server_stream(server_ch, 2)?
+            .write_sctp(now, &Bytes::from(vec![7; 4000]), ppi)?;
+        pair.client_stream(client_ch, 1)?.close(now)?;
+        for _ in 0..10 {
+            pair.drive_client();
+            pair.drive_server();
+            pair.time += Duration::from_secs(1);
+        }
+        assert!(
+            pair.client_conn_mut(client_ch).stream(1).is_err(),
+            "peer-initiated close of stream 1 is blocked by unread stream 2"
+        );
+        assert!(pair.server_conn_mut(server_ch).stream(1).is_err());
+        let unread = pair.client_stream(client_ch, 2)?.read_sctp()?.unwrap();
+        let mut payload = vec![0; 4096];
+        assert_eq!(4096, unread.read(&mut payload)?);
+        assert!(payload.iter().all(|b| *b == 5));
+    }
     Ok(())
 }

--- a/rtc-sctp/src/fuzzing.rs
+++ b/rtc-sctp/src/fuzzing.rs
@@ -42,6 +42,16 @@ fn to_bytes(data: &[u8]) -> Bytes {
     Bytes::copy_from_slice(data)
 }
 
+/// Run a bounded, stateful scenario through a real pair of SCTP endpoints.
+///
+/// Input bytes choose valid application actions and packet loss, duplication,
+/// ordering, and virtual-time advancement. The supplied instant is only an
+/// origin; the driver reads no ambient clock. At the end, losses stop and all
+/// messages are read, checking delivery, retry budgets, deadlines, and buffers.
+pub fn association_state(data: &[u8], origin: std::time::Instant) {
+    crate::fuzzing_state::run(data, origin);
+}
+
 pub fn packet_unmarshal(data: &[u8]) -> Result<()> {
     let raw = to_bytes(data);
     let _ = Packet::unmarshal(&raw)?;

--- a/rtc-sctp/src/fuzzing_state.rs
+++ b/rtc-sctp/src/fuzzing_state.rs
@@ -1,0 +1,668 @@
+//! Bounded stateful SCTP test driver. Compiled only for tests/fuzzing/bench.
+//!
+//! Application commands and packet scheduling are derived from input bytes;
+//! packets always come from a real handshake and keep their original checksum.
+//! In particular, a delayed packet is checked against its transmission time,
+//! never its arrival time. No production state is patched to arrange a test.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use shared::TransportProtocol;
+
+use crate::packet::Packet;
+use crate::{
+    Association, AssociationHandle, ChunkPayloadData, ClientConfig, DatagramEvent, Endpoint,
+    EndpointConfig, Event, Payload, PayloadProtocolIdentifier, ReliabilityType, ServerConfig,
+    StreamEvent, TransportConfig,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Policy {
+    Reliable,
+    Timed(u32),
+    Rexmit(u32),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum CloseKind {
+    Stop,
+    Finish,
+    Close,
+}
+
+struct Node {
+    endpoint: Endpoint,
+    remote: SocketAddr,
+    handle: Option<AssociationHandle>,
+    association: Option<Association>,
+    connected: bool,
+}
+
+#[derive(Clone)]
+struct WirePacket {
+    from: usize,
+    bytes: Bytes,
+}
+
+struct Message {
+    from: usize,
+    sid: u16,
+    ordered: bool,
+    policy: Policy,
+    written_at: Instant,
+    bytes: Bytes,
+    // A close is allowed to discard an application delivery. The generator
+    // therefore requires reliable delivery only while that SID stays open.
+    required: bool,
+}
+
+/// Shared property oracle for hand-written tests and libFuzzer inputs.
+pub(crate) struct Model {
+    nodes: [Node; 2],
+    pub(crate) now: Instant,
+    start: Instant,
+    wire: VecDeque<WirePacket>,
+    messages: BTreeMap<u64, Message>,
+    delivered: BTreeSet<u64>,
+    last_ordered: BTreeMap<(usize, u16), u64>,
+    sent_tsns: BTreeMap<(usize, u32), (u64, usize)>,
+    fragment_message: BTreeMap<(usize, u16, bool, u16), u64>,
+    accepted: BTreeMap<(usize, u16), usize>,
+    released: BTreeMap<(usize, u16), usize>,
+    trace: VecDeque<String>,
+    next_message: u64,
+    had_reset: bool,
+    // App delivery may advance through an EOF fence without scheduling a timer.
+    // Fair draining therefore tracks synchronous progress as well as deadlines.
+    progress: u64,
+}
+
+impl Model {
+    pub(crate) fn new(now: Instant) -> Self {
+        let addresses: [SocketAddr; 2] = [
+            "127.0.0.1:5000".parse().unwrap(),
+            "127.0.0.1:5001".parse().unwrap(),
+        ];
+        let endpoint_config = Arc::new(EndpointConfig::default());
+        let transport = TransportConfig::default()
+            .with_max_message_size(16384)
+            .with_max_num_inbound_streams(32)
+            .with_max_num_outbound_streams(32);
+        let mut nodes = [
+            Node {
+                endpoint: Endpoint::new(
+                    addresses[0],
+                    TransportProtocol::UDP,
+                    endpoint_config.clone(),
+                    None,
+                ),
+                remote: addresses[1],
+                handle: None,
+                association: None,
+                connected: false,
+            },
+            Node {
+                endpoint: Endpoint::new(
+                    addresses[1],
+                    TransportProtocol::UDP,
+                    endpoint_config,
+                    Some(Arc::new(ServerConfig::new(transport.clone()))),
+                ),
+                remote: addresses[0],
+                handle: None,
+                association: None,
+                connected: false,
+            },
+        ];
+        let (handle, association) = nodes[0]
+            .endpoint
+            .connect(now, ClientConfig::new(transport), addresses[1])
+            .unwrap();
+        nodes[0].handle = Some(handle);
+        nodes[0].association = Some(association);
+        let mut model = Self {
+            nodes,
+            now,
+            start: now,
+            wire: VecDeque::new(),
+            messages: BTreeMap::new(),
+            delivered: BTreeSet::new(),
+            last_ordered: BTreeMap::new(),
+            sent_tsns: BTreeMap::new(),
+            fragment_message: BTreeMap::new(),
+            accepted: BTreeMap::new(),
+            released: BTreeMap::new(),
+            trace: VecDeque::new(),
+            next_message: 1,
+            had_reset: false,
+            progress: 0,
+        };
+        model.poll();
+        model.deliver_all();
+        model.require(
+            model.nodes.iter().all(|n| n.connected),
+            "handshake did not complete",
+        );
+        model
+    }
+
+    fn record(&mut self, action: String) {
+        if self.trace.len() == 2048 {
+            // Keep the first application actions even when a stuck procedure
+            // generates many repeated timer events at the end of a trace.
+            self.trace.remove(128);
+        }
+        self.trace.push_back(format!(
+            "t={}ms {action}",
+            self.now.duration_since(self.start).as_millis()
+        ));
+    }
+
+    fn require(&self, predicate: bool, message: &str) {
+        assert!(
+            predicate,
+            "{message}\n{}",
+            self.trace.iter().cloned().collect::<Vec<_>>().join("\n")
+        );
+    }
+
+    pub(crate) fn open(&mut self, side: usize, sid: u16) -> bool {
+        self.record(format!("open {side} {sid}"));
+        let association = self.nodes[side].association.as_mut().unwrap();
+        if association.is_closed() {
+            return false;
+        }
+        association
+            .open_stream(sid, PayloadProtocolIdentifier::Binary)
+            .is_ok()
+    }
+
+    pub(crate) fn send(
+        &mut self,
+        side: usize,
+        sid: u16,
+        ordered: bool,
+        policy: Policy,
+        length: usize,
+    ) -> Option<u64> {
+        let id = self.next_message;
+        self.next_message += 1;
+        self.record(format!(
+            "send {side} {sid} {ordered} {policy:?} len={length} id={id}"
+        ));
+        let mut bytes = vec![0; length.max(8)];
+        for (index, value) in bytes.iter_mut().enumerate() {
+            *value = (id.wrapping_mul(37).wrapping_add(index as u64 * 13) % 251) as u8;
+        }
+        bytes[..8].copy_from_slice(&id.to_be_bytes());
+        let bytes = Bytes::from(bytes);
+        // A peer which explicitly stopped its read half is allowed to discard
+        // later arrivals. An absent receiver stream is different: DATA opens it.
+        let receiver_reading = self.nodes[1 - side]
+            .association
+            .as_mut()
+            .unwrap()
+            .stream(sid)
+            .map_or(true, |stream| stream.is_readable());
+        let association = self.nodes[side].association.as_mut().unwrap();
+        if association.is_closed() {
+            return None;
+        }
+        let Ok(mut stream) = association.stream(sid) else {
+            return None;
+        };
+        let (kind, value) = match policy {
+            Policy::Reliable => (ReliabilityType::Reliable, 0),
+            Policy::Timed(value) => (ReliabilityType::Timed, value),
+            Policy::Rexmit(value) => (ReliabilityType::Rexmit, value),
+        };
+        stream
+            .set_reliability_params(!ordered, kind, value)
+            .unwrap();
+        let before = stream.buffered_amount().unwrap();
+        let Ok(written) = stream.write_sctp(self.now, &bytes, PayloadProtocolIdentifier::Binary)
+        else {
+            return None;
+        };
+        let after = stream.buffered_amount().unwrap();
+        self.require(
+            written == bytes.len(),
+            "accepted a partial application message",
+        );
+        self.require(
+            after == before + written,
+            "write did not account for every payload byte",
+        );
+        *self.accepted.entry((side, sid)).or_default() += written;
+        self.messages.insert(
+            id,
+            Message {
+                from: side,
+                sid,
+                ordered,
+                policy,
+                written_at: self.now,
+                bytes,
+                required: matches!(policy, Policy::Reliable) && receiver_reading,
+            },
+        );
+        Some(id)
+    }
+
+    pub(crate) fn close(&mut self, side: usize, sid: u16, kind: CloseKind) {
+        self.record(format!("close {side} {sid} {kind:?}"));
+        let association = self.nodes[side].association.as_mut().unwrap();
+        let Ok(mut stream) = association.stream(sid) else {
+            return;
+        };
+        let result = match kind {
+            CloseKind::Stop => stream.stop(self.now),
+            CloseKind::Finish => stream.finish(),
+            CloseKind::Close => stream.close(self.now),
+        };
+        if result.is_ok() {
+            self.had_reset = true;
+            if matches!(kind, CloseKind::Stop | CloseKind::Close) {
+                for message in self
+                    .messages
+                    .values_mut()
+                    .filter(|m| m.sid == sid && m.from == 1 - side)
+                {
+                    message.required = false;
+                }
+            }
+        }
+    }
+
+    fn inspect_transmission(&mut self, from: usize, bytes: &Bytes) {
+        let packet = Packet::unmarshal(bytes).expect("stack emitted malformed packet");
+        for chunk in packet.chunks {
+            let Some(data) = chunk.as_any().downcast_ref::<ChunkPayloadData>() else {
+                self.record(format!("control {from} {chunk}"));
+                continue;
+            };
+            let fragment_key = (
+                from,
+                data.stream_identifier,
+                data.unordered,
+                data.stream_sequence_number,
+            );
+            let key = (from, data.tsn);
+            let previous = self.sent_tsns.get(&key).copied();
+            let id = if let Some((id, _)) = previous {
+                id
+            } else if data.beginning_fragment {
+                self.require(
+                    data.user_data.len() >= 8,
+                    "empty/synthetic DATA escaped to wire",
+                );
+                let id = u64::from_be_bytes(data.user_data[..8].try_into().unwrap());
+                self.fragment_message.insert(fragment_key, id);
+                id
+            } else {
+                *self
+                    .fragment_message
+                    .get(&fragment_key)
+                    .expect("fragment emitted without its initial message fragment")
+            };
+            let message = self
+                .messages
+                .get(&id)
+                .expect("DATA references unaccepted message");
+            self.require(
+                message.from == from && message.sid == data.stream_identifier,
+                "DATA changed message owner",
+            );
+            let attempts = previous.map_or(1, |(_, attempts)| attempts + 1);
+            match message.policy {
+                Policy::Timed(0) => self.require(attempts == 1, "Timed(0) DATA was retransmitted"),
+                Policy::Timed(lifetime) => self.require(
+                    self.now < message.written_at + Duration::from_millis(lifetime.into()),
+                    "Timed DATA was sent at or after its deadline",
+                ),
+                Policy::Rexmit(retries) => self.require(
+                    attempts <= retries as usize + 1,
+                    "Rexmit DATA exceeded its fragment retry budget",
+                ),
+                Policy::Reliable => {}
+            }
+            self.sent_tsns.insert(key, (id, attempts));
+            self.record(format!(
+                "DATA {from} tsn={} sid={} ssn={} id={id} attempt={attempts} len={}",
+                data.tsn,
+                data.stream_identifier,
+                data.stream_sequence_number,
+                data.user_data.len()
+            ));
+        }
+    }
+
+    pub(crate) fn poll(&mut self) {
+        for side in 0..2 {
+            let Some(association) = self.nodes[side].association.as_mut() else {
+                continue;
+            };
+            let mut packets = Vec::new();
+            for iteration in 0..256 {
+                let Some(transmit) = association.poll_transmit(self.now) else {
+                    break;
+                };
+                assert!(iteration < 255, "poll_transmit did not quiesce");
+                if let Payload::RawEncode(contents) = transmit.message {
+                    packets.extend(contents);
+                }
+            }
+            for bytes in packets {
+                self.progress += 1;
+                self.inspect_transmission(side, &bytes);
+                self.record(format!(
+                    "packet {side} kind={} len={}",
+                    bytes[12],
+                    bytes.len()
+                ));
+                self.wire.push_back(WirePacket { from: side, bytes });
+            }
+            let mut events = Vec::new();
+            let node = &mut self.nodes[side];
+            let association = node.association.as_mut().unwrap();
+            association.assert_receive_accounting();
+            while let Some(event) = association.poll() {
+                events.push(event);
+            }
+            while let Some(event) = association.poll_endpoint_event() {
+                node.endpoint.handle_event(node.handle.unwrap(), event);
+            }
+            for event in events {
+                self.progress += 1;
+                self.record(format!("event {side} {event:?}"));
+                match event {
+                    Event::Connected => self.nodes[side].connected = true,
+                    Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) => {
+                        *self.released.entry((side, id)).or_default() += n_bytes;
+                        self.require(
+                            self.released[&(side, id)]
+                                <= *self.accepted.get(&(side, id)).unwrap_or(&0),
+                            "released more bytes than the application accepted",
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+        self.require(
+            self.wire.len() <= 4096,
+            "wire queue exceeded bounded scenario budget",
+        );
+    }
+
+    pub(crate) fn wire_len(&self) -> usize {
+        self.wire.len()
+    }
+
+    pub(crate) fn drop_packet(&mut self, index: usize) {
+        if self.wire.is_empty() {
+            return;
+        }
+        let index = index % self.wire.len();
+        self.record(format!("drop {index}"));
+        self.wire.remove(index);
+    }
+
+    pub(crate) fn duplicate(&mut self, index: usize) {
+        if self.wire.is_empty() {
+            return;
+        }
+        let index = index % self.wire.len();
+        self.record(format!("duplicate {index}"));
+        self.wire.push_back(self.wire[index].clone());
+    }
+
+    pub(crate) fn deliver(&mut self, index: usize) {
+        if self.wire.is_empty() {
+            return;
+        }
+        let index = index % self.wire.len();
+        self.record(format!("deliver {index}"));
+        let packet = self.wire.remove(index).unwrap();
+        self.progress += 1;
+        let node = &mut self.nodes[1 - packet.from];
+        if let Some((handle, event)) =
+            node.endpoint
+                .handle(self.now, node.remote, None, packet.bytes)
+        {
+            match event {
+                DatagramEvent::NewAssociation(association) => {
+                    node.handle = Some(handle);
+                    node.association = Some(association);
+                }
+                DatagramEvent::AssociationEvent(event) => {
+                    node.association.as_mut().unwrap().handle_event(event);
+                }
+            }
+        }
+        self.poll();
+    }
+
+    pub(crate) fn deliver_all(&mut self) {
+        for _ in 0..4096 {
+            if self.wire.is_empty() {
+                return;
+            }
+            self.deliver(0);
+        }
+        self.require(false, "loss-free packet exchange did not quiesce");
+    }
+
+    pub(crate) fn advance(&mut self, millis: u64) {
+        self.record(format!("advance {millis}"));
+        self.now += Duration::from_millis(millis);
+        for node in &mut self.nodes {
+            if let Some(association) = &mut node.association
+                && association
+                    .poll_timeout()
+                    .is_some_and(|deadline| deadline <= self.now)
+            {
+                association.handle_timeout(self.now);
+            }
+        }
+        self.poll();
+    }
+
+    pub(crate) fn read(&mut self, side: usize) {
+        self.record(format!("read {side}"));
+        let association = self.nodes[side].association.as_mut().unwrap();
+        while association.accept_stream().is_some() {}
+        let mut received = Vec::new();
+        for sid in association.stream_ids() {
+            for _ in 0..256 {
+                let Some(chunks) = association
+                    .stream(sid)
+                    .ok()
+                    .and_then(|mut stream| stream.read_sctp().ok().flatten())
+                else {
+                    break;
+                };
+                let mut bytes = vec![0; chunks.len()];
+                assert_eq!(chunks.read(&mut bytes).unwrap(), bytes.len());
+                received.push((sid, bytes));
+            }
+        }
+        for (sid, bytes) in received {
+            self.require(
+                bytes.len() >= 8,
+                "application received an incomplete message header",
+            );
+            let id = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+            self.record(format!("message {side} {sid} id={id} len={}", bytes.len()));
+            let message = self
+                .messages
+                .get(&id)
+                .expect("delivered unaccepted message");
+            self.require(
+                message.from == 1 - side && message.sid == sid,
+                "message reached wrong peer/SID",
+            );
+            self.require(
+                bytes == message.bytes,
+                "message payload was truncated or mixed",
+            );
+            self.require(
+                !self.delivered.contains(&id),
+                "application received duplicate message",
+            );
+            if message.ordered {
+                let key = (message.from, sid);
+                self.require(
+                    self.last_ordered.get(&key).is_none_or(|last| id > *last),
+                    "ordered application messages were reordered",
+                );
+                self.last_ordered.insert(key, id);
+            }
+            self.delivered.insert(id);
+            self.progress += 1;
+        }
+        self.poll();
+    }
+
+    pub(crate) fn received(&self, id: u64) -> bool {
+        self.delivered.contains(&id)
+    }
+
+    pub(crate) fn buffered(&mut self, side: usize, sid: u16) -> Option<usize> {
+        self.nodes[side]
+            .association
+            .as_mut()
+            .unwrap()
+            .stream(sid)
+            .ok()
+            .and_then(|stream| stream.buffered_amount().ok())
+    }
+
+    /// Network losses stop and applications read every available message. All
+    /// accepted reliable messages on untouched SIDs must become readable, and
+    /// every live stream's send buffer must eventually be released.
+    pub(crate) fn finish(&mut self) {
+        self.record("fair network begins".into());
+        let mut quiescent = false;
+        for _ in 0..128 {
+            let previous_progress = self.progress;
+            self.deliver_all();
+            self.read(0);
+            self.read(1);
+            self.deliver_all();
+            if self.progress != previous_progress {
+                // Reading old ready data can expose a new receiver for the
+                // same SID during poll(). Drain its app events/messages before
+                // advancing time or declaring timer-free quiescence.
+                continue;
+            }
+            let next = self
+                .nodes
+                .iter()
+                .filter_map(|node| {
+                    node.association
+                        .as_ref()
+                        .and_then(Association::poll_timeout)
+                })
+                .min();
+            let Some(next) = next else {
+                quiescent = true;
+                break;
+            };
+            let delta = next.saturating_duration_since(self.now).as_millis() as u64;
+            self.advance(delta.max(1));
+        }
+        self.require(
+            quiescent,
+            "protocol did not quiesce after losses stopped and applications read",
+        );
+        for (id, message) in &self.messages {
+            let association = self.nodes[message.from].association.as_ref().unwrap();
+            if message.required && !association.is_closed() {
+                self.require(self.received(*id), &format!(
+                    "reliable message id={id} side={} sid={} not delivered after losses stopped",
+                    message.from, message.sid));
+            }
+        }
+        for side in 0..2 {
+            let ids = self.nodes[side].association.as_ref().unwrap().stream_ids();
+            for sid in ids {
+                let buffered = self.buffered(side, sid);
+                self.require(buffered == Some(0), "send buffer leaked after fair drain");
+            }
+        }
+        if !self.had_reset
+            && self
+                .nodes
+                .iter()
+                .all(|node| !node.association.as_ref().unwrap().is_closed())
+        {
+            self.require(
+                self.accepted.iter().all(|(key, bytes)| {
+                    self.released.get(key).copied().unwrap_or_default() == *bytes
+                }),
+                "payload release events did not exactly account for accepted bytes",
+            );
+        }
+    }
+}
+
+/// Decode at most 128 four-byte actions; libFuzzer can shrink the input directly.
+pub(crate) fn run(input: &[u8], now: Instant) {
+    let mut model = Model::new(now);
+    for side in 0..2 {
+        for sid in 0..3 {
+            model.open(side, sid);
+        }
+    }
+    for action in input.chunks_exact(4).take(128) {
+        let side = usize::from(action[1] & 1);
+        let sid = u16::from((action[1] >> 1) % 3);
+        let ordered = action[2] & 1 == 0;
+        let length = [32, 1200, 4000][usize::from(action[3] % 3)];
+        match action[0] % 12 {
+            0 => {
+                model.send(side, sid, ordered, Policy::Reliable, length);
+            }
+            1 => {
+                model.send(
+                    side,
+                    sid,
+                    ordered,
+                    Policy::Timed([0, 1, 100][usize::from(action[2] % 3)]),
+                    length,
+                );
+            }
+            2 => {
+                model.send(
+                    side,
+                    sid,
+                    ordered,
+                    Policy::Rexmit(u32::from(action[2] % 3)),
+                    length,
+                );
+            }
+            3 => model.deliver(usize::from(action[2])),
+            4 => model.drop_packet(usize::from(action[2])),
+            5 => model.duplicate(usize::from(action[2])),
+            6 => model.advance([0, 1, 100, 500, 1100][usize::from(action[2] % 5)]),
+            7 => model.read(side),
+            8 => model.close(
+                side,
+                sid,
+                [CloseKind::Stop, CloseKind::Finish, CloseKind::Close][usize::from(action[2] % 3)],
+            ),
+            9 => {
+                model.open(side, sid);
+            }
+            10 => model.deliver(model.wire_len().saturating_sub(1)),
+            _ => model.poll(),
+        }
+        model.poll();
+    }
+    model.finish();
+}

--- a/rtc-sctp/src/lib.rs
+++ b/rtc-sctp/src/lib.rs
@@ -52,6 +52,9 @@
 #![allow(dead_code)]
 #![allow(clippy::bool_to_int_with_if)]
 
+#[cfg(any(test, fuzzing, feature = "bench"))]
+mod fuzzing_state;
+
 use bytes::Bytes;
 use std::{fmt, ops};
 

--- a/rtc-sctp/src/queue/mod.rs
+++ b/rtc-sctp/src/queue/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod payload_queue;
 pub(crate) mod pending_queue;
 pub(crate) mod reassembly_queue;
 pub(crate) mod receive_queue;
+pub(crate) mod receive_tsn_queue;

--- a/rtc-sctp/src/queue/mod.rs
+++ b/rtc-sctp/src/queue/mod.rs
@@ -4,3 +4,4 @@ mod queue_test;
 pub(crate) mod payload_queue;
 pub(crate) mod pending_queue;
 pub(crate) mod reassembly_queue;
+pub(crate) mod receive_queue;

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -1,9 +1,63 @@
-use crate::chunk::chunk_payload_data::ChunkPayloadData;
+use crate::chunk::chunk_payload_data::{ChunkPayloadData, MessageId, MessageReliability};
 use crate::chunk::chunk_selective_ack::GapAckBlock;
 use crate::util::*;
 
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
+
+/// Most messages fit in a single DATA chunk. Keep that TSN in the index itself
+/// rather than allocating a separate collection on every send and SACK.
+#[derive(Debug)]
+enum MessageTsns {
+    One(u32),
+    Fragmented(VecDeque<u32>),
+}
+
+impl MessageTsns {
+    fn insert(&mut self, tsn: u32) {
+        match self {
+            Self::One(first) => {
+                let pair = if sna32lt(tsn, *first) {
+                    [tsn, *first]
+                } else {
+                    [*first, tsn]
+                };
+                *self = Self::Fragmented(VecDeque::from(pair));
+            }
+            Self::Fragmented(tsns) => {
+                if tsns.back().is_none_or(|last| sna32lt(*last, tsn)) {
+                    tsns.push_back(tsn);
+                } else {
+                    let index = tsns.partition_point(|&item| sna32lt(item, tsn));
+                    tsns.insert(index, tsn);
+                }
+            }
+        }
+    }
+
+    /// Cumulative acknowledgment removes only a prefix of a message's TSNs.
+    /// Returns true when the whole index entry can be removed.
+    fn pop(&mut self, tsn: u32) -> bool {
+        match self {
+            Self::One(first) => {
+                debug_assert_eq!(*first, tsn);
+                true
+            }
+            Self::Fragmented(tsns) => {
+                debug_assert_eq!(tsns.front(), Some(&tsn));
+                tsns.pop_front();
+                tsns.is_empty()
+            }
+        }
+    }
+
+    fn to_vec(&self) -> Vec<u32> {
+        match self {
+            Self::One(tsn) => vec![*tsn],
+            Self::Fragmented(tsns) => tsns.iter().copied().collect(),
+        }
+    }
+}
 
 #[derive(Default, Debug)]
 pub(crate) struct PayloadQueue {
@@ -19,6 +73,11 @@ pub(crate) struct PayloadQueue {
     pub(crate) sorted: VecDeque<u32>,
     dup_tsn: Vec<u32>,
     n_bytes: usize,
+    outstanding_bytes: usize,
+    buffered_bytes: usize,
+    /// Sent fragments of messages eligible for abandonment. A whole message
+    /// uses its candidate TSN directly; only fragmented messages need a group.
+    message_tsns: FxHashMap<MessageId, MessageTsns>,
 }
 
 impl PayloadQueue {
@@ -32,16 +91,42 @@ impl PayloadQueue {
     /// common case, since TSNs are assigned/received sequentially — land at the
     /// end in O(1) amortized.
     fn insert_sorted(&mut self, tsn: u32) {
-        let idx = self.sorted.partition_point(|&x| sna32lt(x, tsn));
-        self.sorted.insert(idx, tsn);
+        if self.sorted.back().is_none_or(|last| sna32lt(*last, tsn)) {
+            self.sorted.push_back(tsn);
+        } else {
+            let idx = self.sorted.partition_point(|&x| sna32lt(x, tsn));
+            self.sorted.insert(idx, tsn);
+        }
     }
 
     pub(crate) fn can_push(&self, p: &ChunkPayloadData, cumulative_tsn: u32) -> bool {
         !(self.chunk_map.contains_key(&p.tsn) || sna32lte(p.tsn, cumulative_tsn))
     }
 
+    fn abandonment_id(p: &ChunkPayloadData) -> Option<MessageId> {
+        if p.beginning_fragment && p.ending_fragment {
+            return None;
+        }
+        match p.reliability {
+            MessageReliability::Reliable => None,
+            _ => p.message_id,
+        }
+    }
+
     pub(crate) fn push_no_check(&mut self, p: ChunkPayloadData) {
+        if let Some(id) = Self::abandonment_id(&p) {
+            self.message_tsns
+                .entry(id)
+                .and_modify(|tsns| tsns.insert(p.tsn))
+                .or_insert(MessageTsns::One(p.tsn));
+        }
         self.n_bytes += p.user_data.len();
+        if p.is_outstanding() {
+            self.outstanding_bytes += p.user_data.len();
+        }
+        if !p.buffer_released {
+            self.buffered_bytes += p.user_data.len();
+        }
         self.insert_sorted(p.tsn);
         self.chunk_map.insert(p.tsn, p);
         //self.length += 1;
@@ -58,26 +143,43 @@ impl PayloadQueue {
             return false;
         }
 
-        self.n_bytes += p.user_data.len();
-        self.insert_sorted(p.tsn);
-        self.chunk_map.insert(p.tsn, p);
-        //self.length += 1;
+        self.push_no_check(p);
 
         true
     }
 
     /// pop pops only if the oldest chunk's TSN matches the given TSN.
+    // SACK/RX consumers use only some fields. Inline so they need not copy the
+    // entire DATA metadata through a separate struct-return calling convention.
+    #[inline(always)]
     pub(crate) fn pop(&mut self, tsn: u32) -> Option<ChunkPayloadData> {
         if self.sorted.front() == Some(&tsn) {
             self.sorted.pop_front();
             if let Some(c) = self.chunk_map.remove(&tsn) {
-                //self.length -= 1;
+                if let Some(id) = Self::abandonment_id(&c) {
+                    let tsns = self.message_tsns.get_mut(&id).unwrap();
+                    if tsns.pop(tsn) {
+                        self.message_tsns.remove(&id);
+                    }
+                }
                 self.n_bytes -= c.user_data.len();
+                if c.is_outstanding() {
+                    self.outstanding_bytes -= c.user_data.len();
+                }
+                if !c.buffer_released {
+                    self.buffered_bytes -= c.user_data.len();
+                }
                 return Some(c);
             }
         }
 
         None
+    }
+
+    pub(crate) fn message_tsns(&self, id: MessageId) -> Vec<u32> {
+        self.message_tsns
+            .get(&id)
+            .map_or_else(Vec::new, MessageTsns::to_vec)
     }
 
     /// get returns reference to chunkPayloadData with the given TSN value.
@@ -98,31 +200,25 @@ impl PayloadQueue {
             return vec![];
         }
 
-        let mut b = GapAckBlock::default();
-        let mut gap_ack_blocks = vec![];
-        for (i, tsn) in self.sorted.iter().enumerate() {
-            let diff = if *tsn >= cumulative_tsn {
-                (*tsn - cumulative_tsn) as u16
+        let mut blocks: Vec<GapAckBlock> = vec![];
+        for tsn in &self.sorted {
+            let offset = tsn.wrapping_sub(cumulative_tsn);
+            if offset == 0 || offset > u16::MAX as u32 {
+                continue; // This SACK cannot represent a larger gap offset.
+            }
+            let offset = offset as u16;
+            if let Some(last) = blocks.last_mut()
+                && last.end.checked_add(1) == Some(offset)
+            {
+                last.end = offset;
             } else {
-                0
-            };
-
-            if i == 0 {
-                b.start = diff;
-                b.end = b.start;
-            } else if b.end + 1 == diff {
-                b.end += 1;
-            } else {
-                gap_ack_blocks.push(b);
-
-                b.start = diff;
-                b.end = diff;
+                blocks.push(GapAckBlock {
+                    start: offset,
+                    end: offset,
+                });
             }
         }
-
-        gap_ack_blocks.push(b);
-
-        gap_ack_blocks
+        blocks
     }
 
     pub(crate) fn get_gap_ack_blocks_string(&self, cumulative_tsn: u32) -> String {
@@ -133,17 +229,54 @@ impl PayloadQueue {
         s
     }
 
-    pub(crate) fn mark_as_acked(&mut self, tsn: u32) -> usize {
-        if let Some(c) = self.chunk_map.get_mut(&tsn) {
-            c.acked = true;
-            c.retransmit = false;
-            let n = c.user_data.len();
-            self.n_bytes -= n;
-            c.user_data.clear();
-            n
-        } else {
-            0
+    pub(crate) fn acknowledge(&mut self, tsn: u32) -> bool {
+        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+            return false;
+        };
+        if c.is_outstanding() {
+            self.outstanding_bytes -= c.user_data.len();
         }
+        c.acknowledge()
+    }
+
+    /// A gap ACK can be revoked. Retain its Bytes until cumulative ACK or
+    /// abandonment while returning the existing API's buffer credit once.
+    pub(crate) fn release_buffer(&mut self, tsn: u32) -> usize {
+        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+            return 0;
+        };
+        let released = c.release_buffer();
+        self.buffered_bytes -= released;
+        released
+    }
+
+    pub(crate) fn revoke_gap_ack(&mut self, tsn: u32) -> bool {
+        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+            return false;
+        };
+        if c.acknowledged && !c.abandoned {
+            c.acknowledged = false;
+            self.outstanding_bytes += c.user_data.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn abandon(&mut self, tsn: u32) -> (bool, usize) {
+        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+            return (false, 0);
+        };
+        let changed = !c.abandoned;
+        if c.is_outstanding() {
+            self.outstanding_bytes -= c.user_data.len();
+        }
+        c.mark_abandoned();
+        let released = c.release_buffer();
+        self.buffered_bytes -= released;
+        self.n_bytes -= c.user_data.len();
+        c.user_data.clear();
+        (changed, released)
     }
 
     pub(crate) fn get_last_tsn_received(&self) -> Option<&u32> {
@@ -152,7 +285,7 @@ impl PayloadQueue {
 
     pub(crate) fn mark_all_to_retrasmit(&mut self) {
         for c in self.chunk_map.values_mut() {
-            if c.acked || c.abandoned() {
+            if !c.is_outstanding() {
                 continue;
             }
             c.retransmit = true;
@@ -161,6 +294,14 @@ impl PayloadQueue {
 
     pub(crate) fn get_num_bytes(&self) -> usize {
         self.n_bytes
+    }
+
+    pub(crate) fn outstanding_bytes(&self) -> usize {
+        self.outstanding_bytes
+    }
+
+    pub(crate) fn buffered_bytes(&self) -> usize {
+        self.buffered_bytes
     }
 
     pub(crate) fn len(&self) -> usize {

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -9,6 +9,10 @@ use std::collections::VecDeque;
 #[path = "payload_queue_model_test.rs"]
 mod model_test;
 
+#[cfg(test)]
+#[path = "payload_queue_shrink_test.rs"]
+mod shrink_test;
+
 pub(crate) enum GapAck<'a> {
     Duplicate,
     New {
@@ -201,6 +205,16 @@ impl PayloadQueue {
             self.buffered_bytes -= payload_len;
         }
         Some(c)
+    }
+
+    /// Release oversized storage after a successful cumulative-ACK batch.
+    /// Keep headroom and a small floor so ordinary flights do not resize.
+    pub(crate) fn shrink_after_cumulative_ack(&mut self) {
+        let capacity = self.inflight.capacity();
+        let len = self.inflight.len();
+        if capacity > 4096 && len <= capacity / 4 {
+            self.inflight.shrink_to((2 * len).max(1024));
+        }
     }
 
     pub(crate) fn message_tsns(&self, id: MessageId) -> Vec<u32> {

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -2,8 +2,18 @@ use crate::chunk::chunk_payload_data::{ChunkPayloadData, MessageId, MessageRelia
 use crate::chunk::chunk_selective_ack::GapAckBlock;
 use crate::util::*;
 
+use bytes::Bytes;
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
+
+pub(crate) enum GapAck<'a> {
+    Duplicate,
+    New {
+        chunk: &'a ChunkPayloadData,
+        released_buffer: usize,
+        delivery_credit: usize,
+    },
+}
 
 /// Most messages fit in a single DATA chunk. Keep that TSN in the index itself
 /// rather than allocating a separate collection on every send and SACK.
@@ -229,25 +239,27 @@ impl PayloadQueue {
         s
     }
 
-    pub(crate) fn acknowledge(&mut self, tsn: u32) -> bool {
-        let Some(c) = self.chunk_map.get_mut(&tsn) else {
-            return false;
-        };
+    /// Apply a gap ACK and return its accounting and metadata in one lookup.
+    /// Retain the payload because a gap ACK can still be revoked. Repeated ACKs
+    /// do not change recovery state or return either kind of credit again.
+    #[inline]
+    pub(crate) fn acknowledge(&mut self, tsn: u32) -> Option<GapAck<'_>> {
+        let c = self.chunk_map.get_mut(&tsn)?;
+        if c.acknowledged {
+            return Some(GapAck::Duplicate);
+        }
         if c.is_outstanding() {
             self.outstanding_bytes -= c.user_data.len();
         }
-        c.acknowledge()
-    }
-
-    /// A gap ACK can be revoked. Retain its Bytes until cumulative ACK or
-    /// abandonment while returning the existing API's buffer credit once.
-    pub(crate) fn release_buffer(&mut self, tsn: u32) -> usize {
-        let Some(c) = self.chunk_map.get_mut(&tsn) else {
-            return 0;
-        };
-        let released = c.release_buffer();
-        self.buffered_bytes -= released;
-        released
+        c.acknowledge();
+        let released_buffer = c.release_buffer();
+        self.buffered_bytes -= released_buffer;
+        let delivery_credit = c.take_delivery_credit();
+        Some(GapAck::New {
+            chunk: c,
+            released_buffer,
+            delivery_credit,
+        })
     }
 
     pub(crate) fn revoke_gap_ack(&mut self, tsn: u32) -> bool {
@@ -275,7 +287,9 @@ impl PayloadQueue {
         let released = c.release_buffer();
         self.buffered_bytes -= released;
         self.n_bytes -= c.user_data.len();
-        c.user_data.clear();
+        // Bytes::clear() retains the backing allocation. Abandonment is final,
+        // so keep only the TSN/message metadata needed for FORWARD TSN and ACKs.
+        c.user_data = Bytes::new();
         (changed, released)
     }
 

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -1,6 +1,5 @@
 use crate::chunk::chunk_payload_data::{ChunkPayloadData, MessageId, MessageReliability};
-use crate::chunk::chunk_selective_ack::GapAckBlock;
-use crate::util::*;
+use crate::util::sna32lt;
 
 use bytes::Bytes;
 use rustc_hash::FxHashMap;
@@ -69,19 +68,24 @@ impl MessageTsns {
     }
 }
 
+/// Sending credit follows the original DATA size, even when its payload can
+/// no longer be retransmitted and has been released after a revocable gap ACK.
+#[derive(Debug)]
+struct InflightData {
+    chunk: ChunkPayloadData,
+    payload_len: usize,
+}
+
 #[derive(Default, Debug)]
 pub(crate) struct PayloadQueue {
     // length: usize,
-    /// Keyed by TSN; per-chunk lookups on both the send (in-flight) and
-    /// receive paths. TSNs are window-bounded, so the faster non-SipHash
-    /// hasher is safe.
-    chunk_map: FxHashMap<u32, ChunkPayloadData>,
+    /// Keyed by TSN for sender in-flight lookups.
+    chunk_map: FxHashMap<u32, InflightData>,
     /// TSNs in serial-number order. A `VecDeque` so that `pop` — which almost
-    /// always removes the front, once per acked/received chunk — is O(1)
+    /// always removes the front, once per acked chunk — is O(1)
     /// instead of shifting the whole in-flight window left (`Vec::remove(0)`
     /// showed up as ~9% of the end-to-end transfer profile as memmove).
     pub(crate) sorted: VecDeque<u32>,
-    dup_tsn: Vec<u32>,
     n_bytes: usize,
     outstanding_bytes: usize,
     buffered_bytes: usize,
@@ -98,7 +102,7 @@ impl PayloadQueue {
     /// Insert `tsn` into `sorted`, keeping SCTP serial-number order. Binary-search
     /// the insertion point instead of re-sorting the whole vector on every push:
     /// re-sorting made a burst of N chunks O(N^2 log N). In-order arrivals — the
-    /// common case, since TSNs are assigned/received sequentially — land at the
+    /// common case, since TSNs are assigned sequentially — land at the
     /// end in O(1) amortized.
     fn insert_sorted(&mut self, tsn: u32) {
         if self.sorted.back().is_none_or(|last| sna32lt(*last, tsn)) {
@@ -107,10 +111,6 @@ impl PayloadQueue {
             let idx = self.sorted.partition_point(|&x| sna32lt(x, tsn));
             self.sorted.insert(idx, tsn);
         }
-    }
-
-    pub(crate) fn can_push(&self, p: &ChunkPayloadData, cumulative_tsn: u32) -> bool {
-        !(self.chunk_map.contains_key(&p.tsn) || sna32lte(p.tsn, cumulative_tsn))
     }
 
     fn abandonment_id(p: &ChunkPayloadData) -> Option<MessageId> {
@@ -138,34 +138,28 @@ impl PayloadQueue {
             self.buffered_bytes += p.user_data.len();
         }
         self.insert_sorted(p.tsn);
-        self.chunk_map.insert(p.tsn, p);
+        self.chunk_map.insert(
+            p.tsn,
+            InflightData {
+                payload_len: p.user_data.len(),
+                chunk: p,
+            },
+        );
         //self.length += 1;
     }
 
-    /// push pushes a payload data. If the payload data is already in our queue or
-    /// older than our cumulative_tsn marker, it will be recored as duplications,
-    /// which can later be retrieved using popDuplicates.
-    pub(crate) fn push(&mut self, p: ChunkPayloadData, cumulative_tsn: u32) -> bool {
-        let ok = self.chunk_map.contains_key(&p.tsn);
-        if ok || sna32lte(p.tsn, cumulative_tsn) {
-            // Found the packet, log in dups
-            self.dup_tsn.push(p.tsn);
-            return false;
-        }
-
-        self.push_no_check(p);
-
-        true
-    }
-
     /// pop pops only if the oldest chunk's TSN matches the given TSN.
-    // SACK/RX consumers use only some fields. Inline so they need not copy the
+    // SACK consumers use only some fields. Inline so they need not copy the
     // entire DATA metadata through a separate struct-return calling convention.
     #[inline(always)]
     pub(crate) fn pop(&mut self, tsn: u32) -> Option<ChunkPayloadData> {
         if self.sorted.front() == Some(&tsn) {
             self.sorted.pop_front();
-            if let Some(c) = self.chunk_map.remove(&tsn) {
+            if let Some(InflightData {
+                chunk: c,
+                payload_len,
+            }) = self.chunk_map.remove(&tsn)
+            {
                 if let Some(id) = Self::abandonment_id(&c) {
                     let tsns = self.message_tsns.get_mut(&id).unwrap();
                     if tsns.pop(tsn) {
@@ -174,10 +168,10 @@ impl PayloadQueue {
                 }
                 self.n_bytes -= c.user_data.len();
                 if c.is_outstanding() {
-                    self.outstanding_bytes -= c.user_data.len();
+                    self.outstanding_bytes -= payload_len;
                 }
                 if !c.buffer_released {
-                    self.buffered_bytes -= c.user_data.len();
+                    self.buffered_bytes -= payload_len;
                 }
                 return Some(c);
             }
@@ -194,67 +188,42 @@ impl PayloadQueue {
 
     /// get returns reference to chunkPayloadData with the given TSN value.
     pub(crate) fn get(&self, tsn: u32) -> Option<&ChunkPayloadData> {
-        self.chunk_map.get(&tsn)
+        self.chunk_map.get(&tsn).map(|data| &data.chunk)
     }
     pub(crate) fn get_mut(&mut self, tsn: u32) -> Option<&mut ChunkPayloadData> {
-        self.chunk_map.get_mut(&tsn)
+        self.chunk_map.get_mut(&tsn).map(|data| &mut data.chunk)
     }
 
-    /// popDuplicates returns an array of TSN values that were found duplicate.
-    pub(crate) fn pop_duplicates(&mut self) -> Vec<u32> {
-        std::mem::take(&mut self.dup_tsn)
-    }
-
-    pub(crate) fn get_gap_ack_blocks(&self, cumulative_tsn: u32) -> Vec<GapAckBlock> {
-        if self.chunk_map.is_empty() {
-            return vec![];
-        }
-
-        let mut blocks: Vec<GapAckBlock> = vec![];
-        for tsn in &self.sorted {
-            let offset = tsn.wrapping_sub(cumulative_tsn);
-            if offset == 0 || offset > u16::MAX as u32 {
-                continue; // This SACK cannot represent a larger gap offset.
-            }
-            let offset = offset as u16;
-            if let Some(last) = blocks.last_mut()
-                && last.end.checked_add(1) == Some(offset)
-            {
-                last.end = offset;
-            } else {
-                blocks.push(GapAckBlock {
-                    start: offset,
-                    end: offset,
-                });
-            }
-        }
-        blocks
-    }
-
-    pub(crate) fn get_gap_ack_blocks_string(&self, cumulative_tsn: u32) -> String {
-        let mut s = format!("cumTSN={}", cumulative_tsn);
-        for b in self.get_gap_ack_blocks(cumulative_tsn) {
-            s += format!(",{}-{}", b.start, b.end).as_str();
-        }
-        s
+    pub(crate) fn payload_len(&self, tsn: u32) -> Option<usize> {
+        self.chunk_map.get(&tsn).map(|data| data.payload_len)
     }
 
     /// Apply a gap ACK and return its accounting and metadata in one lookup.
-    /// Retain the payload because a gap ACK can still be revoked. Repeated ACKs
-    /// do not change recovery state or return either kind of credit again.
+    /// Retain retransmittable payload because a gap ACK can still be revoked.
+    /// An exhausted Rexmit policy forbids any future retransmission, so only
+    /// its metadata and original size need survive (RFC 7496 section 3.1).
+    /// Eviction does not abandon the message or affect its pending fragments.
+    /// Repeated ACKs do not change recovery state or return credit again.
     #[inline]
-    pub(crate) fn acknowledge(&mut self, tsn: u32) -> Option<GapAck<'_>> {
-        let c = self.chunk_map.get_mut(&tsn)?;
+    pub(crate) fn acknowledge(&mut self, tsn: u32, use_forward_tsn: bool) -> Option<GapAck<'_>> {
+        let data = self.chunk_map.get_mut(&tsn)?;
+        let c = &mut data.chunk;
         if c.acknowledged {
             return Some(GapAck::Duplicate);
         }
         if c.is_outstanding() {
-            self.outstanding_bytes -= c.user_data.len();
+            self.outstanding_bytes -= data.payload_len;
         }
         c.acknowledge();
         let released_buffer = c.release_buffer();
         self.buffered_bytes -= released_buffer;
         let delivery_credit = c.take_delivery_credit();
+        if use_forward_tsn
+            && matches!(c.reliability, MessageReliability::Rexmit { max_retransmits } if c.nsent > max_retransmits)
+        {
+            self.n_bytes -= c.user_data.len();
+            c.user_data = Bytes::new();
+        }
         Some(GapAck::New {
             chunk: c,
             released_buffer,
@@ -263,12 +232,13 @@ impl PayloadQueue {
     }
 
     pub(crate) fn revoke_gap_ack(&mut self, tsn: u32) -> bool {
-        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+        let Some(data) = self.chunk_map.get_mut(&tsn) else {
             return false;
         };
+        let c = &mut data.chunk;
         if c.acknowledged && !c.abandoned {
             c.acknowledged = false;
-            self.outstanding_bytes += c.user_data.len();
+            self.outstanding_bytes += data.payload_len;
             true
         } else {
             false
@@ -276,12 +246,13 @@ impl PayloadQueue {
     }
 
     pub(crate) fn abandon(&mut self, tsn: u32) -> (bool, usize) {
-        let Some(c) = self.chunk_map.get_mut(&tsn) else {
+        let Some(data) = self.chunk_map.get_mut(&tsn) else {
             return (false, 0);
         };
+        let c = &mut data.chunk;
         let changed = !c.abandoned;
         if c.is_outstanding() {
-            self.outstanding_bytes -= c.user_data.len();
+            self.outstanding_bytes -= data.payload_len;
         }
         c.mark_abandoned();
         let released = c.release_buffer();
@@ -293,12 +264,9 @@ impl PayloadQueue {
         (changed, released)
     }
 
-    pub(crate) fn get_last_tsn_received(&self) -> Option<&u32> {
-        self.sorted.back()
-    }
-
     pub(crate) fn mark_all_to_retrasmit(&mut self) {
-        for c in self.chunk_map.values_mut() {
+        for data in self.chunk_map.values_mut() {
+            let c = &mut data.chunk;
             if !c.is_outstanding() {
                 continue;
             }

--- a/rtc-sctp/src/queue/payload_queue.rs
+++ b/rtc-sctp/src/queue/payload_queue.rs
@@ -5,6 +5,10 @@ use bytes::Bytes;
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 
+#[cfg(test)]
+#[path = "payload_queue_model_test.rs"]
+mod model_test;
+
 pub(crate) enum GapAck<'a> {
     Duplicate,
     New {
@@ -78,14 +82,10 @@ struct InflightData {
 
 #[derive(Default, Debug)]
 pub(crate) struct PayloadQueue {
-    // length: usize,
-    /// Keyed by TSN for sender in-flight lookups.
-    chunk_map: FxHashMap<u32, InflightData>,
-    /// TSNs in serial-number order. A `VecDeque` so that `pop` — which almost
-    /// always removes the front, once per acked chunk — is O(1)
-    /// instead of shifting the whole in-flight window left (`Vec::remove(0)`
-    /// showed up as ~9% of the end-to-end transfer profile as memmove).
-    pub(crate) sorted: VecDeque<u32>,
+    /// Assigned DATA in serial TSN order, including acknowledged and abandoned
+    /// records retained until cumulative ACK. Sender assignment is contiguous;
+    /// ordered insertion also supports unique sparse/reordered queue users.
+    inflight: VecDeque<InflightData>,
     n_bytes: usize,
     outstanding_bytes: usize,
     buffered_bytes: usize,
@@ -99,17 +99,44 @@ impl PayloadQueue {
         PayloadQueue::default()
     }
 
-    /// Insert `tsn` into `sorted`, keeping SCTP serial-number order. Binary-search
-    /// the insertion point instead of re-sorting the whole vector on every push:
-    /// re-sorting made a burst of N chunks O(N^2 log N). In-order arrivals — the
-    /// common case, since TSNs are assigned sequentially — land at the
-    /// end in O(1) amortized.
-    fn insert_sorted(&mut self, tsn: u32) {
-        if self.sorted.back().is_none_or(|last| sna32lt(*last, tsn)) {
-            self.sorted.push_back(tsn);
+    /// Contiguous sender TSNs have a direct deque index. Check the stored TSN
+    /// before accepting it so sparse/reordered insertions need no empty slots.
+    fn position(&self, tsn: u32) -> Option<usize> {
+        let first = self.inflight.front()?;
+        let index = tsn.wrapping_sub(first.chunk.tsn) as usize;
+        if self
+            .inflight
+            .get(index)
+            .is_some_and(|data| data.chunk.tsn == tsn)
+        {
+            return Some(index);
+        }
+        let index = self
+            .inflight
+            .partition_point(|data| sna32lt(data.chunk.tsn, tsn));
+        self.inflight
+            .get(index)
+            .filter(|data| data.chunk.tsn == tsn)
+            .map(|_| index)
+    }
+
+    pub(crate) fn tsns(&self) -> impl Iterator<Item = u32> + '_ {
+        self.inflight.iter().map(|data| data.chunk.tsn)
+    }
+
+    fn insert_sorted(&mut self, data: InflightData) {
+        let tsn = data.chunk.tsn;
+        if self
+            .inflight
+            .back()
+            .is_none_or(|last| sna32lt(last.chunk.tsn, tsn))
+        {
+            self.inflight.push_back(data);
         } else {
-            let idx = self.sorted.partition_point(|&x| sna32lt(x, tsn));
-            self.sorted.insert(idx, tsn);
+            let index = self
+                .inflight
+                .partition_point(|item| sna32lt(item.chunk.tsn, tsn));
+            self.inflight.insert(index, data);
         }
     }
 
@@ -123,7 +150,12 @@ impl PayloadQueue {
         }
     }
 
+    /// The caller must not insert a TSN already retained in the queue.
     pub(crate) fn push_no_check(&mut self, p: ChunkPayloadData) {
+        debug_assert!(
+            self.position(p.tsn).is_none(),
+            "inflight TSNs must be unique"
+        );
         if let Some(id) = Self::abandonment_id(&p) {
             self.message_tsns
                 .entry(id)
@@ -137,15 +169,10 @@ impl PayloadQueue {
         if !p.buffer_released {
             self.buffered_bytes += p.user_data.len();
         }
-        self.insert_sorted(p.tsn);
-        self.chunk_map.insert(
-            p.tsn,
-            InflightData {
-                payload_len: p.user_data.len(),
-                chunk: p,
-            },
-        );
-        //self.length += 1;
+        self.insert_sorted(InflightData {
+            payload_len: p.user_data.len(),
+            chunk: p,
+        });
     }
 
     /// pop pops only if the oldest chunk's TSN matches the given TSN.
@@ -153,31 +180,27 @@ impl PayloadQueue {
     // entire DATA metadata through a separate struct-return calling convention.
     #[inline(always)]
     pub(crate) fn pop(&mut self, tsn: u32) -> Option<ChunkPayloadData> {
-        if self.sorted.front() == Some(&tsn) {
-            self.sorted.pop_front();
-            if let Some(InflightData {
-                chunk: c,
-                payload_len,
-            }) = self.chunk_map.remove(&tsn)
-            {
-                if let Some(id) = Self::abandonment_id(&c) {
-                    let tsns = self.message_tsns.get_mut(&id).unwrap();
-                    if tsns.pop(tsn) {
-                        self.message_tsns.remove(&id);
-                    }
-                }
-                self.n_bytes -= c.user_data.len();
-                if c.is_outstanding() {
-                    self.outstanding_bytes -= payload_len;
-                }
-                if !c.buffer_released {
-                    self.buffered_bytes -= payload_len;
-                }
-                return Some(c);
+        if self.inflight.front().map(|data| data.chunk.tsn) != Some(tsn) {
+            return None;
+        }
+        let InflightData {
+            chunk: c,
+            payload_len,
+        } = self.inflight.pop_front()?;
+        if let Some(id) = Self::abandonment_id(&c) {
+            let tsns = self.message_tsns.get_mut(&id).unwrap();
+            if tsns.pop(tsn) {
+                self.message_tsns.remove(&id);
             }
         }
-
-        None
+        self.n_bytes -= c.user_data.len();
+        if c.is_outstanding() {
+            self.outstanding_bytes -= payload_len;
+        }
+        if !c.buffer_released {
+            self.buffered_bytes -= payload_len;
+        }
+        Some(c)
     }
 
     pub(crate) fn message_tsns(&self, id: MessageId) -> Vec<u32> {
@@ -188,14 +211,17 @@ impl PayloadQueue {
 
     /// get returns reference to chunkPayloadData with the given TSN value.
     pub(crate) fn get(&self, tsn: u32) -> Option<&ChunkPayloadData> {
-        self.chunk_map.get(&tsn).map(|data| &data.chunk)
+        let index = self.position(tsn)?;
+        Some(&self.inflight[index].chunk)
     }
     pub(crate) fn get_mut(&mut self, tsn: u32) -> Option<&mut ChunkPayloadData> {
-        self.chunk_map.get_mut(&tsn).map(|data| &mut data.chunk)
+        let index = self.position(tsn)?;
+        Some(&mut self.inflight[index].chunk)
     }
 
     pub(crate) fn payload_len(&self, tsn: u32) -> Option<usize> {
-        self.chunk_map.get(&tsn).map(|data| data.payload_len)
+        let index = self.position(tsn)?;
+        Some(self.inflight[index].payload_len)
     }
 
     /// Apply a gap ACK and return its accounting and metadata in one lookup.
@@ -206,7 +232,8 @@ impl PayloadQueue {
     /// Repeated ACKs do not change recovery state or return credit again.
     #[inline]
     pub(crate) fn acknowledge(&mut self, tsn: u32, use_forward_tsn: bool) -> Option<GapAck<'_>> {
-        let data = self.chunk_map.get_mut(&tsn)?;
+        let index = self.position(tsn)?;
+        let data = &mut self.inflight[index];
         let c = &mut data.chunk;
         if c.acknowledged {
             return Some(GapAck::Duplicate);
@@ -232,9 +259,10 @@ impl PayloadQueue {
     }
 
     pub(crate) fn revoke_gap_ack(&mut self, tsn: u32) -> bool {
-        let Some(data) = self.chunk_map.get_mut(&tsn) else {
+        let Some(index) = self.position(tsn) else {
             return false;
         };
+        let data = &mut self.inflight[index];
         let c = &mut data.chunk;
         if c.acknowledged && !c.abandoned {
             c.acknowledged = false;
@@ -246,9 +274,10 @@ impl PayloadQueue {
     }
 
     pub(crate) fn abandon(&mut self, tsn: u32) -> (bool, usize) {
-        let Some(data) = self.chunk_map.get_mut(&tsn) else {
+        let Some(index) = self.position(tsn) else {
             return (false, 0);
         };
+        let data = &mut self.inflight[index];
         let c = &mut data.chunk;
         let changed = !c.abandoned;
         if c.is_outstanding() {
@@ -265,7 +294,7 @@ impl PayloadQueue {
     }
 
     pub(crate) fn mark_all_to_retrasmit(&mut self) {
-        for data in self.chunk_map.values_mut() {
+        for data in &mut self.inflight {
             let c = &mut data.chunk;
             if !c.is_outstanding() {
                 continue;
@@ -287,8 +316,7 @@ impl PayloadQueue {
     }
 
     pub(crate) fn len(&self) -> usize {
-        //assert_eq!(self.chunk_map.len(), self.length);
-        self.chunk_map.len()
+        self.inflight.len()
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/rtc-sctp/src/queue/payload_queue_model_test.rs
+++ b/rtc-sctp/src/queue/payload_queue_model_test.rs
@@ -1,0 +1,356 @@
+use super::{ChunkPayloadData, GapAck, MessageReliability, PayloadQueue};
+use bytes::Bytes;
+use std::collections::{BTreeMap, BTreeSet};
+
+// The oracle keys are unwrapped, signed positions chosen by the test. Ordering
+// and membership use BTreeMap, independently of SCTP serial comparisons and
+// the queue's checked-offset/binary-search lookup implementation.
+fn wire(origin: u32, position: i64) -> u32 {
+    (i64::from(origin) + position).rem_euclid(1_i64 << 32) as u32
+}
+
+#[derive(Clone)]
+struct ExpectedData {
+    len: usize,
+    byte: u8,
+    miss: u32,
+    exhausted: bool,
+}
+
+impl ExpectedData {
+    fn new(position: i64, exhausted: bool) -> Self {
+        Self {
+            len: 7 + position.rem_euclid(31) as usize,
+            byte: position.rem_euclid(251) as u8,
+            miss: 0,
+            exhausted,
+        }
+    }
+
+    fn chunk(&self, tsn: u32) -> ChunkPayloadData {
+        ChunkPayloadData {
+            tsn,
+            beginning_fragment: true,
+            ending_fragment: true,
+            nsent: 1,
+            user_data: Bytes::from(vec![self.byte; self.len]),
+            reliability: if self.exhausted {
+                MessageReliability::Rexmit { max_retransmits: 0 }
+            } else {
+                MessageReliability::Reliable
+            },
+            ..Default::default()
+        }
+    }
+}
+
+fn insert(
+    queue: &mut PayloadQueue,
+    expected: &mut BTreeMap<i64, ExpectedData>,
+    origin: u32,
+    position: i64,
+    exhausted: bool,
+) {
+    let data = ExpectedData::new(position, exhausted);
+    queue.push_no_check(data.chunk(wire(origin, position)));
+    assert!(expected.insert(position, data).is_none());
+}
+
+fn assert_unacknowledged_model(
+    queue: &PayloadQueue,
+    expected: &BTreeMap<i64, ExpectedData>,
+    origin: u32,
+    last_probe: i64,
+) {
+    assert_eq!(
+        queue.tsns().collect::<Vec<_>>(),
+        expected
+            .keys()
+            .map(|&p| wire(origin, p))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(queue.len(), expected.len());
+    assert_eq!(queue.is_empty(), expected.is_empty());
+    let bytes: usize = expected.values().map(|data| data.len).sum();
+    assert_eq!(queue.get_num_bytes(), bytes);
+    assert_eq!(queue.outstanding_bytes(), bytes);
+    assert_eq!(queue.buffered_bytes(), bytes);
+    for position in -3..=last_probe {
+        let tsn = wire(origin, position);
+        assert_eq!(
+            queue.payload_len(tsn),
+            expected.get(&position).map(|data| data.len),
+            "original length at {origin}/{position}"
+        );
+        match (queue.get(tsn), expected.get(&position)) {
+            (Some(actual), Some(data)) => {
+                assert_eq!(actual.tsn, tsn);
+                assert_eq!(actual.user_data.as_ref(), vec![data.byte; data.len]);
+                assert_eq!(actual.miss_indicator, data.miss);
+                assert!(actual.is_outstanding());
+            }
+            (None, None) => {}
+            _ => panic!("membership differs at {origin}/{position}"),
+        }
+    }
+}
+
+fn pop_model_front(
+    queue: &mut PayloadQueue,
+    expected: &mut BTreeMap<i64, ExpectedData>,
+    origin: u32,
+) {
+    let (position, data) = expected.pop_first().unwrap();
+    let tsn = wire(origin, position);
+    let popped = queue.pop(tsn).expect("model front must pop");
+    assert_eq!(popped.tsn, tsn);
+    assert_eq!(popped.user_data.as_ref(), vec![data.byte; data.len]);
+    assert_eq!(popped.miss_indicator, data.miss);
+    assert!(queue.get(tsn).is_none());
+    assert!(queue.get_mut(tsn).is_none());
+    assert_eq!(queue.payload_len(tsn), None);
+}
+
+#[test]
+fn dense_and_sparse_inflight_match_serial_model_through_wrap_and_prefix_churn() {
+    for origin in [4096, u32::MAX - 16] {
+        let mut queue = PayloadQueue::default();
+        let mut expected = BTreeMap::new();
+        // At [0,4,9], querying 1 has an in-bounds direct candidate belonging to
+        // TSN 4. It must miss, and querying 4 must find the sparse fallback.
+        for position in [0, 4, 9, 1, 3, 8, 2, 7, 6, 5] {
+            insert(&mut queue, &mut expected, origin, position, false);
+            assert_unacknowledged_model(&queue, &expected, origin, 12);
+            assert!(queue.get_mut(wire(origin, 11)).is_none());
+        }
+        for position in 10..512 {
+            insert(&mut queue, &mut expected, origin, position, false);
+        }
+        for position in [1, 4, 127, 511] {
+            let miss = 1000 + position as u32;
+            queue
+                .get_mut(wire(origin, position))
+                .unwrap()
+                .miss_indicator = miss;
+            expected.get_mut(&position).unwrap().miss = miss;
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 514);
+        for wrong in [-1, 7, 511, 512] {
+            assert!(queue.pop(wire(origin, wrong)).is_none());
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 514);
+
+        // Repeated front removal and tail appending exercises a wrapped deque
+        // buffer as well as a wrapped wire TSN. No permanent insertion base is
+        // a valid lookup base once the prefix starts moving.
+        for position in 512..1536 {
+            pop_model_front(&mut queue, &mut expected, origin);
+            insert(&mut queue, &mut expected, origin, position, false);
+            if position % 113 == 0 {
+                assert_unacknowledged_model(&queue, &expected, origin, position + 2);
+            }
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 1538);
+        while !expected.is_empty() {
+            pop_model_front(&mut queue, &mut expected, origin);
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 1538);
+
+        // An empty queue accepts a fresh base independently of the last TSN it
+        // held. This also represents acknowledged TSN-cycle elision in tests.
+        let fresh_origin = origin.wrapping_add(1 << 31);
+        for position in [0, 3, 1, 2] {
+            insert(&mut queue, &mut expected, fresh_origin, position, false);
+        }
+        assert_unacknowledged_model(&queue, &expected, fresh_origin, 6);
+        // Association close replaces the whole queue, even with live entries.
+        queue = PayloadQueue::default();
+        expected.clear();
+        assert_unacknowledged_model(&queue, &expected, origin, 6);
+        for position in [2, 0, 1] {
+            insert(&mut queue, &mut expected, origin, position, false);
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 6);
+        while !expected.is_empty() {
+            pop_model_front(&mut queue, &mut expected, origin);
+        }
+        assert_unacknowledged_model(&queue, &expected, origin, 6);
+    }
+}
+
+#[derive(Default)]
+struct ReceiptModel {
+    acknowledged: BTreeSet<i64>,
+    buffer_released: BTreeSet<i64>,
+    delivery_credited: BTreeSet<i64>,
+    payload_freed: BTreeSet<i64>,
+    abandoned: BTreeSet<i64>,
+}
+
+fn assert_receipt_model(
+    queue: &PayloadQueue,
+    expected: &BTreeMap<i64, ExpectedData>,
+    origin: u32,
+    receipts: &ReceiptModel,
+) {
+    assert_eq!(
+        queue.tsns().collect::<Vec<_>>(),
+        expected
+            .keys()
+            .map(|&p| wire(origin, p))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(queue.len(), expected.len());
+    assert_eq!(queue.is_empty(), expected.is_empty());
+    let sum = |include: &dyn Fn(i64) -> bool| -> usize {
+        expected
+            .iter()
+            .filter(|(position, _)| include(**position))
+            .map(|(_, data)| data.len)
+            .sum()
+    };
+    assert_eq!(
+        queue.get_num_bytes(),
+        sum(&|p| !receipts.payload_freed.contains(&p))
+    );
+    assert_eq!(
+        queue.buffered_bytes(),
+        sum(&|p| !receipts.buffer_released.contains(&p))
+    );
+    assert_eq!(
+        queue.outstanding_bytes(),
+        sum(&|p| !receipts.acknowledged.contains(&p) && !receipts.abandoned.contains(&p))
+    );
+    for (&position, data) in expected {
+        let tsn = wire(origin, position);
+        let chunk = queue.get(tsn).unwrap();
+        assert_eq!(chunk.tsn, tsn);
+        assert_eq!(queue.payload_len(tsn), Some(data.len));
+        assert_eq!(
+            chunk.acknowledged,
+            receipts.acknowledged.contains(&position)
+        );
+        assert_eq!(
+            chunk.buffer_released,
+            receipts.buffer_released.contains(&position)
+        );
+        assert_eq!(
+            chunk.delivery_credited,
+            receipts.delivery_credited.contains(&position)
+        );
+        assert_eq!(chunk.abandoned, receipts.abandoned.contains(&position));
+        if receipts.payload_freed.contains(&position) {
+            assert!(chunk.user_data.is_empty());
+        } else {
+            assert_eq!(chunk.user_data.as_ref(), vec![data.byte; data.len]);
+        }
+    }
+}
+
+fn expect_new_ack(queue: &mut PayloadQueue, tsn: u32, released: usize, credited: usize) {
+    match queue.acknowledge(tsn, true) {
+        Some(GapAck::New {
+            chunk,
+            released_buffer,
+            delivery_credit,
+        }) => {
+            assert_eq!(chunk.tsn, tsn);
+            assert!(chunk.acknowledged);
+            assert!(!chunk.retransmit);
+            assert_eq!(chunk.miss_indicator, 0);
+            assert_eq!(released_buffer, released);
+            assert_eq!(delivery_credit, credited);
+        }
+        _ => panic!("expected a first receipt or reACK for {tsn}"),
+    }
+}
+
+#[test]
+fn sparse_lookup_preserves_original_debt_and_once_only_credit_after_reack() {
+    for origin in [8192, u32::MAX - 5] {
+        let mut queue = PayloadQueue::default();
+        let mut expected = BTreeMap::new();
+        let mut receipts = ReceiptModel::default();
+        for position in [0, 6, 12, 1, 4, 10] {
+            insert(&mut queue, &mut expected, origin, position, position == 4);
+        }
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+        queue.mark_all_to_retrasmit();
+        for position in [4, 10] {
+            let len = expected[&position].len;
+            expect_new_ack(&mut queue, wire(origin, position), len, len);
+            receipts.acknowledged.insert(position);
+            receipts.buffer_released.insert(position);
+            receipts.delivery_credited.insert(position);
+        }
+        receipts.payload_freed.insert(4); // Only exhausted Rexmit(0) can evict on gap ACK.
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+        for position in [4, 10] {
+            assert!(matches!(
+                queue.acknowledge(wire(origin, position), true),
+                Some(GapAck::Duplicate)
+            ));
+        }
+        // In-bounds wrong candidates and missing fallbacks must not mutate a
+        // neighboring DATA record through any indexed accounting operation.
+        for position in [-1, 2, 5, 7, 11, 13] {
+            let tsn = wire(origin, position);
+            assert!(queue.get_mut(tsn).is_none());
+            assert!(queue.acknowledge(tsn, true).is_none());
+            assert!(!queue.revoke_gap_ack(tsn));
+            assert_eq!(queue.abandon(tsn), (false, 0));
+            assert!(queue.pop(tsn).is_none());
+        }
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+
+        assert!(queue.revoke_gap_ack(wire(origin, 4)));
+        receipts.acknowledged.remove(&4);
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+        assert!(!queue.revoke_gap_ack(wire(origin, 4)));
+        queue.get_mut(wire(origin, 4)).unwrap().miss_indicator = 2;
+        expect_new_ack(&mut queue, wire(origin, 4), 0, 0);
+        receipts.acknowledged.insert(4);
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+
+        assert_eq!(queue.abandon(wire(origin, 6)), (true, expected[&6].len));
+        receipts.abandoned.insert(6);
+        receipts.buffer_released.insert(6);
+        receipts.payload_freed.insert(6);
+        assert_eq!(queue.abandon(wire(origin, 6)), (false, 0));
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+
+        assert!(queue.revoke_gap_ack(wire(origin, 10)));
+        receipts.acknowledged.remove(&10);
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+        expect_new_ack(&mut queue, wire(origin, 10), 0, 0);
+        receipts.acknowledged.insert(10);
+        assert_eq!(queue.abandon(wire(origin, 10)), (true, 0));
+        receipts.abandoned.insert(10);
+        receipts.payload_freed.insert(10);
+        assert!(!queue.revoke_gap_ack(wire(origin, 10)));
+        assert!(matches!(
+            queue.acknowledge(wire(origin, 10), true),
+            Some(GapAck::Duplicate)
+        ));
+        expect_new_ack(&mut queue, wire(origin, 6), 0, 0);
+        receipts.acknowledged.insert(6);
+        receipts.delivery_credited.insert(6);
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+
+        assert!(queue.pop(wire(origin, 4)).is_none());
+        assert_receipt_model(&queue, &expected, origin, &receipts);
+        while let Some((position, data)) = expected.pop_first() {
+            let tsn = wire(origin, position);
+            let popped = queue.pop(tsn).unwrap();
+            assert_eq!(popped.tsn, tsn);
+            if receipts.payload_freed.contains(&position) {
+                assert!(popped.user_data.is_empty());
+            } else {
+                assert_eq!(popped.user_data.as_ref(), vec![data.byte; data.len]);
+            }
+            assert!(queue.get(tsn).is_none());
+            assert_eq!(queue.payload_len(tsn), None);
+            assert_receipt_model(&queue, &expected, origin, &receipts);
+        }
+    }
+}

--- a/rtc-sctp/src/queue/payload_queue_shrink_test.rs
+++ b/rtc-sctp/src/queue/payload_queue_shrink_test.rs
@@ -1,0 +1,209 @@
+use super::{ChunkPayloadData, GapAck, MessageId, MessageReliability, PayloadQueue};
+use bytes::Bytes;
+
+fn whole(tsn: u32, size: usize) -> ChunkPayloadData {
+    ChunkPayloadData {
+        tsn,
+        beginning_fragment: true,
+        ending_fragment: true,
+        nsent: 1,
+        user_data: Bytes::from(vec![0x5a; size]),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn cumulative_shrink_keeps_busy_and_small_queues_and_leaves_headroom() {
+    let mut queue = PayloadQueue::default();
+    queue.inflight.reserve(8192);
+    let original_capacity = queue.inflight.capacity();
+    assert!(original_capacity > 4096);
+    let quarter = original_capacity / 4;
+    for tsn in 0..=quarter as u32 {
+        queue.push_no_check(whole(tsn, 1));
+    }
+
+    queue.shrink_after_cumulative_ack();
+    assert_eq!(queue.inflight.capacity(), original_capacity);
+    assert!(queue.pop(0).is_some());
+    // Individual pops must not resize the allocation.
+    assert_eq!(queue.inflight.capacity(), original_capacity);
+    queue.shrink_after_cumulative_ack();
+    let smaller = queue.inflight.capacity();
+    assert!(smaller < original_capacity);
+    assert!(smaller >= 2 * queue.len());
+    assert_eq!(queue.get_num_bytes(), quarter);
+    assert_eq!(queue.outstanding_bytes(), quarter);
+    assert_eq!(queue.buffered_bytes(), quarter);
+    queue.shrink_after_cumulative_ack();
+    assert_eq!(queue.inflight.capacity(), smaller);
+
+    let mut empty = PayloadQueue::default();
+    empty.inflight.reserve(8192);
+    let empty_before = empty.inflight.capacity();
+    empty.shrink_after_cumulative_ack();
+    assert!(empty.inflight.capacity() < empty_before);
+    assert!(empty.inflight.capacity() >= 1024);
+    let floor_capacity = empty.inflight.capacity();
+    empty.shrink_after_cumulative_ack();
+    assert_eq!(empty.inflight.capacity(), floor_capacity);
+
+    let mut small = PayloadQueue::default();
+    small.inflight.reserve(4096);
+    assert_eq!(small.inflight.capacity(), 4096);
+    small.shrink_after_cumulative_ack();
+    assert_eq!(small.inflight.capacity(), 4096);
+}
+
+#[test]
+fn cumulative_shrink_preserves_wrapped_sparse_entries_and_original_byte_credit() {
+    for wrap_tsn in [false, true] {
+        let mut queue = PayloadQueue::default();
+        queue.inflight.reserve(8192);
+        let capacity = queue.inflight.capacity();
+        let first_position = capacity as u32 - 4;
+        let origin = if wrap_tsn {
+            u32::MAX - (capacity as u32 - 2)
+        } else {
+            4096
+        };
+        let tsn = |position: u32| origin.wrapping_add(position);
+        let size = |position: u32| 11 + (position % 7) as usize;
+        let positions = [
+            first_position,
+            first_position + 1,
+            first_position + 2,
+            first_position + 3,
+            first_position + 5,
+            first_position + 6,
+            first_position + 10,
+        ];
+        let id = MessageId::new(42);
+        let make = |position: u32| {
+            let mut chunk = whole(tsn(position), size(position));
+            chunk.stream_identifier = 7;
+            chunk.stream_generation = 11;
+            chunk.stream_sequence_number = 8;
+            chunk.miss_indicator = position % 3;
+            if position == first_position || position == first_position + 2 {
+                chunk.message_id = Some(id);
+                chunk.beginning_fragment = position == first_position;
+                chunk.ending_fragment = position == first_position + 2;
+                chunk.reliability = MessageReliability::Rexmit { max_retransmits: 0 };
+            }
+            chunk
+        };
+        for position in 0..capacity as u32 {
+            queue.push_no_check(make(position));
+        }
+        for position in 0..first_position {
+            assert!(queue.pop(tsn(position)).is_some());
+        }
+        // Append across the physical ring boundary, then insert into its sparse tail.
+        for position in [positions[5], positions[6], positions[4]] {
+            queue.push_no_check(make(position));
+        }
+        assert!(!queue.inflight.as_slices().1.is_empty());
+        let expected_tsns: Vec<_> = positions.iter().map(|&p| tsn(p)).collect();
+        assert_eq!(queue.tsns().collect::<Vec<_>>(), expected_tsns);
+        let missing = tsn(first_position + 4);
+        assert!(queue.get(missing).is_none());
+        assert!(queue.get_mut(missing).is_none());
+        assert_eq!(queue.payload_len(missing), None);
+        assert!(queue.pop(expected_tsns[1]).is_none());
+
+        let evicted = expected_tsns[0];
+        let reliable = expected_tsns[1];
+        for (acked, expected_len) in [
+            (evicted, size(positions[0])),
+            (reliable, size(positions[1])),
+        ] {
+            let Some(GapAck::New {
+                released_buffer,
+                delivery_credit,
+                ..
+            }) = queue.acknowledge(acked, true)
+            else {
+                panic!("the first acknowledgment must grant its original credit");
+            };
+            assert_eq!(released_buffer, expected_len);
+            assert_eq!(delivery_credit, expected_len);
+        }
+        let abandoned = expected_tsns[3];
+        assert_eq!(queue.abandon(abandoned), (true, size(positions[3])));
+        let original_bytes: usize = positions.iter().map(|&p| size(p)).sum();
+        let outstanding =
+            original_bytes - size(positions[0]) - size(positions[1]) - size(positions[3]);
+        let retained = original_bytes - size(positions[0]) - size(positions[3]);
+        assert_eq!(queue.get_num_bytes(), retained);
+        assert_eq!(queue.outstanding_bytes(), outstanding);
+        assert_eq!(queue.buffered_bytes(), outstanding);
+        let describe = |queue: &PayloadQueue| {
+            expected_tsns
+                .iter()
+                .map(|&tsn| {
+                    let chunk = queue.get(tsn).unwrap();
+                    (format!("{chunk:?}"), chunk.user_data.as_ptr() as usize)
+                })
+                .collect::<Vec<_>>()
+        };
+        let before_entries = describe(&queue);
+        queue.shrink_after_cumulative_ack();
+        let shrunk_capacity = queue.inflight.capacity();
+        assert!(shrunk_capacity < capacity);
+        assert!(shrunk_capacity >= 1024);
+        assert_eq!(describe(&queue), before_entries);
+        assert_eq!(queue.tsns().collect::<Vec<_>>(), expected_tsns);
+        assert_eq!(
+            queue.message_tsns(id),
+            vec![expected_tsns[0], expected_tsns[2]]
+        );
+        assert_eq!(queue.get_num_bytes(), retained);
+        assert_eq!(queue.outstanding_bytes(), outstanding);
+        assert_eq!(queue.buffered_bytes(), outstanding);
+        assert!(queue.get(missing).is_none());
+        assert!(queue.get_mut(missing).is_none());
+        assert_eq!(queue.payload_len(missing), None);
+        for &position in &positions {
+            assert_eq!(queue.payload_len(tsn(position)), Some(size(position)));
+        }
+
+        assert!(queue.revoke_gap_ack(evicted));
+        assert_eq!(queue.outstanding_bytes(), outstanding + size(positions[0]));
+        assert_eq!(queue.get_num_bytes(), retained);
+        assert_eq!(queue.buffered_bytes(), outstanding);
+        assert!(queue.get(evicted).unwrap().user_data.is_empty());
+        assert!(queue.revoke_gap_ack(reliable));
+        queue.mark_all_to_retrasmit();
+        let retry = queue.get(reliable).unwrap();
+        assert!(retry.retransmit);
+        assert_eq!(retry.user_data.as_ref(), vec![0x5a; size(positions[1])]);
+        for acked in [evicted, reliable] {
+            let Some(GapAck::New {
+                released_buffer,
+                delivery_credit,
+                ..
+            }) = queue.acknowledge(acked, true)
+            else {
+                panic!("a revoked ACK must be accepted again");
+            };
+            assert_eq!((released_buffer, delivery_credit), (0, 0));
+            assert!(matches!(
+                queue.acknowledge(acked, true),
+                Some(GapAck::Duplicate)
+            ));
+        }
+        assert_eq!(queue.inflight.capacity(), shrunk_capacity);
+        assert_eq!(queue.outstanding_bytes(), outstanding);
+        assert_eq!(queue.buffered_bytes(), outstanding);
+        assert_eq!(queue.get_num_bytes(), retained);
+        for expected in expected_tsns {
+            assert_eq!(queue.pop(expected).unwrap().tsn, expected);
+        }
+        assert!(queue.is_empty());
+        assert!(queue.message_tsns(id).is_empty());
+        assert_eq!(queue.get_num_bytes(), 0);
+        assert_eq!(queue.outstanding_bytes(), 0);
+        assert_eq!(queue.buffered_bytes(), 0);
+    }
+}

--- a/rtc-sctp/src/queue/pending_queue.rs
+++ b/rtc-sctp/src/queue/pending_queue.rs
@@ -1,52 +1,608 @@
-use crate::chunk::chunk_payload_data::ChunkPayloadData;
+use super::receive_queue::ReceiveEpoch;
+use crate::chunk::chunk_payload_data::{
+    ChunkPayloadData, MessageId, MessageReliability, PayloadProtocolIdentifier,
+};
+use rustc_hash::FxHashMap;
+use slab::Slab;
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 
-/// pendingBaseQueue
 pub(crate) type PendingBaseQueue = VecDeque<ChunkPayloadData>;
 
-/// pendingQueue
+/// Ownership and policy remain available after the first fragment is sent or
+/// the API stream closes. Later fragments cannot replace this message snapshot.
+#[derive(Debug, Copy, Clone)]
+struct MessageSnapshot {
+    id: Option<MessageId>,
+    stream_identifier: u16,
+    stream_generation: u64,
+    unordered: bool,
+    payload_type: PayloadProtocolIdentifier,
+    reliability: MessageReliability,
+}
+
+impl MessageSnapshot {
+    fn from_chunk(c: &ChunkPayloadData) -> Self {
+        Self {
+            id: c.message_id,
+            stream_identifier: c.stream_identifier,
+            stream_generation: c.stream_generation,
+            unordered: c.unordered,
+            payload_type: c.payload_type,
+            reliability: c.reliability,
+        }
+    }
+
+    fn apply(&self, c: &mut ChunkPayloadData) {
+        debug_assert_eq!(self.id, c.message_id);
+        debug_assert_eq!(self.stream_identifier, c.stream_identifier);
+        debug_assert_eq!(self.stream_generation, c.stream_generation);
+        debug_assert_eq!(self.unordered, c.unordered);
+        c.payload_type = self.payload_type;
+        c.reliability = self.reliability;
+    }
+}
+
+/// One message owns its complete unsent tail. Unfragmented messages stay inline
+/// to avoid allocating a fragment deque for every small application write.
+#[derive(Debug)]
+enum QueuedMessage {
+    Whole(ChunkPayloadData),
+    Fragmented {
+        snapshot: MessageSnapshot,
+        fragments: PendingBaseQueue,
+        /// Position of the next fragment, including those already transmitted.
+        next_fragment: usize,
+        /// The ending fragment has been enqueued, even if the head was sent.
+        complete: bool,
+        bytes: usize,
+    },
+}
+
+impl QueuedMessage {
+    fn new(c: ChunkPayloadData) -> Self {
+        if c.beginning_fragment && c.ending_fragment {
+            Self::Whole(c)
+        } else {
+            Self::Fragmented {
+                snapshot: MessageSnapshot::from_chunk(&c),
+                complete: c.ending_fragment,
+                bytes: c.user_data.len(),
+                fragments: VecDeque::from([c]),
+                next_fragment: 0,
+            }
+        }
+    }
+
+    fn snapshot(&self) -> MessageSnapshot {
+        match self {
+            Self::Whole(c) => MessageSnapshot::from_chunk(c),
+            Self::Fragmented { snapshot, .. } => *snapshot,
+        }
+    }
+
+    /// Only Timed whole messages can expire before their first transmission.
+    /// Rexmit and Reliable whole messages need no pending group lookup.
+    fn indexed_id(&self) -> Option<MessageId> {
+        match self {
+            Self::Whole(c) if !matches!(c.reliability, MessageReliability::Timed { .. }) => None,
+            Self::Whole(c) => c.message_id,
+            Self::Fragmented { snapshot, .. } => snapshot.id,
+        }
+    }
+
+    fn accepts_anonymous_fragment(&self, c: &ChunkPayloadData) -> bool {
+        matches!(
+            self,
+            Self::Fragmented {
+                complete: false,
+                ..
+            }
+        ) && self.snapshot().id.is_none()
+            && self.snapshot().stream_identifier == c.stream_identifier
+            && self.snapshot().stream_generation == c.stream_generation
+            && self.snapshot().unordered == c.unordered
+    }
+
+    fn push_fragment(&mut self, mut c: ChunkPayloadData) {
+        let Self::Fragmented {
+            snapshot,
+            fragments,
+            complete,
+            bytes,
+            ..
+        } = self
+        else {
+            panic!("cannot append to an unfragmented message");
+        };
+        debug_assert!(!*complete && !c.beginning_fragment);
+        snapshot.apply(&mut c);
+        *complete = c.ending_fragment;
+        *bytes += c.user_data.len();
+        fragments.push_back(c);
+    }
+
+    fn peek(&self) -> Option<&ChunkPayloadData> {
+        match self {
+            Self::Whole(c) => Some(c),
+            Self::Fragmented { fragments, .. } => fragments.front(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Whole(_) => 1,
+            Self::Fragmented { fragments, .. } => fragments.len(),
+        }
+    }
+
+    fn bytes(&self) -> usize {
+        match self {
+            Self::Whole(c) => c.user_data.len(),
+            Self::Fragmented { bytes, .. } => *bytes,
+        }
+    }
+
+    fn is_last_fragment(&self) -> bool {
+        match self {
+            Self::Whole(_) => true,
+            Self::Fragmented {
+                fragments,
+                complete,
+                ..
+            } => *complete && fragments.len() == 1,
+        }
+    }
+
+    fn pop_fragment(&mut self) -> Option<ChunkPayloadData> {
+        let Self::Fragmented {
+            fragments,
+            next_fragment,
+            bytes,
+            ..
+        } = self
+        else {
+            unreachable!("the final fragment removes its message owner");
+        };
+        let c = fragments.pop_front()?;
+        *next_fragment += 1;
+        *bytes -= c.user_data.len();
+        Some(c)
+    }
+
+    fn into_last_fragment(self) -> ChunkPayloadData {
+        match self {
+            Self::Whole(c) => c,
+            Self::Fragmented { mut fragments, .. } => {
+                debug_assert_eq!(fragments.len(), 1);
+                fragments.pop_front().unwrap()
+            }
+        }
+    }
+
+    fn into_fragments(self) -> Vec<ChunkPayloadData> {
+        match self {
+            Self::Whole(c) => vec![c],
+            Self::Fragmented { fragments, .. } => fragments.into_iter().collect(),
+        }
+    }
+}
+
+/// A reset boundary belongs to control state, not to a DATA chunk. It waits
+/// for earlier messages of its own stream and holds later writes until the
+/// peer completes the reset. No payload or partial-reliability policy applies.
+#[derive(Debug, Default)]
+pub(crate) struct ResetMarker {
+    pub(crate) stream_identifier: u16,
+    pub(crate) receive_epoch: ReceiveEpoch,
+}
+
+#[derive(Debug)]
+enum WaitingEntry {
+    Message(QueuedMessage),
+    Reset(ResetMarker),
+}
+
+/// Stable slots and explicit links allow O(1) removal without shifting other
+/// message indexes. Vacant slots are reused even while the queue head is blocked;
+/// abandoned messages cannot leave an ever-growing sequence of tombstones.
+#[derive(Debug)]
+struct IndexedQueue<T> {
+    entries: Slab<QueueEntry<T>>,
+    first: Option<usize>,
+    last: Option<usize>,
+}
+
+// Slab slots cannot reach usize::MAX. Compact links avoid two Option tags
+// being copied along with every (potentially large) message on removal.
+const NO_LINK: usize = usize::MAX;
+
+#[derive(Debug)]
+struct QueueEntry<T> {
+    value: T,
+    previous: usize,
+    next: usize,
+}
+
+impl<T> Default for IndexedQueue<T> {
+    fn default() -> Self {
+        Self {
+            entries: Slab::new(),
+            first: None,
+            last: None,
+        }
+    }
+}
+
+impl<T> IndexedQueue<T> {
+    #[inline]
+    fn push(&mut self, value: T) -> usize {
+        let position = self.entries.insert(QueueEntry {
+            value,
+            previous: self.last.unwrap_or(NO_LINK),
+            next: NO_LINK,
+        });
+        if let Some(last) = self.last {
+            self.entries[last].next = position;
+        } else {
+            self.first = Some(position);
+        }
+        self.last = Some(position);
+        position
+    }
+
+    #[inline]
+    fn front(&self) -> Option<(usize, &T)> {
+        let first = self.first?;
+        Some((first, &self.entries[first].value))
+    }
+
+    fn back(&self) -> Option<(usize, &T)> {
+        let last = self.last?;
+        Some((last, &self.entries[last].value))
+    }
+
+    #[inline]
+    fn get(&self, position: usize) -> Option<&T> {
+        Some(&self.entries.get(position)?.value)
+    }
+
+    #[inline]
+    fn get_mut(&mut self, position: usize) -> Option<&mut T> {
+        Some(&mut self.entries.get_mut(position)?.value)
+    }
+
+    #[inline]
+    fn remove(&mut self, position: usize) -> Option<T> {
+        let entry = self.entries.try_remove(position)?;
+        if entry.previous != NO_LINK {
+            self.entries[entry.previous].next = entry.next;
+        } else {
+            self.first = (entry.next != NO_LINK).then_some(entry.next);
+        }
+        if entry.next != NO_LINK {
+            self.entries[entry.next].previous = entry.previous;
+        } else {
+            self.last = (entry.previous != NO_LINK).then_some(entry.previous);
+        }
+        Some(entry.value)
+    }
+
+    fn pop_front(&mut self) -> Option<T> {
+        self.remove(self.front()?.0)
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum MessageLocation {
+    Ordered(usize),
+    Unordered(usize),
+    Waiting {
+        stream_identifier: u16,
+        position: usize,
+    },
+}
+
+#[derive(Debug, Default)]
+struct PendingStreamData {
+    /// DATA before this stream's first queued or in-flight reset.
+    ready_chunks: usize,
+    resetting: bool,
+    /// A reset waiting for its own DATA, together with its activation order.
+    blocked_reset: Option<(u64, ResetMarker)>,
+    /// Message ownership and subsequent reset boundaries retain write order.
+    waiting: IndexedQueue<WaitingEntry>,
+}
+
+/// Keep the usual single ready reset inline, retaining ordered insertion for
+/// earlier boundaries that become ready after a later stream's boundary.
+#[derive(Debug, Default)]
+struct ReadyResets {
+    first: Option<(u64, ResetMarker)>,
+    remaining: BTreeMap<u64, ResetMarker>,
+}
+
+impl ReadyResets {
+    fn insert(&mut self, order: u64, reset: ResetMarker) -> Option<ResetMarker> {
+        match self.first.as_mut() {
+            None => {
+                self.first = Some((order, reset));
+                None
+            }
+            Some((first_order, first)) if order == *first_order => {
+                Some(std::mem::replace(first, reset))
+            }
+            Some((first_order, _)) if order < *first_order => {
+                let (old_order, old_reset) = self.first.replace((order, reset)).unwrap();
+                self.remaining.insert(old_order, old_reset);
+                None
+            }
+            Some(_) => self.remaining.insert(order, reset),
+        }
+    }
+
+    fn pop_first(&mut self) -> Option<(u64, ResetMarker)> {
+        let first = self.first.take()?;
+        self.first = self.remaining.pop_first();
+        Some(first)
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct PendingQueue {
-    unordered_queue: PendingBaseQueue,
-    ordered_queue: PendingBaseQueue,
+    unordered_queue: IndexedQueue<QueuedMessage>,
+    ordered_queue: IndexedQueue<QueuedMessage>,
+    /// Only ready markers appear here. Per-fragment drains never scan blocked
+    /// resets; activation order preserves the previous reset selection order.
+    ready_resets: ReadyResets,
+    next_reset_order: u64,
+    messages: FxHashMap<MessageId, MessageLocation>,
+    stream_data: FxHashMap<u16, PendingStreamData>,
     queue_len: usize,
     n_bytes: usize,
-    selected: bool,
-    unordered_is_selected: bool,
+    selected: Option<MessageLocation>,
 }
 
 impl PendingQueue {
     pub(crate) fn new() -> Self {
-        PendingQueue::default()
+        Self::default()
     }
 
     pub(crate) fn push(&mut self, c: ChunkPayloadData) {
+        let stream_identifier = c.stream_identifier;
         self.n_bytes += c.user_data.len();
-        if c.unordered {
-            self.unordered_queue.push_back(c);
-        } else {
-            self.ordered_queue.push_back(c);
-        }
         self.queue_len += 1;
+
+        if let Some(location) = self.continuation_location(&c) {
+            self.message_mut(location).unwrap().push_fragment(c);
+            if !matches!(location, MessageLocation::Waiting { .. }) {
+                self.stream_data
+                    .entry(stream_identifier)
+                    .or_default()
+                    .ready_chunks += 1;
+            }
+            return;
+        }
+
+        let message = QueuedMessage::new(c);
+        let id = message.indexed_id();
+        let data = self.stream_data.entry(stream_identifier).or_default();
+        if data.resetting {
+            let position = data.waiting.push(WaitingEntry::Message(message));
+            if let Some(id) = id {
+                self.messages.insert(
+                    id,
+                    MessageLocation::Waiting {
+                        stream_identifier,
+                        position,
+                    },
+                );
+            }
+        } else {
+            data.ready_chunks += 1;
+            self.push_ready_message(message);
+        }
+    }
+
+    pub(crate) fn push_reset(&mut self, reset: ResetMarker) {
+        self.queue_len += 1;
+        let stream_identifier = reset.stream_identifier;
+        let data = self.stream_data.entry(stream_identifier).or_default();
+        if data.resetting {
+            data.waiting.push(WaitingEntry::Reset(reset));
+        } else {
+            let mut data = self.stream_data.remove(&stream_identifier).unwrap();
+            self.activate_reset(&mut data, reset);
+            self.stream_data.insert(stream_identifier, data);
+        }
+    }
+
+    fn continuation_location(&self, c: &ChunkPayloadData) -> Option<MessageLocation> {
+        // A beginning fragment creates its owner. Avoid probing the message
+        // index on the common path of one unfragmented application write.
+        if c.beginning_fragment {
+            return None;
+        }
+        if let Some(id) = c.message_id {
+            return self.messages.get(&id).copied();
+        }
+        // Queue fixtures can omit MessageId. Preserve their B/E grouping without
+        // treating a repeated timestamp or SSN as a production message identity.
+        if let Some(data) = self.stream_data.get(&c.stream_identifier)
+            && data.resetting
+        {
+            let (position, WaitingEntry::Message(message)) = data.waiting.back()? else {
+                return None;
+            };
+            return message
+                .accepts_anonymous_fragment(c)
+                .then_some(MessageLocation::Waiting {
+                    stream_identifier: c.stream_identifier,
+                    position,
+                });
+        }
+        let (position, message) = if c.unordered {
+            self.unordered_queue.back()?
+        } else {
+            self.ordered_queue.back()?
+        };
+        message
+            .accepts_anonymous_fragment(c)
+            .then_some(if c.unordered {
+                MessageLocation::Unordered(position)
+            } else {
+                MessageLocation::Ordered(position)
+            })
+    }
+
+    fn push_ready_message(&mut self, message: QueuedMessage) {
+        let unordered = message.snapshot().unordered;
+        let id = message.indexed_id();
+        let location = if unordered {
+            MessageLocation::Unordered(self.unordered_queue.push(message))
+        } else {
+            MessageLocation::Ordered(self.ordered_queue.push(message))
+        };
+        if let Some(id) = id {
+            self.messages.insert(id, location);
+        }
+    }
+
+    #[inline]
+    fn message(&self, location: MessageLocation) -> Option<&QueuedMessage> {
+        match location {
+            MessageLocation::Ordered(position) => self.ordered_queue.get(position),
+            MessageLocation::Unordered(position) => self.unordered_queue.get(position),
+            MessageLocation::Waiting {
+                stream_identifier,
+                position,
+            } => {
+                match self
+                    .stream_data
+                    .get(&stream_identifier)?
+                    .waiting
+                    .get(position)?
+                {
+                    WaitingEntry::Message(message) => Some(message),
+                    WaitingEntry::Reset(_) => None,
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn message_mut(&mut self, location: MessageLocation) -> Option<&mut QueuedMessage> {
+        match location {
+            MessageLocation::Ordered(position) => self.ordered_queue.get_mut(position),
+            MessageLocation::Unordered(position) => self.unordered_queue.get_mut(position),
+            MessageLocation::Waiting {
+                stream_identifier,
+                position,
+            } => {
+                match self
+                    .stream_data
+                    .get_mut(&stream_identifier)?
+                    .waiting
+                    .get_mut(position)?
+                {
+                    WaitingEntry::Message(message) => Some(message),
+                    WaitingEntry::Reset(_) => None,
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn remove_message(&mut self, location: MessageLocation) -> Option<QueuedMessage> {
+        match location {
+            MessageLocation::Ordered(position) => self.ordered_queue.remove(position),
+            MessageLocation::Unordered(position) => self.unordered_queue.remove(position),
+            MessageLocation::Waiting {
+                stream_identifier,
+                position,
+            } => {
+                match self
+                    .stream_data
+                    .get_mut(&stream_identifier)?
+                    .waiting
+                    .remove(position)?
+                {
+                    WaitingEntry::Message(message) => Some(message),
+                    WaitingEntry::Reset(_) => unreachable!("message index points to a reset"),
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn front_location(&self, unordered: bool) -> Option<MessageLocation> {
+        if unordered {
+            Some(MessageLocation::Unordered(self.unordered_queue.front()?.0))
+        } else {
+            Some(MessageLocation::Ordered(self.ordered_queue.front()?.0))
+        }
     }
 
     pub(crate) fn peek(&self) -> Option<&ChunkPayloadData> {
-        if self.selected {
-            if self.unordered_is_selected {
-                return self.unordered_queue.front();
-            } else {
-                return self.ordered_queue.front();
+        let location = self
+            .selected
+            .or_else(|| self.front_location(true))
+            .or_else(|| self.front_location(false))?;
+        self.message(location)?.peek()
+    }
+
+    /// Includes queued boundaries as well as the request already on the wire.
+    pub(crate) fn is_resetting(&self, stream_identifier: u16) -> bool {
+        self.stream_data
+            .get(&stream_identifier)
+            .is_some_and(|data| data.resetting)
+    }
+
+    /// Release complete owners up to the next reset boundary. Unsent messages
+    /// have no SSN; the TX direction assigns it on their first transmission.
+    pub(crate) fn complete_reset(&mut self, stream_identifier: u16) {
+        let Some(mut data) = self.stream_data.remove(&stream_identifier) else {
+            return;
+        };
+        debug_assert!(data.resetting && data.ready_chunks == 0);
+        data.resetting = false;
+        while let Some(entry) = data.waiting.pop_front() {
+            match entry {
+                WaitingEntry::Reset(reset) => {
+                    self.activate_reset(&mut data, reset);
+                    break;
+                }
+                WaitingEntry::Message(message) => {
+                    data.ready_chunks += message.len();
+                    self.push_ready_message(message);
+                }
             }
         }
-
-        let c = self.unordered_queue.front();
-
-        if c.is_some() {
-            return c;
+        if data.resetting || data.ready_chunks > 0 {
+            self.stream_data.insert(stream_identifier, data);
         }
+    }
 
-        self.ordered_queue.front()
+    /// Remove an abandonment candidate anywhere, including behind a reset.
+    /// The caller has already selected a partial-reliability message. Its index remains
+    /// valid when other messages are sent or removed. Repetition cannot consume
+    /// a neighboring message or reset with the same SID, SSN or creation time.
+    pub(crate) fn drain_message(&mut self, id: MessageId) -> Vec<ChunkPayloadData> {
+        let Some(location) = self.messages.remove(&id) else {
+            return vec![];
+        };
+        let message = self
+            .remove_message(location)
+            .expect("indexed pending message exists");
+        if self.selected == Some(location) {
+            self.selected = None;
+        }
+        self.n_bytes -= message.bytes();
+        self.queue_len -= message.len();
+        if !matches!(location, MessageLocation::Waiting { .. }) {
+            self.release_ready_chunks(message.snapshot().stream_identifier, message.len());
+        }
+        message.into_fragments()
     }
 
     pub(crate) fn pop(
@@ -54,49 +610,62 @@ impl PendingQueue {
         beginning_fragment: bool,
         unordered: bool,
     ) -> Option<ChunkPayloadData> {
-        let popped = if self.selected {
-            let popped = if self.unordered_is_selected {
-                self.unordered_queue.pop_front()
-            } else {
-                self.ordered_queue.pop_front()
-            };
-            if let Some(p) = &popped
-                && p.ending_fragment
-            {
-                self.selected = false;
-            }
-            popped
-        } else {
-            if !beginning_fragment {
-                return None;
-            }
-            if unordered {
-                let popped = { self.unordered_queue.pop_front() };
-                if let Some(p) = &popped
-                    && !p.ending_fragment
-                {
-                    self.selected = true;
-                    self.unordered_is_selected = true;
-                }
-                popped
-            } else {
-                let popped = { self.ordered_queue.pop_front() };
-                if let Some(p) = &popped
-                    && !p.ending_fragment
-                {
-                    self.selected = true;
-                    self.unordered_is_selected = false;
-                }
-                popped
-            }
+        let location = match self.selected {
+            Some(location) => location,
+            None if beginning_fragment => self.front_location(unordered)?,
+            None => return None,
         };
+        let message = self.message(location)?;
+        message.peek()?;
+        let c = if message.is_last_fragment() {
+            let message = self.remove_message(location).unwrap();
+            if let Some(id) = message.indexed_id() {
+                self.messages.remove(&id);
+            }
+            message.into_last_fragment()
+        } else {
+            self.message_mut(location).unwrap().pop_fragment()?
+        };
+        self.selected = (!c.ending_fragment).then_some(location);
+        self.n_bytes -= c.user_data.len();
+        self.queue_len -= 1;
+        self.release_ready_chunks(c.stream_identifier, 1);
+        Some(c)
+    }
 
-        if let Some(p) = &popped {
-            self.n_bytes -= p.user_data.len();
-            self.queue_len -= 1;
+    fn release_ready_chunks(&mut self, stream_identifier: u16, count: usize) {
+        if count == 0 {
+            return;
         }
+        let data = self.stream_data.get_mut(&stream_identifier).unwrap();
+        data.ready_chunks -= count;
+        if data.ready_chunks == 0 {
+            if let Some((order, reset)) = data.blocked_reset.take() {
+                self.ready_resets.insert(order, reset);
+            }
+            if !data.resetting {
+                self.stream_data.remove(&stream_identifier);
+            }
+        }
+    }
 
-        popped
+    fn activate_reset(&mut self, data: &mut PendingStreamData, reset: ResetMarker) {
+        let order = self.next_reset_order;
+        self.next_reset_order = order.checked_add(1).expect("reset queue order exhausted");
+        data.resetting = true;
+        if data.ready_chunks == 0 {
+            self.ready_resets.insert(order, reset);
+        } else {
+            data.blocked_reset = Some((order, reset));
+        }
+    }
+
+    /// Each fragment updates only its stream's count. A reset becomes ready
+    /// once, when that count reaches zero, instead of being rescanned per DATA.
+    pub(crate) fn pop_ready_reset(&mut self) -> Option<ResetMarker> {
+        let (_, reset) = self.ready_resets.pop_first()?;
+        self.queue_len -= 1;
+        Some(reset)
     }
 
     pub(crate) fn get_num_bytes(&self) -> usize {
@@ -109,5 +678,326 @@ impl PendingQueue {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn inline_ready_resets_preserve_order_replacement_and_refill() {
+        let mut resets = ReadyResets::default();
+        let mut expected = BTreeMap::new();
+        assert!(resets.pop_first().is_none());
+        // Includes replacement of the inline minimum and of a tree entry,
+        // plus an earlier boundary becoming ready after a later one.
+        for (step, order) in [7, 7, 9, 1, 9, 4, 0, 8, 4, 12].into_iter().enumerate() {
+            let sid = step as u16;
+            let replaced = resets.insert(
+                order,
+                ResetMarker {
+                    stream_identifier: sid,
+                    ..Default::default()
+                },
+            );
+            assert_eq!(
+                replaced.map(|marker| marker.stream_identifier),
+                expected.insert(order, sid)
+            );
+            if step % 3 == 2 {
+                assert_eq!(
+                    resets
+                        .pop_first()
+                        .map(|(key, marker)| (key, marker.stream_identifier)),
+                    expected.pop_first()
+                );
+            }
+        }
+        while !expected.is_empty() {
+            assert_eq!(
+                resets
+                    .pop_first()
+                    .map(|(key, marker)| (key, marker.stream_identifier)),
+                expected.pop_first()
+            );
+        }
+        assert!(resets.pop_first().is_none());
+        resets.insert(3, ResetMarker::default());
+        assert!(
+            resets.remaining.is_empty(),
+            "one ready reset has no tree node"
+        );
+        assert_eq!(resets.pop_first().unwrap().0, 3);
+        assert!(resets.pop_first().is_none());
+    }
+
+    fn fragment(
+        id: u64,
+        sid: u16,
+        unordered: bool,
+        beginning: bool,
+        ending: bool,
+    ) -> ChunkPayloadData {
+        ChunkPayloadData {
+            message_id: Some(MessageId::new(id)),
+            stream_identifier: sid,
+            stream_generation: 7,
+            reliability: MessageReliability::Rexmit { max_retransmits: 0 },
+            unordered,
+            beginning_fragment: beginning,
+            ending_fragment: ending,
+            user_data: Bytes::from_static(b"payload"),
+            ..Default::default()
+        }
+    }
+
+    fn reset(sid: u16) -> ResetMarker {
+        ResetMarker {
+            stream_identifier: sid,
+            ..Default::default()
+        }
+    }
+
+    // Pending abandonment of a whole message requires a deadline: a Rexmit
+    // budget cannot be exhausted before that message's first transmission.
+    fn expiring_whole(id: u64, sid: u16, unordered: bool) -> ChunkPayloadData {
+        let mut c = fragment(id, sid, unordered, true, true);
+        c.reliability = MessageReliability::Timed {
+            deadline: Instant::now(),
+        };
+        c
+    }
+
+    #[test]
+    fn queued_reset_retains_its_receive_epoch_after_an_earlier_result() {
+        let mut receive = super::super::receive_queue::ReceiveQueue::new(1);
+        let first = receive.note_outgoing_reset();
+        receive.reset();
+        receive.open();
+        let next = receive.note_outgoing_reset();
+        let mut queue = PendingQueue::new();
+        assert!(!queue.is_resetting(1));
+        for receive_epoch in [first, next] {
+            queue.push_reset(ResetMarker {
+                stream_identifier: 1,
+                receive_epoch,
+            });
+        }
+        assert!(queue.is_resetting(1));
+        assert_eq!(queue.pop_ready_reset().unwrap().receive_epoch, first);
+        queue.complete_reset(1);
+        assert!(queue.is_resetting(1));
+        assert_eq!(queue.pop_ready_reset().unwrap().receive_epoch, next);
+        queue.complete_reset(1);
+        assert!(!queue.is_resetting(1));
+    }
+
+    #[test]
+    fn index_tracks_continuations_and_abandonment_candidates_only() {
+        let mut queue = PendingQueue::new();
+        let mut whole = fragment(0, 1, false, true, true);
+        whole.reliability = MessageReliability::Reliable;
+        queue.push(whole);
+        for (beginning, ending) in [(true, false), (false, true)] {
+            let mut part = fragment(1, 1, false, beginning, ending);
+            part.reliability = MessageReliability::Reliable;
+            queue.push(part);
+        }
+        queue.push(expiring_whole(2, 1, false));
+        queue.push_reset(reset(1));
+        queue.push(fragment(3, 1, false, true, true));
+        assert!(!queue.messages.contains_key(&MessageId::new(0)));
+        assert!(queue.messages.contains_key(&MessageId::new(1)));
+        assert!(queue.messages.contains_key(&MessageId::new(2)));
+        assert!(!queue.messages.contains_key(&MessageId::new(3)));
+        assert_eq!(queue.messages.len(), 2);
+        assert_eq!(
+            Some(MessageId::new(0)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        assert_eq!(1, queue.drain_message(MessageId::new(2)).len());
+        assert_eq!(
+            Some(MessageId::new(1)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        assert_eq!(
+            Some(MessageId::new(1)),
+            queue.pop(false, false).unwrap().message_id
+        );
+        assert_eq!(1, queue.pop_ready_reset().unwrap().stream_identifier);
+        queue.complete_reset(1);
+        assert_eq!(
+            Some(MessageId::new(3)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        assert!(queue.is_empty());
+        assert!(queue.messages.is_empty());
+    }
+
+    #[test]
+    fn drain_nonselected_message_preserves_active_fragmentation() {
+        let mut queue = PendingQueue::new();
+        queue.push(fragment(1, 5, false, true, false));
+        queue.push(fragment(1, 5, false, false, true));
+        assert_eq!(
+            Some(MessageId::new(1)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        queue.push(fragment(2, 5, false, true, false));
+        queue.push(fragment(2, 5, false, false, true));
+        queue.push(fragment(3, 5, true, true, true));
+
+        // Matching SID/SSN/policy does not make these fragments one message.
+        let abandoned = queue.drain_message(MessageId::new(2));
+        assert_eq!(2, abandoned.len());
+        assert!(
+            abandoned
+                .iter()
+                .all(|c| c.message_id == Some(MessageId::new(2)))
+        );
+        assert!(queue.drain_message(MessageId::new(2)).is_empty());
+        assert_eq!(Some(MessageId::new(1)), queue.peek().unwrap().message_id);
+        assert_eq!(2, queue.len());
+        assert_eq!(14, queue.get_num_bytes());
+
+        // Abandoning the selected tail releases its scheduling reservation.
+        assert_eq!(1, queue.drain_message(MessageId::new(1)).len());
+        assert_eq!(Some(MessageId::new(3)), queue.peek().unwrap().message_id);
+        assert_eq!(
+            Some(MessageId::new(3)),
+            queue.pop(true, true).unwrap().message_id
+        );
+        assert!(queue.is_empty());
+        assert_eq!(0, queue.get_num_bytes());
+        assert!(queue.messages.is_empty());
+    }
+
+    #[test]
+    fn drain_messages_behind_resets_keeps_each_boundary_and_generation() {
+        for unordered in [false, true] {
+            let mut queue = PendingQueue::new();
+            queue.push_reset(reset(1));
+            queue.push(fragment(1, 1, unordered, true, false));
+            queue.push(fragment(1, 1, unordered, false, true));
+            queue.push_reset(reset(1));
+            let mut next_generation = expiring_whole(2, 1, !unordered);
+            next_generation.stream_generation += 1;
+            queue.push(next_generation);
+            queue.push(fragment(3, 2, false, true, true));
+
+            let abandoned = queue.drain_message(MessageId::new(2));
+            assert_eq!(1, abandoned.len());
+            assert_eq!(8, abandoned[0].stream_generation);
+            assert_eq!(1, queue.pop_ready_reset().unwrap().stream_identifier);
+            queue.complete_reset(1);
+            assert!(queue.pop_ready_reset().is_none());
+            assert_eq!(2, queue.drain_message(MessageId::new(1)).len());
+            assert_eq!(1, queue.pop_ready_reset().unwrap().stream_identifier);
+            queue.complete_reset(1);
+            assert!(queue.pop_ready_reset().is_none());
+            assert_eq!(Some(MessageId::new(3)), queue.peek().unwrap().message_id);
+            assert_eq!(1, queue.len());
+            assert_eq!(7, queue.get_num_bytes());
+            queue.pop(true, false).unwrap();
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn message_snapshot_and_cursor_survive_a_sent_prefix() {
+        let mut queue = PendingQueue::new();
+        let created = Instant::now();
+        let deadline = created + Duration::from_millis(100);
+        let mut first = fragment(1, 1, false, true, false);
+        first.reliability = MessageReliability::Timed { deadline };
+        queue.push(first);
+        queue.pop(true, false).unwrap();
+        // An incomplete owner survives even when no fragment is currently
+        // pending. A different unordered message cannot steal its reservation.
+        queue.push(fragment(2, 2, true, true, true));
+        assert!(queue.peek().is_none());
+        let mut tail = fragment(1, 1, false, false, true);
+        tail.reliability = MessageReliability::Rexmit {
+            max_retransmits: 99,
+        };
+        queue.push(tail);
+        let location = queue.messages[&MessageId::new(1)];
+        assert!(matches!(
+            queue.message(location).unwrap(),
+            QueuedMessage::Fragmented {
+                next_fragment: 1,
+                ..
+            }
+        ));
+        let tail = queue.pop(false, false).unwrap();
+        assert_eq!(Some(deadline), tail.reliability.deadline());
+        assert_eq!(7, tail.stream_generation);
+        assert_eq!(Some(MessageId::new(2)), queue.peek().unwrap().message_id);
+        queue.pop(true, true).unwrap();
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn zero_size_data_is_not_a_reset_marker() {
+        for id in [None, Some(MessageId::new(1))] {
+            let mut queue = PendingQueue::new();
+            let mut data = fragment(1, 2, false, true, true);
+            data.message_id = id;
+            data.user_data = Bytes::new();
+            queue.push(data);
+            assert_eq!(1, queue.len());
+            assert_eq!(0, queue.get_num_bytes());
+            assert!(queue.pop_ready_reset().is_none());
+            assert_eq!(id, queue.peek().unwrap().message_id);
+            queue.pop(true, false).unwrap();
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn abandoned_slots_are_reused_while_an_earlier_message_waits() {
+        let mut queue = PendingQueue::new();
+        queue.push(fragment(0, 1, false, true, true));
+        queue.push(expiring_whole(1, 1, false));
+        for id in 2..4096 {
+            queue.push(expiring_whole(id, 1, false));
+            assert_eq!(1, queue.drain_message(MessageId::new(id - 1)).len());
+            assert_eq!(Some(MessageId::new(0)), queue.peek().unwrap().message_id);
+            assert_eq!(2, queue.len());
+            assert_eq!(14, queue.get_num_bytes());
+        }
+        // Only three message owners were simultaneously present. Removed
+        // middle messages must not leave unbounded reserved queue storage.
+        assert!(queue.ordered_queue.entries.capacity() <= 4);
+        assert_eq!(
+            Some(MessageId::new(0)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        assert_eq!(
+            Some(MessageId::new(4095)),
+            queue.pop(true, false).unwrap().message_id
+        );
+        assert!(queue.messages.is_empty());
+        assert_eq!(0, queue.ordered_queue.entries.len());
+    }
+
+    #[test]
+    fn reset_readiness_preserves_activation_order_without_scanning_data() {
+        let mut queue = PendingQueue::new();
+        queue.push(expiring_whole(1, 1, false));
+        queue.push_reset(reset(1));
+        queue.push(expiring_whole(2, 2, false));
+        queue.push_reset(reset(2));
+        queue.push_reset(reset(3));
+        queue.drain_message(MessageId::new(2));
+        queue.drain_message(MessageId::new(1));
+        for sid in 1..=3 {
+            assert_eq!(sid, queue.pop_ready_reset().unwrap().stream_identifier);
+        }
+        assert!(queue.pop_ready_reset().is_none());
+        assert!(queue.is_empty());
     }
 }

--- a/rtc-sctp/src/queue/queue_test.rs
+++ b/rtc-sctp/src/queue/queue_test.rs
@@ -6,6 +6,7 @@ use bytes::{Bytes, BytesMut};
 //payload_queue_test
 ///////////////////////////////////////////////////////////////////
 use super::payload_queue::*;
+use super::receive_tsn_queue::ReceiveTsnQueue;
 use crate::chunk::chunk_payload_data::{ChunkPayloadData, PayloadProtocolIdentifier};
 use crate::chunk::chunk_selective_ack::GapAckBlock;
 
@@ -69,15 +70,15 @@ fn test_payload_queue_push_no_check() -> Result<()> {
 }
 
 #[test]
-fn test_payload_queue_get_gap_ack_block() -> Result<()> {
-    let mut pq = PayloadQueue::new();
+fn test_receive_tsn_queue_get_gap_ack_block() -> Result<()> {
+    let mut pq = ReceiveTsnQueue::default();
 
-    pq.push(make_payload(1, 0), 0);
-    pq.push(make_payload(2, 0), 0);
-    pq.push(make_payload(3, 0), 0);
-    pq.push(make_payload(4, 0), 0);
-    pq.push(make_payload(5, 0), 0);
-    pq.push(make_payload(6, 0), 0);
+    pq.push(1, 0);
+    pq.push(2, 0);
+    pq.push(3, 0);
+    pq.push(4, 0);
+    pq.push(5, 0);
+    pq.push(6, 0);
 
     let gab1 = vec![GapAckBlock { start: 1, end: 6 }];
     let gab2 = pq.get_gap_ack_blocks(0);
@@ -87,8 +88,8 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
     assert_eq!(gab1[0].start, gab2[0].start);
     assert_eq!(gab1[0].end, gab2[0].end);
 
-    pq.push(make_payload(8, 0), 0);
-    pq.push(make_payload(9, 0), 0);
+    pq.push(8, 0);
+    pq.push(9, 0);
 
     let gab1 = vec![
         GapAckBlock { start: 1, end: 6 },
@@ -107,28 +108,28 @@ fn test_payload_queue_get_gap_ack_block() -> Result<()> {
 }
 
 #[test]
-fn test_payload_queue_get_last_tsn_received() -> Result<()> {
-    let mut pq = PayloadQueue::new();
+fn test_receive_tsn_queue_get_last_tsn_received() -> Result<()> {
+    let mut pq = ReceiveTsnQueue::default();
 
     // empty queie should return false
     let ok = pq.get_last_tsn_received();
     assert!(ok.is_none(), "should be none");
 
-    let ok = pq.push(make_payload(20, 0), 0);
+    let ok = pq.push(20, 0);
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
     assert_eq!(Some(&20), tsn, "should match");
 
     // append should work
-    let ok = pq.push(make_payload(21, 0), 0);
+    let ok = pq.push(21, 0);
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
     assert_eq!(Some(&21), tsn, "should match");
 
     // check if sorting applied
-    let ok = pq.push(make_payload(19, 0), 0);
+    let ok = pq.push(19, 0);
     assert!(ok, "should be true");
     let tsn = pq.get_last_tsn_received();
     assert!(tsn.is_some(), "should be false");
@@ -142,9 +143,9 @@ fn test_payload_queue_mark_all_to_retrasmit() -> Result<()> {
     let mut pq = PayloadQueue::new();
 
     for i in 0..3 {
-        pq.push(make_payload(i + 1, 10), 0);
+        pq.push_no_check(make_payload(i + 1, 10));
     }
-    pq.acknowledge(2).unwrap();
+    pq.acknowledge(2, false).unwrap();
     pq.mark_all_to_retrasmit();
 
     let c = pq.get(1);
@@ -165,12 +166,12 @@ fn test_payload_queue_reset_retransmit_flag_on_ack() -> Result<()> {
     let mut pq = PayloadQueue::new();
 
     for i in 0..4 {
-        pq.push(make_payload(i + 1, 10), 0);
+        pq.push_no_check(make_payload(i + 1, 10));
     }
 
     pq.mark_all_to_retrasmit();
-    pq.acknowledge(2).unwrap(); // should cancel retransmission for TSN 2
-    pq.acknowledge(4).unwrap(); // should cancel retransmission for TSN 4
+    pq.acknowledge(2, false).unwrap(); // should cancel retransmission for TSN 2
+    pq.acknowledge(4, false).unwrap(); // should cancel retransmission for TSN 4
 
     let c = pq.get(1);
     assert!(c.is_some(), "should be true");

--- a/rtc-sctp/src/queue/queue_test.rs
+++ b/rtc-sctp/src/queue/queue_test.rs
@@ -144,7 +144,7 @@ fn test_payload_queue_mark_all_to_retrasmit() -> Result<()> {
     for i in 0..3 {
         pq.push(make_payload(i + 1, 10), 0);
     }
-    pq.mark_as_acked(2);
+    pq.acknowledge(2);
     pq.mark_all_to_retrasmit();
 
     let c = pq.get(1);
@@ -169,8 +169,8 @@ fn test_payload_queue_reset_retransmit_flag_on_ack() -> Result<()> {
     }
 
     pq.mark_all_to_retrasmit();
-    pq.mark_as_acked(2); // should cancel retransmission for TSN 2
-    pq.mark_as_acked(4); // should cancel retransmission for TSN 4
+    pq.acknowledge(2); // should cancel retransmission for TSN 2
+    pq.acknowledge(4); // should cancel retransmission for TSN 4
 
     let c = pq.get(1);
     assert!(c.is_some(), "should be true");
@@ -423,6 +423,81 @@ fn test_pending_queue_selection_persistence() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_pending_reset_preserves_ordered_and_unordered_boundaries() {
+    for earlier_unordered in [false, true] {
+        for later_unordered in [false, true] {
+            let mut queue = PendingQueue::new();
+            queue.push(make_data_chunk(0, earlier_unordered, FRAG_BEGIN));
+            queue.push(make_data_chunk(1, earlier_unordered, FRAG_END));
+            assert_eq!(0, queue.pop(true, earlier_unordered).unwrap().tsn);
+            queue.push_reset(ResetMarker {
+                stream_identifier: 0,
+                ..Default::default()
+            });
+            queue.push(make_data_chunk(2, later_unordered, NO_FRAGMENT));
+            assert!(
+                queue.pop_ready_reset().is_none(),
+                "must wait for the earlier fragment tail"
+            );
+            assert_eq!(1, queue.peek().unwrap().tsn);
+            assert_eq!(1, queue.pop(false, earlier_unordered).unwrap().tsn);
+            let reset = queue
+                .pop_ready_reset()
+                .expect("later DATA must not hold the reset");
+            assert_eq!(0, reset.stream_identifier);
+            assert_eq!(1, queue.len());
+            assert_eq!(10, queue.get_num_bytes());
+            assert!(
+                queue.peek().is_none(),
+                "later writes wait for the reset ACK"
+            );
+            queue.complete_reset(reset.stream_identifier);
+            assert_eq!(2, queue.peek().unwrap().tsn);
+            assert_eq!(2, queue.pop(true, later_unordered).unwrap().tsn);
+            assert!(queue.is_empty());
+            assert_eq!(0, queue.get_num_bytes());
+            // A subsequent reset on the same SID must not depend on retired DATA.
+            queue.push_reset(ResetMarker {
+                stream_identifier: 0,
+                ..Default::default()
+            });
+            assert_eq!(1, queue.len());
+            assert_eq!(0, queue.pop_ready_reset().unwrap().stream_identifier);
+            assert!(queue.is_empty());
+        }
+    }
+}
+
+#[test]
+fn test_pending_reset_releases_only_writes_before_the_next_reset() {
+    let mut queue = PendingQueue::new();
+    let reset = || ResetMarker {
+        stream_identifier: 0,
+        ..Default::default()
+    };
+    queue.push_reset(reset());
+    queue.push(make_data_chunk(1, false, FRAG_BEGIN));
+    queue.push(make_data_chunk(2, false, FRAG_END));
+    queue.push_reset(reset());
+    queue.push(make_data_chunk(3, true, NO_FRAGMENT));
+    assert_eq!(0, queue.pop_ready_reset().unwrap().stream_identifier);
+    assert!(queue.pop_ready_reset().is_none());
+    assert!(queue.peek().is_none());
+    assert_eq!(30, queue.get_num_bytes());
+    queue.complete_reset(0);
+    assert_eq!(1, queue.pop(true, false).unwrap().tsn);
+    assert!(queue.pop_ready_reset().is_none());
+    assert_eq!(2, queue.pop(false, false).unwrap().tsn);
+    assert_eq!(0, queue.pop_ready_reset().unwrap().stream_identifier);
+    assert!(queue.peek().is_none());
+    assert_eq!(10, queue.get_num_bytes());
+    queue.complete_reset(0);
+    assert_eq!(3, queue.pop(true, true).unwrap().tsn);
+    assert!(queue.is_empty());
+    assert_eq!(0, queue.get_num_bytes());
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -1137,4 +1212,29 @@ fn test_reassembly_queue_ssn_overflow_in_forward_tsn_for_ordered() -> Result<()>
     rq.forward_tsn_for_ordered(u16::MAX);
 
     Ok(())
+}
+
+#[test]
+fn test_message_index_survives_cumulative_prefix_and_tsn_wrap() {
+    use crate::chunk::chunk_payload_data::{MessageId, MessageReliability};
+    let mut queue = PayloadQueue::new();
+    for (tsn, id, beginning, ending) in [
+        (0, 11, false, true),
+        (u32::MAX, 11, true, false),
+        // A lone remaining tail still belongs to a fragmented message.
+        (1, 12, false, true),
+    ] {
+        let mut chunk = make_payload(tsn, 10);
+        chunk.message_id = Some(MessageId::new(id));
+        chunk.reliability = MessageReliability::Rexmit { max_retransmits: 1 };
+        chunk.beginning_fragment = beginning;
+        chunk.ending_fragment = ending;
+        queue.push_no_check(chunk);
+    }
+    assert_eq!(vec![u32::MAX, 0], queue.message_tsns(MessageId::new(11)));
+    queue.pop(u32::MAX).unwrap();
+    assert_eq!(vec![0], queue.message_tsns(MessageId::new(11)));
+    queue.pop(0).unwrap();
+    assert!(queue.message_tsns(MessageId::new(11)).is_empty());
+    assert_eq!(vec![1], queue.message_tsns(MessageId::new(12)));
 }

--- a/rtc-sctp/src/queue/queue_test.rs
+++ b/rtc-sctp/src/queue/queue_test.rs
@@ -37,7 +37,7 @@ fn test_payload_queue_push_no_check() -> Result<()> {
     assert_eq!(3, pq.len(), "item count mismatch");
 
     for i in 0..3 {
-        assert!(!pq.sorted.is_empty(), "should not be empty");
+        assert!(!pq.is_empty(), "should not be empty");
         let c = pq.pop(i);
         assert!(c.is_some(), "pop should succeed");
         if let Some(c) = c {
@@ -48,14 +48,14 @@ fn test_payload_queue_push_no_check() -> Result<()> {
     assert_eq!(0, pq.get_num_bytes(), "total bytes mismatch");
     assert_eq!(0, pq.len(), "item count mismatch");
 
-    assert!(pq.sorted.is_empty(), "should be empty");
+    assert!(pq.is_empty(), "should be empty");
     pq.push_no_check(make_payload(3, 13));
     assert_eq!(13, pq.get_num_bytes(), "total bytes mismatch");
     pq.push_no_check(make_payload(4, 14));
     assert_eq!(27, pq.get_num_bytes(), "total bytes mismatch");
 
     for i in 3..5 {
-        assert!(!pq.sorted.is_empty(), "should not be empty");
+        assert!(!pq.is_empty(), "should not be empty");
         let c = pq.pop(i);
         assert!(c.is_some(), "pop should succeed");
         if let Some(c) = c {

--- a/rtc-sctp/src/queue/queue_test.rs
+++ b/rtc-sctp/src/queue/queue_test.rs
@@ -144,7 +144,7 @@ fn test_payload_queue_mark_all_to_retrasmit() -> Result<()> {
     for i in 0..3 {
         pq.push(make_payload(i + 1, 10), 0);
     }
-    pq.acknowledge(2);
+    pq.acknowledge(2).unwrap();
     pq.mark_all_to_retrasmit();
 
     let c = pq.get(1);
@@ -169,8 +169,8 @@ fn test_payload_queue_reset_retransmit_flag_on_ack() -> Result<()> {
     }
 
     pq.mark_all_to_retrasmit();
-    pq.acknowledge(2); // should cancel retransmission for TSN 2
-    pq.acknowledge(4); // should cancel retransmission for TSN 4
+    pq.acknowledge(2).unwrap(); // should cancel retransmission for TSN 2
+    pq.acknowledge(4).unwrap(); // should cancel retransmission for TSN 4
 
     let c = pq.get(1);
     assert!(c.is_some(), "should be true");

--- a/rtc-sctp/src/queue/reassembly_queue.rs
+++ b/rtc-sctp/src/queue/reassembly_queue.rs
@@ -180,7 +180,7 @@ impl Chunks {
                 //   used by the receiver to reassemble the message.  This means that the
                 //   TSNs for each fragment of a fragmented user message MUST be strictly
                 //   sequential.
-                if c.tsn != last_tsn + 1 {
+                if c.tsn != last_tsn.wrapping_add(1) {
                     // mid or end fragment is missing
                     return false;
                 }
@@ -271,7 +271,15 @@ impl ReassemblyQueue {
 
             // If not found, create a new chunkSet and insert it in SSN order
             // (this branch is only reached for ordered chunks).
-            let mut cset = Chunks::new(self.next_arrival, ssn, chunk.payload_type, vec![]);
+            // A complete single-chunk message needs one metadata record, while
+            // fragmented messages retain normal geometric capacity growth.
+            let capacity = usize::from(chunk.beginning_fragment && chunk.ending_fragment);
+            let mut cset = Chunks::new(
+                self.next_arrival,
+                ssn,
+                chunk.payload_type,
+                Vec::with_capacity(capacity),
+            );
             self.next_arrival += 1;
             let ok = cset.push(chunk);
             self.ordered.insert(idx, cset);
@@ -305,7 +313,7 @@ impl ReassemblyQueue {
             }
 
             // Check if contiguous in TSN
-            if c.tsn != last_tsn + 1 {
+            if c.tsn != last_tsn.wrapping_add(1) {
                 start_idx = -1;
                 continue;
             }

--- a/rtc-sctp/src/queue/receive_queue.rs
+++ b/rtc-sctp/src/queue/receive_queue.rs
@@ -1,0 +1,291 @@
+//! Separates deliverable messages from protocol reassembly and its SSN space.
+
+use super::reassembly_queue::{Chunks, ReassemblyQueue};
+use crate::StreamId;
+use crate::chunk::chunk_payload_data::ChunkPayloadData;
+use std::collections::VecDeque;
+
+/// Local identity of an RX SSN space; independent of API delivery generations.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ReceiveEpoch(u64);
+
+#[derive(Debug)]
+pub(crate) enum DeferredReceive {
+    Data(ChunkPayloadData),
+    ForwardUnordered(u32),
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ReceiveQueue {
+    id: StreamId,
+    assembly: ReassemblyQueue,
+    // The wire SSN epoch may be newer than the oldest API delivery below.
+    epoch: ReceiveEpoch,
+    active: bool,
+    outgoing_reset_requested: bool,
+    // A completed RX reset still needs a pending TX reset to close both sides.
+    // This obligation survives reuse of RX while TX requests stay serialized.
+    required_outgoing_epoch: Option<ReceiveEpoch>,
+    // None is EOF for the preceding API receiver. Later messages belong to
+    // the next receiver even while the application is still reading the old one.
+    ready: VecDeque<Option<Chunks>>,
+    ready_bytes: usize,
+    closed_deliveries: usize,
+    stopped: bool,
+    deferred: VecDeque<DeferredReceive>,
+    deferred_bytes: usize,
+}
+
+impl ReceiveQueue {
+    pub(crate) fn new(id: StreamId) -> Self {
+        Self {
+            id,
+            assembly: ReassemblyQueue::new(id),
+            active: true,
+            ..Self::default()
+        }
+    }
+
+    /// A local open starts use of the current wire epoch even before DATA.
+    pub(crate) fn open(&mut self) {
+        self.active = true;
+    }
+
+    pub(crate) fn needs_reciprocal_reset(&self) -> bool {
+        self.active && !self.outgoing_reset_requested
+    }
+
+    pub(crate) fn note_outgoing_reset(&mut self) -> ReceiveEpoch {
+        self.outgoing_reset_requested = true;
+        self.epoch
+    }
+
+    pub(crate) fn require_outgoing_reset(&mut self) {
+        if self.active {
+            self.required_outgoing_epoch = Some(self.epoch);
+        }
+    }
+
+    /// A later TX reset also covers any earlier unfinished close on this SID.
+    pub(crate) fn complete_outgoing_reset(&mut self, epoch: ReceiveEpoch) {
+        if self
+            .required_outgoing_epoch
+            .is_some_and(|required| epoch >= required)
+        {
+            self.required_outgoing_epoch = None;
+        }
+    }
+
+    /// A refused last request may be attempted again by a later peer close.
+    /// Returns whether an already completed RX reset now cannot be matched.
+    pub(crate) fn refuse_outgoing_reset(&mut self) -> bool {
+        self.outgoing_reset_requested = false;
+        self.required_outgoing_epoch.is_some()
+    }
+
+    /// The API receiver at the front belongs to a completed wire epoch.
+    pub(crate) fn delivery_closed(&self) -> bool {
+        self.closed_deliveries != 0
+    }
+
+    fn collect_ready(&mut self) {
+        while let Some(message) = self.assembly.read() {
+            if !self.stopped || self.delivery_closed() {
+                self.ready_bytes += message.len();
+                self.ready.push_back(Some(message));
+            }
+        }
+    }
+
+    pub(crate) fn push(&mut self, data: ChunkPayloadData) -> bool {
+        self.active = true;
+        let before = self.ready.len();
+        self.assembly.push(data);
+        self.collect_ready();
+        self.ready.len() > before
+    }
+
+    pub(crate) fn is_readable(&self) -> bool {
+        matches!(self.ready.front(), Some(Some(_)))
+    }
+
+    pub(crate) fn read(&mut self) -> Option<Chunks> {
+        if !self.is_readable() {
+            return None;
+        }
+        let message = self.ready.pop_front().flatten().unwrap();
+        self.ready_bytes -= message.len();
+        Some(message)
+    }
+
+    pub(crate) fn forward_tsn_for_ordered(&mut self, ssn: u16) {
+        self.active = true;
+        self.assembly.forward_tsn_for_ordered(ssn);
+        self.collect_ready();
+    }
+
+    pub(crate) fn forward_tsn_for_unordered(&mut self, tsn: u32) {
+        self.assembly.forward_tsn_for_unordered(tsn);
+        self.collect_ready();
+    }
+
+    pub(crate) fn get_num_bytes(&self) -> usize {
+        // Moving a complete message into delivery does not reopen receive credit.
+        self.assembly.get_num_bytes() + self.ready_bytes + self.deferred_bytes
+    }
+
+    pub(crate) fn reset(&mut self) {
+        self.collect_ready();
+        self.assembly = ReassemblyQueue::new(self.id);
+        self.epoch.0 = self
+            .epoch
+            .0
+            .checked_add(1)
+            .expect("RX epoch counter exhausted");
+        self.active = false;
+        self.outgoing_reset_requested = false;
+        // Empty generations need no separate delivery object or unbounded EOFs.
+        if !matches!(self.ready.back(), Some(None)) {
+            self.ready.push_back(None);
+            self.closed_deliveries += 1;
+        }
+    }
+
+    pub(crate) fn finish_delivery(&mut self) -> bool {
+        if !matches!(self.ready.front(), Some(None)) {
+            return false;
+        }
+        self.ready.pop_front();
+        self.closed_deliveries -= 1;
+        self.stopped = false;
+        true
+    }
+
+    pub(crate) fn stop(&mut self) {
+        while let Some(message) = self.read() {
+            drop(message);
+        }
+        self.stopped = true;
+    }
+
+    pub(crate) fn defer(&mut self, action: DeferredReceive) {
+        self.deferred_bytes += match &action {
+            DeferredReceive::Data(data) => data.user_data.len(),
+            DeferredReceive::ForwardUnordered(_) => 4,
+        };
+        self.deferred.push_back(action);
+    }
+
+    pub(crate) fn take_deferred(&mut self) -> VecDeque<DeferredReceive> {
+        self.deferred_bytes = 0;
+        std::mem::take(&mut self.deferred)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    #[test]
+    fn completed_reset_covers_only_its_rx_epoch_and_earlier_obligations() {
+        for newer_required in [false, true] {
+            let mut queue = ReceiveQueue::new(1);
+            let first = queue.note_outgoing_reset();
+            queue.require_outgoing_reset();
+            queue.reset();
+            // Repeated reset of an unused epoch creates no new obligation.
+            queue.require_outgoing_reset();
+            queue.reset();
+            queue.open();
+            let next = queue.note_outgoing_reset();
+            assert!(next > first);
+            if newer_required {
+                queue.require_outgoing_reset();
+                queue.reset();
+            }
+            queue.complete_outgoing_reset(first);
+            assert_eq!(queue.refuse_outgoing_reset(), newer_required);
+            queue.complete_outgoing_reset(next);
+            assert!(!queue.refuse_outgoing_reset());
+        }
+    }
+
+    #[test]
+    fn wire_reset_state_is_independent_of_saved_deliveries() {
+        let mut queue = ReceiveQueue::new(1);
+        for tsn in 1..=2 {
+            assert!(queue.needs_reciprocal_reset());
+            queue.note_outgoing_reset();
+            assert!(!queue.needs_reciprocal_reset());
+            queue.push(ChunkPayloadData {
+                tsn,
+                stream_identifier: 1,
+                beginning_fragment: true,
+                ending_fragment: true,
+                user_data: Bytes::from_static(b"saved"),
+                ..Default::default()
+            });
+            queue.reset();
+            assert!(!queue.needs_reciprocal_reset());
+            assert!(queue.delivery_closed());
+            queue.open();
+        }
+        assert_eq!(queue.closed_deliveries, 2);
+        assert!(queue.needs_reciprocal_reset());
+        assert!(queue.read().is_some());
+        assert!(queue.finish_delivery());
+        assert!(
+            queue.delivery_closed(),
+            "a second saved receiver is still closed"
+        );
+        assert!(queue.read().is_some());
+        assert!(queue.finish_delivery());
+        assert!(!queue.delivery_closed());
+        assert!(
+            queue.needs_reciprocal_reset(),
+            "reading EOF cannot reset the active wire epoch"
+        );
+    }
+
+    #[test]
+    fn ready_delivery_and_reset_preserve_payload_allocations_and_window_charge() {
+        for size in [16, 4000] {
+            for unordered in [false, true] {
+                let original = Bytes::from(vec![0x5a; size]);
+                let mut queue = ReceiveQueue::new(1);
+                let mut pointers = vec![];
+                for (index, start) in (0..size).step_by(1200).enumerate() {
+                    let end = (start + 1200).min(size);
+                    let data = original.slice(start..end);
+                    pointers.push(data.as_ptr());
+                    queue.push(ChunkPayloadData {
+                        stream_identifier: 1,
+                        tsn: index as u32,
+                        unordered,
+                        beginning_fragment: start == 0,
+                        ending_fragment: end == size,
+                        user_data: data,
+                        ..Default::default()
+                    });
+                }
+                queue.reset();
+                assert_eq!(queue.get_num_bytes(), size);
+                let delivered = queue.read().unwrap();
+                assert_eq!(delivered.len(), size);
+                assert_eq!(
+                    delivered
+                        .chunks
+                        .iter()
+                        .map(|chunk| chunk.user_data.as_ptr())
+                        .collect::<Vec<_>>(),
+                    pointers,
+                    "moving unread messages across reset must not copy payload"
+                );
+                assert_eq!(queue.get_num_bytes(), 0);
+                assert!(queue.finish_delivery());
+                assert!(!queue.finish_delivery(), "EOF is consumed once");
+            }
+        }
+    }
+}

--- a/rtc-sctp/src/queue/receive_tsn_queue.rs
+++ b/rtc-sctp/src/queue/receive_tsn_queue.rs
@@ -2,6 +2,18 @@ use crate::chunk::chunk_selective_ack::GapAckBlock;
 use crate::util::{sna32lt, sna32lte};
 use std::collections::VecDeque;
 
+#[derive(Debug)]
+struct ReceivedRange {
+    start: u32,
+    end: u32,
+}
+
+impl ReceivedRange {
+    fn contains(&self, tsn: u32) -> bool {
+        tsn.wrapping_sub(self.start) <= self.end.wrapping_sub(self.start)
+    }
+}
+
 /// Received TSNs above the cumulative ACK, independent of message delivery.
 ///
 /// Unordered messages can be read while an earlier TSN is missing. Receipt
@@ -9,23 +21,26 @@ use std::collections::VecDeque;
 /// must not keep the delivered payload backing alive.
 #[derive(Debug, Default)]
 pub(crate) struct ReceiveTsnQueue {
-    // Serial-number order within the receive window. Sequential arrivals and
-    // cumulative advancement append/pop in amortized O(1), without a second index.
-    tsns: VecDeque<u32>,
+    // Canonical, nonadjacent ranges in serial-number order within the receive
+    // window. A range may cross u32::MAX. Increasing contiguous DATA extends
+    // the tail in O(1); sparse tail appends remain amortized O(1).
+    ranges: VecDeque<ReceivedRange>,
+    n_tsns: usize,
     duplicates: Vec<u32>,
 }
 
 impl ReceiveTsnQueue {
-    /// The common increasing-TSN path needs no binary search. Reordered DATA
-    /// uses the same serial ordering for membership and insertion.
+    /// Locate the containing range, or the gap where a receipt belongs.
     fn position(&self, tsn: u32) -> std::result::Result<usize, usize> {
-        if self.tsns.back().is_none_or(|&last| sna32lt(last, tsn)) {
-            return Err(self.tsns.len());
+        if self.ranges.back().is_none_or(|last| sna32lt(last.end, tsn)) {
+            return Err(self.ranges.len());
         }
-        let index = self
-            .tsns
-            .partition_point(|&received| sna32lt(received, tsn));
-        if self.tsns.get(index) == Some(&tsn) {
+        let index = self.ranges.partition_point(|range| sna32lt(range.end, tsn));
+        if self
+            .ranges
+            .get(index)
+            .is_some_and(|range| range.contains(tsn))
+        {
             Ok(index)
         } else {
             Err(index)
@@ -43,11 +58,27 @@ impl ReceiveTsnQueue {
         if !sna32lte(tsn, cumulative_tsn)
             && let Err(index) = self.position(tsn)
         {
-            if index == self.tsns.len() {
-                self.tsns.push_back(tsn);
-            } else {
-                self.tsns.insert(index, tsn);
+            let joins_previous = index != 0 && self.ranges[index - 1].end.wrapping_add(1) == tsn;
+            let joins_next = self
+                .ranges
+                .get(index)
+                .is_some_and(|next| tsn.wrapping_add(1) == next.start);
+            match (joins_previous, joins_next) {
+                (true, true) => {
+                    let next = self.ranges.remove(index).unwrap();
+                    self.ranges[index - 1].end = next.end;
+                }
+                (true, false) => self.ranges[index - 1].end = tsn,
+                (false, true) => self.ranges[index].start = tsn,
+                (false, false) => self.ranges.insert(
+                    index,
+                    ReceivedRange {
+                        start: tsn,
+                        end: tsn,
+                    },
+                ),
             }
+            self.n_tsns += 1;
             true
         } else {
             self.duplicates.push(tsn);
@@ -57,26 +88,40 @@ impl ReceiveTsnQueue {
 
     /// Remove only the oldest receipt when it matches the next cumulative TSN.
     pub(crate) fn pop(&mut self, tsn: u32) -> Option<u32> {
-        if self.tsns.front() == Some(&tsn) {
-            self.tsns.pop_front()
-        } else {
-            None
+        let first = self.ranges.front_mut()?;
+        if first.start != tsn {
+            return None;
         }
+        if first.start == first.end {
+            self.ranges.pop_front();
+        } else {
+            first.start = first.start.wrapping_add(1);
+        }
+        self.n_tsns -= 1;
+        Some(tsn)
     }
 
     /// FORWARD-TSN retires every receipt covered by its new cumulative point.
     pub(crate) fn discard_through(&mut self, cumulative_tsn: u32) {
-        while self
-            .tsns
-            .front()
-            .is_some_and(|&tsn| sna32lte(tsn, cumulative_tsn))
-        {
-            self.tsns.pop_front();
+        while let Some(first) = self.ranges.front_mut() {
+            if !sna32lte(first.start, cumulative_tsn) {
+                break;
+            }
+            // Widen before adding one: inclusive endpoints can cross u32::MAX.
+            let length = u64::from(first.end.wrapping_sub(first.start)) + 1;
+            let removed = length.min(u64::from(cumulative_tsn.wrapping_sub(first.start)) + 1);
+            self.n_tsns -= removed as usize;
+            if removed == length {
+                self.ranges.pop_front();
+            } else {
+                first.start = cumulative_tsn.wrapping_add(1);
+                break;
+            }
         }
     }
 
     pub(crate) fn get_last_tsn_received(&self) -> Option<&u32> {
-        self.tsns.back()
+        self.ranges.back().map(|range| &range.end)
     }
 
     pub(crate) fn pop_duplicates(&mut self) -> Vec<u32> {
@@ -84,22 +129,32 @@ impl ReceiveTsnQueue {
     }
 
     pub(crate) fn get_gap_ack_blocks(&self, cumulative_tsn: u32) -> Vec<GapAckBlock> {
-        let mut blocks: Vec<GapAckBlock> = vec![];
-        for &tsn in &self.tsns {
-            let offset = tsn.wrapping_sub(cumulative_tsn);
-            if offset == 0 || offset > u16::MAX as u32 {
-                continue; // Retain receipts that this SACK cannot represent yet.
+        fn append_clipped(blocks: &mut Vec<GapAckBlock>, start: u32, end: u32) {
+            let start = start.max(1);
+            let end = end.min(u16::MAX as u32);
+            if start > end {
+                return;
             }
-            let offset = offset as u16;
-            if let Some(last) = blocks.last_mut()
-                && last.end.checked_add(1) == Some(offset)
-            {
-                last.end = offset;
+            // Receipt ranges are already maximal. Clipping to the SACK
+            // window cannot close a hole between two surviving ranges.
+            blocks.push(GapAckBlock {
+                start: start as u16,
+                end: end as u16,
+            });
+        }
+
+        let mut blocks = vec![];
+        for range in &self.ranges {
+            let start = range.start.wrapping_sub(cumulative_tsn);
+            let end = range.end.wrapping_sub(cumulative_tsn);
+            if start <= end {
+                append_clipped(&mut blocks, start, end);
             } else {
-                blocks.push(GapAckBlock {
-                    start: offset,
-                    end: offset,
-                });
+                // The queried cumulative point may lie inside this range.
+                // Match per-TSN filtering on both sides of offset zero without
+                // forgetting receipts outside this SACK's 16-bit window.
+                append_clipped(&mut blocks, start, u32::MAX);
+                append_clipped(&mut blocks, 0, end);
             }
         }
         blocks
@@ -114,7 +169,7 @@ impl ReceiveTsnQueue {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.tsns.len()
+        self.n_tsns
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -224,5 +279,396 @@ mod tests {
         queue.discard_through(cumulative.wrapping_add(7));
         assert!(queue.is_empty());
         assert!(gaps(&queue, cumulative.wrapping_add(7)).is_empty());
+    }
+
+    #[derive(Default)]
+    struct ReceiptModel {
+        origin: u32,
+        cumulative: i64,
+        received: std::collections::BTreeSet<i64>,
+        duplicates: Vec<u32>,
+    }
+
+    impl ReceiptModel {
+        fn wire(&self, logical: i64) -> u32 {
+            self.origin.wrapping_add(logical as u32)
+        }
+
+        fn push(&mut self, queue: &mut ReceiveTsnQueue, logical: i64) {
+            let tsn = self.wire(logical);
+            let cumulative = self.wire(self.cumulative);
+            let accepted = logical > self.cumulative && !self.received.contains(&logical);
+            assert_eq!(queue.can_push(tsn, cumulative), accepted);
+            assert_eq!(
+                queue.can_push(tsn, cumulative),
+                accepted,
+                "eligibility is read-only"
+            );
+            assert_eq!(queue.push(tsn, cumulative), accepted);
+            if accepted {
+                assert!(self.received.insert(logical));
+            } else {
+                self.duplicates.push(tsn);
+            }
+        }
+
+        fn pop_next(&mut self, queue: &mut ReceiveTsnQueue) {
+            let next = self.cumulative + 1;
+            let expected = self.received.first().copied() == Some(next);
+            assert_eq!(
+                queue.pop(self.wire(next)),
+                expected.then_some(self.wire(next))
+            );
+            if expected {
+                assert!(self.received.remove(&next));
+                self.cumulative = next;
+            }
+        }
+
+        fn discard(&mut self, queue: &mut ReceiveTsnQueue, through: i64) {
+            queue.discard_through(self.wire(through));
+            self.received.retain(|&logical| logical > through);
+            self.cumulative = self.cumulative.max(through);
+        }
+
+        fn drain_duplicates(&mut self, queue: &mut ReceiveTsnQueue) {
+            assert_eq!(queue.pop_duplicates(), std::mem::take(&mut self.duplicates));
+            assert!(queue.pop_duplicates().is_empty());
+        }
+
+        fn assert_matches(&self, queue: &ReceiveTsnQueue) {
+            assert_eq!(queue.len(), self.received.len());
+            assert_eq!(queue.is_empty(), self.received.is_empty());
+            assert_eq!(
+                queue.get_last_tsn_received().copied(),
+                self.received.last().map(|&n| self.wire(n))
+            );
+            let mut previous = None;
+            let mut runs = 0;
+            for &logical in &self.received {
+                runs += usize::from(previous != Some(logical - 1));
+                previous = Some(logical);
+                assert!(
+                    !queue.can_push(self.wire(logical), self.wire(self.cumulative)),
+                    "receipt outside the SACK window must still suppress duplicates"
+                );
+            }
+            assert_eq!(
+                queue.ranges.len(),
+                runs,
+                "each maximal receipt run has one range"
+            );
+            for offset in [-1, 0, 1, 2, 3, 17, 65534, 65535, 65536, 65537] {
+                let logical = self.cumulative + offset;
+                assert_eq!(
+                    queue.can_push(self.wire(logical), self.wire(self.cumulative)),
+                    logical > self.cumulative && !self.received.contains(&logical)
+                );
+            }
+            // Independent oracle: enumerate individual logical receipts and apply
+            // modulo arithmetic. It never uses the range search/merge/clip logic.
+            // Some queries intentionally use a stale cumulative point or one that
+            // lies inside a retained run, without first trimming the queue.
+            for cumulative in [
+                self.cumulative,
+                self.cumulative - 1,
+                self.cumulative + 1,
+                self.cumulative + 32768,
+                self.cumulative - 65535,
+            ] {
+                let expected: Vec<u16> = self
+                    .received
+                    .iter()
+                    .filter_map(|&logical| {
+                        let offset = (logical - cumulative).rem_euclid(1_i64 << 32);
+                        (1..=65535).contains(&offset).then_some(offset as u16)
+                    })
+                    .collect();
+                let blocks = queue.get_gap_ack_blocks(self.wire(cumulative));
+                for block in &blocks {
+                    assert!(block.start != 0 && block.start <= block.end);
+                }
+                for pair in blocks.windows(2) {
+                    assert!(
+                        u32::from(pair[0].end) + 1 < u32::from(pair[1].start),
+                        "SACK blocks must be ordered, disjoint and maximal"
+                    );
+                }
+                let actual: Vec<u16> = blocks
+                    .iter()
+                    .flat_map(|block| block.start..=block.end)
+                    .collect();
+                assert_eq!(
+                    actual, expected,
+                    "origin {}, queried cumulative {cumulative}",
+                    self.origin
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn range_receipts_match_individual_set_across_interleaved_operations() {
+        fn next(seed: &mut u64) -> u64 {
+            *seed ^= *seed << 13;
+            *seed ^= *seed >> 7;
+            *seed ^= *seed << 17;
+            *seed
+        }
+
+        for origin in [0, u32::MAX - 8, u32::MAX - 65535] {
+            for mut seed in [1, 237, 9260] {
+                let mut queue = ReceiveTsnQueue::default();
+                let mut model = ReceiptModel {
+                    origin,
+                    ..Default::default()
+                };
+                for logical in [2, 4, 3, 65535, 65536, 65537] {
+                    model.push(&mut queue, logical);
+                }
+                for _ in 0..768 {
+                    let choice = next(&mut seed);
+                    match choice % 8 {
+                        0..=2 => {
+                            let offsets = [-2, 0, 1, 2, 3, 17, 65534, 65535, 65536, 65537];
+                            let offset = if choice & 8 == 0 {
+                                offsets[(next(&mut seed) as usize) % offsets.len()]
+                            } else {
+                                (next(&mut seed) % 128) as i64 + 1
+                            };
+                            model.push(&mut queue, model.cumulative + offset);
+                        }
+                        3 => {
+                            let duplicate = if model.received.is_empty() {
+                                model.cumulative - 1
+                            } else {
+                                *model
+                                    .received
+                                    .iter()
+                                    .nth(next(&mut seed) as usize % model.received.len())
+                                    .unwrap()
+                            };
+                            model.push(&mut queue, duplicate);
+                        }
+                        4 => model.pop_next(&mut queue),
+                        5 => {
+                            let advance = match next(&mut seed) % 4 {
+                                0 => -1,
+                                1 => 1,
+                                2 => 65535,
+                                _ => 65536,
+                            };
+                            model.discard(&mut queue, model.cumulative + advance);
+                        }
+                        6 => {
+                            let wrong_front =
+                                model.received.first().copied().unwrap_or(model.cumulative) + 1;
+                            assert_eq!(
+                                queue.pop(model.wire(wrong_front)),
+                                None,
+                                "pop cannot skip the oldest receipt"
+                            );
+                        }
+                        _ => model.drain_duplicates(&mut queue),
+                    }
+                    model.assert_matches(&queue);
+                }
+                model.drain_duplicates(&mut queue);
+                model.discard(&mut queue, model.cumulative + 65537);
+                model.assert_matches(&queue);
+            }
+        }
+    }
+
+    #[test]
+    fn dense_receipt_runs_merge_and_clip_without_losing_unrepresentable_tsns() {
+        for origin in [123, u32::MAX - 32767] {
+            let mut queue = ReceiveTsnQueue::default();
+            let mut model = ReceiptModel {
+                origin,
+                ..Default::default()
+            };
+            // Two dense runs with one missing bridge. In the second case, that
+            // bridge is wire TSN 0, between u32::MAX and 1.
+            for logical in (2..=65540).filter(|&logical| logical != 32768) {
+                model.push(&mut queue, logical);
+            }
+            assert_eq!(queue.ranges.len(), 2);
+            model.assert_matches(&queue);
+            model.push(&mut queue, 32768);
+            assert_eq!(queue.ranges.len(), 1);
+            model.assert_matches(&queue);
+            assert_eq!(gaps(&queue, origin), [(2, 65535)]);
+            model.pop_next(&mut queue); // TSN 1 remains missing.
+            for duplicate in [65536, 65536, 0, 65540] {
+                model.push(&mut queue, duplicate);
+            }
+            model.drain_duplicates(&mut queue);
+
+            model.push(&mut queue, 1); // Extend the run backwards.
+            model.pop_next(&mut queue);
+            model.assert_matches(&queue);
+            model.discard(&mut queue, 65534); // Trim through the middle of the run.
+            model.assert_matches(&queue);
+            assert_eq!(gaps(&queue, model.wire(model.cumulative)), [(1, 6)]);
+            assert_eq!(queue.len(), 6);
+            for _ in 0..6 {
+                model.pop_next(&mut queue);
+            }
+            model.assert_matches(&queue);
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn long_sparse_receipts_survive_interior_bridges_and_front_tail_churn() {
+        const SPARSE: usize = 8192;
+        for origin in [12345, u32::MAX - 7] {
+            let mut queue = ReceiveTsnQueue::default();
+            let mut model = ReceiptModel {
+                origin,
+                ..Default::default()
+            };
+            for index in 1..=SPARSE {
+                model.push(&mut queue, (2 * index) as i64);
+            }
+            model.assert_matches(&queue);
+            assert_eq!(queue.ranges.len(), SPARSE);
+            let capacity = queue.ranges.capacity();
+            assert!(capacity >= SPARSE);
+
+            // Retire a singleton range from the front and append one at the tail,
+            // keeping a missing TSN between every retained receipt. Two complete
+            // turns through the sparse set exercise the deque's wrapped storage.
+            let mut last = (2 * SPARSE) as i64;
+            for step in 0..2 * SPARSE {
+                model.push(&mut queue, model.cumulative + 1);
+                model.pop_next(&mut queue);
+                model.pop_next(&mut queue);
+                last += 2;
+                model.push(&mut queue, last);
+                assert_eq!(queue.len(), SPARSE);
+                assert_eq!(queue.ranges.len(), SPARSE);
+                assert_eq!(
+                    queue.ranges.capacity(),
+                    capacity,
+                    "bounded churn must reuse storage"
+                );
+                if step % 512 == 0 {
+                    // Keep repeated duplicates queued across later front removals.
+                    model.push(&mut queue, last);
+                    model.push(&mut queue, model.cumulative);
+                    model.assert_matches(&queue);
+                }
+            }
+            model.drain_duplicates(&mut queue);
+            model.assert_matches(&queue);
+
+            // Fill holes around the median in alternating directions. These
+            // bridge insertions remove interior range records, with long tails on
+            // either side; they must preserve all the untouched sparse receipts.
+            let middle = model.cumulative + SPARSE as i64;
+            for distance in 1..=256 {
+                for bridge in [middle - (2 * distance - 1), middle + (2 * distance - 1)] {
+                    model.push(&mut queue, bridge);
+                }
+                assert_eq!(queue.ranges.len(), SPARSE - 2 * distance as usize);
+                if distance % 64 == 0 {
+                    model.assert_matches(&queue);
+                }
+            }
+            model.push(&mut queue, middle - 1);
+            model.push(&mut queue, middle - 1);
+
+            // Collapse all remaining interior holes. The logical set becomes one
+            // range, while its historical sparse allocation remains available for
+            // reuse. This checks count preservation independently of range count.
+            for bridge in (model.cumulative + 3..last).step_by(2) {
+                if !model.received.contains(&bridge) {
+                    model.push(&mut queue, bridge);
+                }
+            }
+            model.assert_matches(&queue);
+            assert_eq!(queue.ranges.len(), 1);
+            assert_eq!(queue.len(), 2 * SPARSE - 1);
+            assert_eq!(queue.ranges.capacity(), capacity);
+            assert_eq!(
+                gaps(&queue, model.wire(model.cumulative)),
+                [(2, (2 * SPARSE) as u16)]
+            );
+            model.drain_duplicates(&mut queue);
+
+            model.discard(&mut queue, last);
+            model.assert_matches(&queue);
+            assert!(queue.is_empty());
+            assert_eq!(queue.ranges.capacity(), capacity);
+            for offset in [2, 4, 6, 3, 5] {
+                model.push(&mut queue, model.cumulative + offset);
+            }
+            model.assert_matches(&queue);
+            assert_eq!(queue.ranges.capacity(), capacity);
+        }
+    }
+
+    #[test]
+    fn long_dense_run_pops_through_tsn_wrap_then_accepts_a_new_run() {
+        const COUNT: i64 = 65540;
+        for origin in [12345, u32::MAX - 32767] {
+            let mut queue = ReceiveTsnQueue::default();
+            let mut model = ReceiptModel {
+                origin,
+                ..Default::default()
+            };
+            for logical in 1..=COUNT {
+                model.push(&mut queue, logical);
+            }
+            assert_eq!(queue.ranges.len(), 1);
+            model.assert_matches(&queue);
+            for duplicate in [1, 65536, 65536] {
+                model.push(&mut queue, duplicate);
+            }
+            let mut popped_max = false;
+            let mut popped_zero = false;
+            for logical in 1..=COUNT {
+                assert_eq!(
+                    queue.pop(model.wire(logical + 1)),
+                    None,
+                    "pop must not jump ahead inside a dense range"
+                );
+                model.pop_next(&mut queue);
+                assert_eq!(queue.len(), (COUNT - logical) as usize);
+                assert_eq!(queue.ranges.len(), usize::from(logical != COUNT));
+                let wire = model.wire(logical);
+                popped_max |= wire == u32::MAX;
+                popped_zero |= wire == 0;
+                if logical % 4096 == 0 || wire == u32::MAX || wire == 0 {
+                    model.assert_matches(&queue);
+                }
+            }
+            assert_eq!(
+                popped_max && popped_zero,
+                u64::from(origin) + COUNT as u64 > u64::from(u32::MAX)
+            );
+            model.assert_matches(&queue);
+            model.drain_duplicates(&mut queue);
+            assert!(queue.is_empty());
+            assert!(queue.get_last_tsn_received().is_none());
+
+            // Reuse the emptied tracker with a fresh hole and a dense tail; old
+            // receipt endpoints/counts must not survive the completed front drain.
+            let prefix = model.cumulative;
+            for logical in prefix + 2..=prefix + 1025 {
+                model.push(&mut queue, logical);
+            }
+            model.pop_next(&mut queue);
+            model.assert_matches(&queue);
+            assert_eq!(gaps(&queue, model.wire(prefix)), [(2, 1025)]);
+            model.push(&mut queue, prefix + 1);
+            for _ in 0..1025 {
+                model.pop_next(&mut queue);
+            }
+            model.assert_matches(&queue);
+            assert!(queue.is_empty());
+        }
     }
 }

--- a/rtc-sctp/src/queue/receive_tsn_queue.rs
+++ b/rtc-sctp/src/queue/receive_tsn_queue.rs
@@ -1,0 +1,228 @@
+use crate::chunk::chunk_selective_ack::GapAckBlock;
+use crate::util::{sna32lt, sna32lte};
+use std::collections::VecDeque;
+
+/// Received TSNs above the cumulative ACK, independent of message delivery.
+///
+/// Unordered messages can be read while an earlier TSN is missing. Receipt
+/// tracking must survive those reads for duplicate detection and SACKs, but
+/// must not keep the delivered payload backing alive.
+#[derive(Debug, Default)]
+pub(crate) struct ReceiveTsnQueue {
+    // Serial-number order within the receive window. Sequential arrivals and
+    // cumulative advancement append/pop in amortized O(1), without a second index.
+    tsns: VecDeque<u32>,
+    duplicates: Vec<u32>,
+}
+
+impl ReceiveTsnQueue {
+    /// The common increasing-TSN path needs no binary search. Reordered DATA
+    /// uses the same serial ordering for membership and insertion.
+    fn position(&self, tsn: u32) -> std::result::Result<usize, usize> {
+        if self.tsns.back().is_none_or(|&last| sna32lt(last, tsn)) {
+            return Err(self.tsns.len());
+        }
+        let index = self
+            .tsns
+            .partition_point(|&received| sna32lt(received, tsn));
+        if self.tsns.get(index) == Some(&tsn) {
+            Ok(index)
+        } else {
+            Err(index)
+        }
+    }
+
+    /// Eligibility checks do not record duplicates; the caller may reject
+    /// DATA for other reasons before committing its receipt with `push`.
+    pub(crate) fn can_push(&self, tsn: u32, cumulative_tsn: u32) -> bool {
+        !sna32lte(tsn, cumulative_tsn) && self.position(tsn).is_err()
+    }
+
+    /// Record receipt, or remember a duplicate in arrival order for a SACK.
+    pub(crate) fn push(&mut self, tsn: u32, cumulative_tsn: u32) -> bool {
+        if !sna32lte(tsn, cumulative_tsn)
+            && let Err(index) = self.position(tsn)
+        {
+            if index == self.tsns.len() {
+                self.tsns.push_back(tsn);
+            } else {
+                self.tsns.insert(index, tsn);
+            }
+            true
+        } else {
+            self.duplicates.push(tsn);
+            false
+        }
+    }
+
+    /// Remove only the oldest receipt when it matches the next cumulative TSN.
+    pub(crate) fn pop(&mut self, tsn: u32) -> Option<u32> {
+        if self.tsns.front() == Some(&tsn) {
+            self.tsns.pop_front()
+        } else {
+            None
+        }
+    }
+
+    /// FORWARD-TSN retires every receipt covered by its new cumulative point.
+    pub(crate) fn discard_through(&mut self, cumulative_tsn: u32) {
+        while self
+            .tsns
+            .front()
+            .is_some_and(|&tsn| sna32lte(tsn, cumulative_tsn))
+        {
+            self.tsns.pop_front();
+        }
+    }
+
+    pub(crate) fn get_last_tsn_received(&self) -> Option<&u32> {
+        self.tsns.back()
+    }
+
+    pub(crate) fn pop_duplicates(&mut self) -> Vec<u32> {
+        std::mem::take(&mut self.duplicates)
+    }
+
+    pub(crate) fn get_gap_ack_blocks(&self, cumulative_tsn: u32) -> Vec<GapAckBlock> {
+        let mut blocks: Vec<GapAckBlock> = vec![];
+        for &tsn in &self.tsns {
+            let offset = tsn.wrapping_sub(cumulative_tsn);
+            if offset == 0 || offset > u16::MAX as u32 {
+                continue; // Retain receipts that this SACK cannot represent yet.
+            }
+            let offset = offset as u16;
+            if let Some(last) = blocks.last_mut()
+                && last.end.checked_add(1) == Some(offset)
+            {
+                last.end = offset;
+            } else {
+                blocks.push(GapAckBlock {
+                    start: offset,
+                    end: offset,
+                });
+            }
+        }
+        blocks
+    }
+
+    pub(crate) fn get_gap_ack_blocks_string(&self, cumulative_tsn: u32) -> String {
+        let mut result = format!("cumTSN={cumulative_tsn}");
+        for block in self.get_gap_ack_blocks(cumulative_tsn) {
+            result += format!(",{}-{}", block.start, block.end).as_str();
+        }
+        result
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.tsns.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gaps(queue: &ReceiveTsnQueue, cumulative_tsn: u32) -> Vec<(u16, u16)> {
+        queue
+            .get_gap_ack_blocks(cumulative_tsn)
+            .iter()
+            .map(|gap| (gap.start, gap.end))
+            .collect()
+    }
+
+    #[test]
+    fn reordered_receipts_and_duplicates_cross_tsn_wrap() {
+        let mut queue = ReceiveTsnQueue::default();
+        let cumulative = u32::MAX - 2;
+        for offset in [4, 2, 5, 3] {
+            let tsn = cumulative.wrapping_add(offset);
+            assert!(queue.can_push(tsn, cumulative));
+            assert!(queue.push(tsn, cumulative));
+        }
+        assert_eq!(queue.len(), 4);
+        assert_eq!(queue.get_last_tsn_received(), Some(&2));
+        assert_eq!(gaps(&queue, cumulative), [(2, 5)]);
+        assert_eq!(queue.pop(0), None, "only the oldest receipt may be popped");
+
+        let duplicate = 0;
+        assert!(!queue.can_push(duplicate, cumulative));
+        assert!(!queue.can_push(cumulative, cumulative));
+        assert!(
+            queue.pop_duplicates().is_empty(),
+            "eligibility is read-only"
+        );
+        for tsn in [duplicate, cumulative, cumulative.wrapping_sub(1), duplicate] {
+            assert!(!queue.push(tsn, cumulative));
+        }
+        assert_eq!(
+            queue.pop_duplicates(),
+            [duplicate, cumulative, cumulative.wrapping_sub(1), duplicate]
+        );
+        assert!(queue.pop_duplicates().is_empty());
+        assert_eq!(gaps(&queue, cumulative), [(2, 5)]);
+
+        assert!(queue.push(cumulative.wrapping_add(1), cumulative));
+        assert_eq!(gaps(&queue, cumulative), [(1, 5)]);
+        for offset in 1..=5 {
+            let tsn = cumulative.wrapping_add(offset);
+            assert_eq!(queue.pop(tsn), Some(tsn));
+        }
+        assert!(queue.is_empty());
+        assert_eq!(queue.get_last_tsn_received(), None);
+    }
+
+    #[test]
+    fn sack_offset_limit_does_not_forget_later_receipts() {
+        for cumulative in [123u32, u32::MAX - 12] {
+            let mut queue = ReceiveTsnQueue::default();
+            for offset in [65536, 1, 65535, 65537, 65534] {
+                assert!(queue.push(cumulative.wrapping_add(offset), cumulative));
+            }
+            assert_eq!(gaps(&queue, cumulative), [(1, 1), (65534, 65535)]);
+            let outside_sack = cumulative.wrapping_add(65536);
+            assert!(!queue.can_push(outside_sack, cumulative));
+            assert!(!queue.push(outside_sack, cumulative));
+            assert_eq!(queue.pop_duplicates(), [outside_sack]);
+
+            // Once the cumulative point advances, formerly unrepresentable
+            // receipts reappear in the SACK without receiving DATA again.
+            let advanced = cumulative.wrapping_add(65534);
+            queue.discard_through(advanced);
+            assert_eq!(queue.len(), 3);
+            assert_eq!(gaps(&queue, advanced), [(1, 3)]);
+            for offset in 1..=3 {
+                let tsn = advanced.wrapping_add(offset);
+                assert_eq!(queue.pop(tsn), Some(tsn));
+            }
+            assert!(queue.is_empty());
+        }
+    }
+
+    #[test]
+    fn forward_tsn_discards_only_covered_receipts_across_wrap() {
+        let cumulative = u32::MAX - 2;
+        let mut queue = ReceiveTsnQueue::default();
+        for offset in [2, 4, 7] {
+            assert!(queue.push(cumulative.wrapping_add(offset), cumulative));
+        }
+        let duplicate = cumulative.wrapping_add(2);
+        assert!(!queue.push(duplicate, cumulative));
+        let forwarded = cumulative.wrapping_add(3);
+        queue.discard_through(forwarded);
+        assert_eq!(gaps(&queue, forwarded), [(1, 1), (4, 4)]);
+        assert_eq!(queue.pop_duplicates(), [duplicate]);
+
+        // The association can advance through the receipt immediately after
+        // FORWARD-TSN, but must stop at the next missing TSN.
+        assert_eq!(queue.pop(forwarded.wrapping_add(1)), Some(1));
+        assert_eq!(queue.pop(forwarded.wrapping_add(2)), None);
+        assert_eq!(queue.len(), 1);
+        queue.discard_through(cumulative.wrapping_add(7));
+        assert!(queue.is_empty());
+        assert!(gaps(&queue, cumulative.wrapping_add(7)).is_empty());
+    }
+}

--- a/src/peer_connection/handler/datachannel.rs
+++ b/src/peer_connection/handler/datachannel.rs
@@ -8,7 +8,8 @@ use crate::peer_connection::event::{
     RTCEventInternal, RTCPeerConnectionEvent, TaggedRTCEventInternal,
 };
 use crate::peer_connection::message::internal::{
-    ApplicationMessage, DTLSMessage, DataChannelEvent, RTCMessageInternal, TaggedRTCMessageInternal,
+    ApplicationMessage, DTLSMessage, DataChannelEvent, RTCMessageInternal, SctpEvent,
+    TaggedRTCMessageInternal,
 };
 use crate::peer_connection::transport::dtls::role::RTCDtlsRole;
 use crate::statistics::accumulator::RTCStatsAccumulator;
@@ -21,7 +22,9 @@ use std::time::{Duration, Instant};
 
 pub(crate) struct DataChannelHandlerContext {
     pub(crate) read_outs: VecDeque<TaggedRTCMessageInternal>,
-    pub(crate) write_outs: VecDeque<TaggedRTCMessageInternal>,
+    // A delayed ACK or local command must not attach to a later channel that
+    // reuses its SID. None is a transport message bypassing this handler.
+    pub(crate) write_outs: VecDeque<(Option<RTCDataChannelId>, TaggedRTCMessageInternal)>,
     pub(crate) event_outs: VecDeque<TaggedRTCEventInternal>,
 
     /// The newest instant a caller has supplied, seeded at construction.
@@ -47,6 +50,22 @@ impl DataChannelHandlerContext {
     /// no monotonicity assert alongside the `max`.
     fn observe(&mut self, now: Instant) {
         self.now = now.max(self.now);
+    }
+
+    fn queue_channel_write(
+        &mut self,
+        owner: RTCDataChannelId,
+        now: Instant,
+        message: datachannel::data_channel::DataChannelMessage,
+    ) {
+        self.write_outs.push_back((
+            Some(owner),
+            TaggedRTCMessageInternal {
+                now,
+                transport: TransportContext::default(),
+                message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)),
+            },
+        ));
     }
 }
 
@@ -87,6 +106,20 @@ impl<'a> DataChannelHandler<'a> {
 
     pub(crate) fn name(&self) -> &'static str {
         "DataChannelHandler"
+    }
+
+    /// Remove the old owner before processing the next use of its wire SID.
+    /// A handshake timeout may already have published and counted its close.
+    fn close_channel(&mut self, stream_id: u16) -> Option<RTCDataChannelId> {
+        let dc = self.data_channels.remove_by_stream(&stream_id)?;
+        if dc.close_emitted {
+            return None;
+        }
+        self.stats.peer_connection.on_data_channel_closed();
+        if let Some(dc_stats) = self.stats.data_channels.get_mut(&dc.id) {
+            dc_stats.on_state_changed(RTCDataChannelState::Closed);
+        }
+        Some(dc.id)
     }
 
     /// Emit the `DataChannelEvent::Open` application message and record the
@@ -143,6 +176,34 @@ impl<'a>
     fn handle_read(&mut self, msg: TaggedRTCMessageInternal) -> Result<()> {
         let now = msg.now;
         self.ctx.observe(now);
+
+        if let RTCMessageInternal::Dtls(DTLSMessage::SctpEvent(event)) = &msg.message {
+            // Apply the old channel's lifecycle before accepting the next DATA
+            // message. Deferring this to poll_event would let a reused SID's
+            // DCEP OPEN reach the old channel and then remove the new owner.
+            if let SctpEvent::Closed(_, stream_id) = event {
+                if let Some(channel_id) = self.close_channel(*stream_id) {
+                    // Keep the application-facing fence in the same read
+                    // pipeline too. EndpointHandler must observe OnClose
+                    // before it publishes OnOpen for the next DCEP message.
+                    self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
+                        now,
+                        transport: msg.transport,
+                        message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
+                            ApplicationMessage {
+                                data_channel_id: channel_id,
+                                data_channel_event: DataChannelEvent::Close,
+                            },
+                        )),
+                    });
+                }
+                return Ok(());
+            }
+            return self.handle_event(TaggedRTCEventInternal {
+                now,
+                event: event.into_internal(),
+            });
+        }
 
         if let RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)) = msg.message {
             debug!(
@@ -277,11 +338,8 @@ impl<'a>
 
             while let Some(data_channel_message) = data_channel.poll_write() {
                 debug!("send data channel message from handle_read");
-                self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
-                    now,
-                    transport: TransportContext::default(),
-                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_channel_message)),
-                });
+                self.ctx
+                    .queue_channel_write(channel_id, now, data_channel_message);
             }
         } else {
             // Bypass
@@ -337,11 +395,8 @@ impl<'a>
 
                 while let Some(data_channel_message) = data_channel.poll_write() {
                     debug!("send data channel message from handle_write");
-                    self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
-                        now,
-                        transport: TransportContext::default(),
-                        message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_channel_message)),
-                    });
+                    self.ctx
+                        .queue_channel_write(channel_id, now, data_channel_message);
                 }
             } else {
                 warn!(
@@ -352,7 +407,7 @@ impl<'a>
         } else {
             // Bypass
             debug!("bypass DataChannel write {:?}", msg.transport.peer_addr);
-            self.ctx.write_outs.push_back(msg);
+            self.ctx.write_outs.push_back((None, msg));
         }
         Ok(())
     }
@@ -362,16 +417,21 @@ impl<'a>
             if let Some(data_channel) = data_channel_internal.data_channel.as_mut() {
                 while let Some(data_channel_message) = data_channel.poll_write() {
                     debug!("send data channel message from poll_write");
-                    self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
-                        now: self.ctx.now,
-                        transport: TransportContext::default(),
-                        message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(data_channel_message)),
-                    });
+                    self.ctx.queue_channel_write(
+                        data_channel_internal.id,
+                        self.ctx.now,
+                        data_channel_message,
+                    );
                 }
             }
         }
 
-        self.ctx.write_outs.pop_front()
+        while let Some((owner, message)) = self.ctx.write_outs.pop_front() {
+            if owner.is_none_or(|id| self.data_channels.contains(&id)) {
+                return Some(message);
+            }
+        }
+        None
     }
 
     fn handle_event(&mut self, evt: TaggedRTCEventInternal) -> Result<()> {
@@ -414,13 +474,11 @@ impl<'a>
 
                         while let Some(data_channel_message) = data_channel.poll_write() {
                             debug!("send data channel message from handle_event");
-                            self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
+                            self.ctx.queue_channel_write(
+                                data_channel_internal.id,
                                 now,
-                                transport: TransportContext::default(),
-                                message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(
-                                    data_channel_message,
-                                )),
-                            });
+                                data_channel_message,
+                            );
                         }
                     }
                 }
@@ -431,28 +489,15 @@ impl<'a>
             }
 
             RTCEventInternal::SCTPStreamClosed(_association_handle, stream_id) => {
-                if let Some(dc) = self.data_channels.remove_by_stream(&stream_id) {
-                    // The event names the channel by handle, as every application-facing
-                    // event does; the stream id was only how SCTP referred to it.
-                    let channel_id = dc.id;
-                    // A channel already closed by handshake timeout has already fired OnClose
-                    // and been counted; do not emit or count it twice.
-                    if !dc.close_emitted {
-                        // Track data channel closed
-                        self.stats.peer_connection.on_data_channel_closed();
-                        if let Some(dc_stats) = self.stats.data_channels.get_mut(&channel_id) {
-                            dc_stats.on_state_changed(RTCDataChannelState::Closed);
-                        }
-
-                        self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                            now,
-                            event: RTCEventInternal::RTCPeerConnectionEvent(
-                                RTCPeerConnectionEvent::OnDataChannel(
-                                    RTCDataChannelEvent::OnClose(channel_id),
-                                ),
-                            ),
-                        });
-                    }
+                if let Some(channel_id) = self.close_channel(stream_id) {
+                    self.ctx.event_outs.push_back(TaggedRTCEventInternal {
+                        now,
+                        event: RTCEventInternal::RTCPeerConnectionEvent(
+                            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(
+                                channel_id,
+                            )),
+                        ),
+                    });
                 }
             }
 

--- a/src/peer_connection/handler/mod.rs
+++ b/src/peer_connection/handler/mod.rs
@@ -30,6 +30,7 @@ use crate::peer_connection::state::signaling_state::RTCSignalingState;
 use crate::statistics::accumulator::RTCStatsAccumulator;
 use ::interceptor::Packet;
 use log::warn;
+use sansio::Protocol;
 use shared::TaggedBytesMut;
 use shared::error::{Error, flatten_errs};
 use std::collections::VecDeque;
@@ -189,14 +190,100 @@ impl RTCPeerConnection {
     /// without the other.
     #[doc(hidden)]
     pub fn poll_data_read(&mut self) -> Option<TaggedRTCMessage> {
+        if self.pipeline_context.data_read_outs.is_empty() {
+            self.drain_sctp_reads();
+        }
         self.pipeline_context.data_read_outs.pop_front()
+    }
+
+    /// Continue the read pipeline after SCTP without requiring another network
+    /// packet. Reacquiring the handler for each output accounts for DATA just
+    /// published to the application backlog before the next bounded SCTP drain.
+    /// Lifecycle fences follow the same suffix as DATA, preserving channel reuse.
+    fn drain_sctp_reads(&mut self) {
+        let mut intermediate_routs = VecDeque::new();
+        loop {
+            let message = self.get_sctp_handler().poll_read();
+            let has_sctp_output = message.is_some();
+            if let Some(message) = message {
+                intermediate_routs.push_back(message);
+            }
+            // Interceptors may already have pending media even when SCTP has
+            // no output, so preserve the read pipeline's final empty pass.
+            process_handler_list!(call_macro: process_handler!(self, handler, {
+                while let Some(msg) = intermediate_routs.pop_front() {
+                    if let Err(err) = handler.handle_read(msg) {
+                        warn!("{}.handle_read got error: {}", handler.name(), err);
+                    }
+                }
+                while let Some(msg) = handler.poll_read() {
+                    intermediate_routs.push_back(msg);
+                }
+            }), [get_datachannel_handler, get_srtp_handler, get_interceptor_handler, get_endpoint_handler]);
+            self.publish_application_reads(&mut intermediate_routs);
+            if !has_sctp_output {
+                break;
+            }
+        }
+    }
+
+    fn publish_application_reads(
+        &mut self,
+        intermediate_routs: &mut VecDeque<TaggedRTCMessageInternal>,
+    ) {
+        // Finally, put intermediate_routs into RTCPeerConnection's routs
+        while let Some(msg) = intermediate_routs.pop_front() {
+            let rtc_message = match msg.message {
+                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(application_message)) => {
+                    if let DataChannelEvent::Message(data_channel_message) =
+                        application_message.data_channel_event
+                    {
+                        Some(RTCMessage::DataChannelMessage(
+                            application_message.data_channel_id,
+                            data_channel_message,
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                RTCMessageInternal::Rtp(RTPMessage::TrackPacket(track_packet)) => {
+                    match track_packet.packet {
+                        Packet::Rtp(packet) => {
+                            Some(RTCMessage::RtpPacket(track_packet.track_id, packet))
+                        }
+                        Packet::Rtcp(packet) => {
+                            Some(RTCMessage::RtcpPacket(track_packet.track_id, packet))
+                        }
+                        _ => None,
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(rtc_message) = rtc_message {
+                // The instant travels with the message: the application learns when the packet
+                // was observed at the socket, not when it happened to drain it.
+                let tagged = TaggedRTCMessage {
+                    now: msg.now,
+                    message: rtc_message,
+                };
+                // Routed by kind, so a caller can decline data-channel output — the only way
+                // to apply SCTP back-pressure — without also declining media.
+                match &tagged.message {
+                    RTCMessage::DataChannelMessage(..) => {
+                        self.pipeline_context.data_read_outs.push_back(tagged)
+                    }
+                    _ => self.pipeline_context.media_read_outs.push_back(tagged),
+                }
+            }
+        }
     }
 
     pub(crate) fn get_sctp_handler(&mut self) -> SctpHandler<'_> {
         // The SCTP handler bounds how much it pulls out of the reassembly queues against what
         // the application has not yet consumed. That backlog lives here, not in the handler's
-        // own `read_outs` — the pipeline empties that within a single `handle_read` — and it
-        // is data-channel output only, so unrelated media cannot throttle SCTP.
+        // own `read_outs` — the read pipeline forwards those immediately — and it is
+        // data-channel output only, so unrelated media cannot throttle SCTP.
         let downstream_backlog = self.pipeline_context.data_read_outs.len();
         SctpHandler::new(
             &mut self.pipeline_context.sctp_handler_context,
@@ -258,7 +345,7 @@ impl sansio::Protocol<TaggedBytesMut, TaggedRTCMessage, TaggedRTCEvent> for RTCP
             message: RTCMessageInternal::Raw(msg.message),
         });
 
-        for_each_handler!(forward: process_handler!(self, handler, {
+        process_handler_list!(call_macro: process_handler!(self, handler, {
             while let Some(msg) = intermediate_routs.pop_front() {
                 if let Err(err) = handler.handle_read(msg) {
                     warn!("{}.handle_read got error: {}", handler.name(), err);
@@ -267,59 +354,25 @@ impl sansio::Protocol<TaggedBytesMut, TaggedRTCMessage, TaggedRTCEvent> for RTCP
             while let Some(msg) = handler.poll_read() {
                 intermediate_routs.push_back(msg);
             }
-        }));
+        }), [get_demuxer_handler, get_ice_handler, get_dtls_handler]);
 
-        // Finally, put intermediate_routs into RTCPeerConnection's routs
-        while let Some(msg) = intermediate_routs.pop_front() {
-            let rtc_message = match msg.message {
-                RTCMessageInternal::Dtls(DTLSMessage::DataChannel(application_message)) => {
-                    if let DataChannelEvent::Message(data_channel_message) =
-                        application_message.data_channel_event
-                    {
-                        Some(RTCMessage::DataChannelMessage(
-                            application_message.data_channel_id,
-                            data_channel_message,
-                        ))
-                    } else {
-                        None
-                    }
-                }
-                RTCMessageInternal::Rtp(RTPMessage::TrackPacket(track_packet)) => {
-                    match track_packet.packet {
-                        Packet::Rtp(packet) => {
-                            Some(RTCMessage::RtpPacket(track_packet.track_id, packet))
-                        }
-                        Packet::Rtcp(packet) => {
-                            Some(RTCMessage::RtcpPacket(track_packet.track_id, packet))
-                        }
-                        _ => None,
-                    }
-                }
-                _ => None,
-            };
-
-            if let Some(rtc_message) = rtc_message {
-                // The instant travels with the message: the application learns when the packet
-                // was observed at the socket, not when it happened to drain it.
-                let tagged = TaggedRTCMessage {
-                    now: msg.now,
-                    message: rtc_message,
-                };
-                // Routed by kind, so a caller can decline data-channel output — the only way
-                // to apply SCTP back-pressure — without also declining media.
-                match &tagged.message {
-                    RTCMessage::DataChannelMessage(..) => {
-                        self.pipeline_context.data_read_outs.push_back(tagged)
-                    }
-                    _ => self.pipeline_context.media_read_outs.push_back(tagged),
+        {
+            let mut handler = self.get_sctp_handler();
+            while let Some(msg) = intermediate_routs.pop_front() {
+                if let Err(err) = handler.handle_read(msg) {
+                    warn!("{}.handle_read got error: {}", handler.name(), err);
                 }
             }
         }
+        self.drain_sctp_reads();
 
         Ok(())
     }
 
     fn poll_read(&mut self) -> Option<Self::Rout> {
+        if self.pipeline_context.data_read_outs.is_empty() {
+            self.drain_sctp_reads();
+        }
         if let (Some(data), Some(media)) = (
             self.pipeline_context.data_read_outs.front(),
             self.pipeline_context.media_read_outs.front(),

--- a/src/peer_connection/handler/sctp.rs
+++ b/src/peer_connection/handler/sctp.rs
@@ -1,6 +1,6 @@
 use crate::peer_connection::event::{RTCEventInternal, TaggedRTCEventInternal};
 use crate::peer_connection::message::internal::{
-    DTLSMessage, RTCMessageInternal, TaggedRTCMessageInternal,
+    DTLSMessage, RTCMessageInternal, SctpEvent, TaggedRTCMessageInternal,
 };
 use crate::peer_connection::transport::sctp::SctpTransport;
 use bytes::BytesMut;
@@ -162,15 +162,29 @@ impl<'a> SctpHandler<'a> {
             return Ok(());
         }
 
-        let mut stream = conn.stream(id)?;
         loop {
             if *budget == 0 {
                 // Leave the rest in the reassembly queue: that is what shrinks `a_rwnd`.
                 ctx_pending.insert((ch, id));
                 return Ok(());
             }
-            let Some(chunks) = stream.read_sctp()? else {
+            // A read can retire this API receiver and publish the next use of
+            // its SID. Reacquire the stream after draining its lifecycle events
+            // so the close fence precedes any DATA from that next use.
+            let received = match conn.stream(id) {
+                Ok(mut stream) => stream.read_sctp(),
+                Err(err) => Err(err),
+            };
+            let chunks = match received {
+                Ok(chunks) => chunks,
+                Err(Error::ErrStreamClosed | Error::ErrStreamNotExisted) => None,
+                Err(err) => return Err(err),
+            };
+            let Some(chunks) = chunks else {
                 ctx_pending.remove(&(ch, id));
+                while let Some(readable) = Self::poll_association_events(conn, ch, messages) {
+                    ctx_pending.insert((ch, readable));
+                }
                 return Ok(());
             };
             // Reassemble straight into the delivered buffer: one copy instead of the
@@ -185,6 +199,10 @@ impl<'a> SctpHandler<'a> {
                 negotiated: false,
             }));
             *budget -= 1;
+
+            while let Some(readable) = Self::poll_association_events(conn, ch, messages) {
+                ctx_pending.insert((ch, readable));
+            }
         }
     }
 
@@ -236,16 +254,14 @@ impl<'a> SctpHandler<'a> {
                 &mut messages,
             )?;
 
-            for message in messages {
-                if let SctpMessage::Inbound(message) = message {
-                    drained_any = true;
-                    self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                        now,
-                        transport,
-                        message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)),
-                    });
-                }
-            }
+            drained_any |= !messages.is_empty();
+            Self::enqueue_messages(
+                messages,
+                now,
+                transport,
+                &mut self.ctx.read_outs,
+                &mut self.ctx.write_outs,
+            );
         }
 
         if drained_any {
@@ -260,12 +276,103 @@ impl<'a> SctpHandler<'a> {
         "SctpHandler"
     }
 
+    /// Forward association events until a readable stream needs attention.
+    /// The caller drains or parks that stream, then calls again until None.
+    /// This also processes events produced by reading (such as a deferred reset),
+    /// while preserving the caller's read budget and transport context.
+    fn poll_association_events(
+        conn: &mut Association,
+        ch: AssociationHandle,
+        messages: &mut Vec<SctpMessage>,
+    ) -> Option<StreamId> {
+        while let Some(event) = conn.poll() {
+            match event {
+                Event::HandshakeFailed { reason } => {
+                    debug!(
+                        "association_handle {} handshake failed due to {}",
+                        ch.0, reason
+                    );
+                    //TODO: put it into event_outs?
+                }
+                Event::Connected => {
+                    debug!("association_handle {} is connected", ch.0);
+                    messages.push(SctpMessage::Event(SctpEvent::Connected(ch.0)));
+                }
+                Event::AssociationLost { reason, id } => {
+                    debug!("association_handle {} is closed due to {}", ch.0, reason);
+                    messages.push(SctpMessage::Event(SctpEvent::Closed(ch.0, id)));
+                }
+                Event::Stream(StreamEvent::Readable { id }) => {
+                    return Some(id);
+                }
+                Event::Stream(StreamEvent::BufferedAmountLow { id }) => {
+                    debug!(
+                        "association_handle {} stream id {} is buffered amount low",
+                        ch.0, id
+                    );
+                    messages.push(SctpMessage::Event(SctpEvent::BufferedAmountLow(ch.0, id)));
+                }
+                Event::Stream(StreamEvent::BufferedAmountHigh { id }) => {
+                    debug!(
+                        "association_handle {} stream id {} is buffered amount high",
+                        ch.0, id
+                    );
+                    messages.push(SctpMessage::Event(SctpEvent::BufferedAmountHigh(ch.0, id)));
+                }
+                Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) => {
+                    // Forward the exact released byte count so the data
+                    // channel handler can decrement its synchronous
+                    // send back-pressure counter (see DataChannelHandler).
+                    messages.push(SctpMessage::Event(SctpEvent::BufferReleased(
+                        ch.0, id, n_bytes,
+                    )));
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn enqueue_messages(
+        messages: Vec<SctpMessage>,
+        now: Instant,
+        transport: TransportContext,
+        read_outs: &mut VecDeque<TaggedRTCMessageInternal>,
+        write_outs: &mut VecDeque<TaggedRTCMessageInternal>,
+    ) {
+        for message in messages {
+            let message = match message {
+                SctpMessage::Inbound(message) => DTLSMessage::Sctp(message),
+                SctpMessage::Event(event) => DTLSMessage::SctpEvent(event),
+                SctpMessage::Outbound(transmit) => {
+                    if let Payload::RawEncode(raw_data) = transmit.message {
+                        for raw in raw_data {
+                            write_outs.push_back(TaggedRTCMessageInternal {
+                                now: transmit.now,
+                                transport: transmit.transport,
+                                message: RTCMessageInternal::Dtls(DTLSMessage::Raw(
+                                    BytesMut::from(&raw[..]),
+                                )),
+                            });
+                        }
+                    }
+                    continue;
+                }
+            };
+            read_outs.push_back(TaggedRTCMessageInternal {
+                now,
+                transport,
+                message: RTCMessageInternal::Dtls(message),
+            });
+        }
+    }
+
     /// Batch-drain flush: gather every association's pending outbound in one pass
     /// into `write_outs`. Called once per event-loop iteration from poll_write when
     /// `flush_dirty` is set, after a burst of inbound packets has been ingested, so
     /// their SACKs coalesce into a single datagram.
     fn flush_transmits(&mut self, now: Instant) {
-        for conn in self.ctx.sctp_transport.sctp_associations.values_mut() {
+        for (ch, conn) in self.ctx.sctp_transport.sctp_associations.iter_mut() {
             while let Some(x) = conn.poll_transmit(now) {
                 for transmit in split_transmit(x) {
                     if let Payload::RawEncode(raw_data) = transmit.message {
@@ -281,12 +388,28 @@ impl<'a> SctpHandler<'a> {
                     }
                 }
             }
+            let mut messages = vec![];
+            while let Some(id) = Self::poll_association_events(conn, *ch, &mut messages) {
+                self.ctx.pending_readable.insert((*ch, id));
+            }
+            Self::enqueue_messages(
+                messages,
+                now,
+                self.ctx
+                    .association_transport
+                    .get(ch)
+                    .copied()
+                    .unwrap_or_default(),
+                &mut self.ctx.read_outs,
+                &mut self.ctx.write_outs,
+            );
         }
     }
 }
 
 enum SctpMessage {
     Inbound(DataChannelMessage),
+    Event(SctpEvent),
     Outbound(TransportMessage<Payload>),
 }
 
@@ -367,73 +490,16 @@ impl<'a>
                         }
                     }
 
-                    while let Some(event) = conn.poll() {
-                        match event {
-                            Event::HandshakeFailed { reason } => {
-                                debug!(
-                                    "association_handle {} handshake failed due to {}",
-                                    ch.0, reason
-                                );
-                                //TODO: put it into event_outs?
-                            }
-                            Event::Connected => {
-                                debug!("association_handle {} is connected", ch.0);
-                                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                    now,
-                                    event: RTCEventInternal::SCTPHandshakeComplete(ch.0),
-                                });
-                            }
-                            Event::AssociationLost { reason, id } => {
-                                debug!("association_handle {} is closed due to {}", ch.0, reason);
-                                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                    now,
-                                    event: RTCEventInternal::SCTPStreamClosed(ch.0, id),
-                                });
-                            }
-                            Event::Stream(StreamEvent::Readable { id }) => {
-                                // Bounded: what is not read stays in the reassembly queue,
-                                // which is what lowers `a_rwnd` and throttles the peer.
-                                Self::drain_stream(
-                                    &mut self.ctx.pending_readable,
-                                    conn,
-                                    *ch,
-                                    id,
-                                    max_len,
-                                    &mut budget,
-                                    &mut messages,
-                                )?;
-                            }
-                            Event::Stream(StreamEvent::BufferedAmountLow { id }) => {
-                                debug!(
-                                    "association_handle {} stream id {} is buffered amount low",
-                                    ch.0, id
-                                );
-                                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                    now,
-                                    event: RTCEventInternal::SCTPBufferedAmountLow(ch.0, id),
-                                });
-                            }
-                            Event::Stream(StreamEvent::BufferedAmountHigh { id }) => {
-                                debug!(
-                                    "association_handle {} stream id {} is buffered amount high",
-                                    ch.0, id
-                                );
-                                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                    now,
-                                    event: RTCEventInternal::SCTPBufferedAmountHigh(ch.0, id),
-                                });
-                            }
-                            Event::Stream(StreamEvent::BufferedAmountReleased { id, n_bytes }) => {
-                                // Forward the exact released byte count so the data
-                                // channel handler can decrement its synchronous
-                                // send back-pressure counter (see DataChannelHandler).
-                                self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                    now,
-                                    event: RTCEventInternal::SCTPBufferReleased(ch.0, id, n_bytes),
-                                });
-                            }
-                            _ => {}
-                        }
+                    while let Some(id) = Self::poll_association_events(conn, *ch, &mut messages) {
+                        Self::drain_stream(
+                            &mut self.ctx.pending_readable,
+                            conn,
+                            *ch,
+                            id,
+                            max_len,
+                            &mut budget,
+                            &mut messages,
+                        )?;
                     }
 
                     while let Some(event) = conn.poll_endpoint_event() {
@@ -456,6 +522,9 @@ impl<'a>
                                 messages.push(SctpMessage::Outbound(transmit));
                             }
                         }
+                        while Self::poll_association_events(conn, *drained_ch, &mut messages)
+                            .is_some()
+                        {}
                     }
                 }
 
@@ -469,34 +538,13 @@ impl<'a>
                 }
             }
 
-            for message in messages {
-                match message {
-                    SctpMessage::Inbound(message) => {
-                        debug!(
-                            "recv sctp data channel message {:?}",
-                            msg.transport.peer_addr
-                        );
-                        self.ctx.read_outs.push_back(TaggedRTCMessageInternal {
-                            now: msg.now,
-                            transport: msg.transport,
-                            message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)),
-                        })
-                    }
-                    SctpMessage::Outbound(transmit) => {
-                        if let Payload::RawEncode(raw_data) = transmit.message {
-                            for raw in raw_data {
-                                self.ctx.write_outs.push_back(TaggedRTCMessageInternal {
-                                    now: transmit.now,
-                                    transport: transmit.transport,
-                                    message: RTCMessageInternal::Dtls(DTLSMessage::Raw(
-                                        BytesMut::from(&raw[..]),
-                                    )),
-                                });
-                            }
-                        }
-                    }
-                }
-            }
+            Self::enqueue_messages(
+                messages,
+                msg.now,
+                msg.transport,
+                &mut self.ctx.read_outs,
+                &mut self.ctx.write_outs,
+            );
 
             if let Some((ch, transport)) = inbound_transport
                 && self.ctx.sctp_transport.sctp_associations.contains_key(&ch)
@@ -594,14 +642,6 @@ impl<'a>
                             );
                             let mut stream = conn.stream(message.stream_id)?;
                             stream.close(now)?;
-
-                            self.ctx.event_outs.push_back(TaggedRTCEventInternal {
-                                now,
-                                event: RTCEventInternal::SCTPStreamClosed(
-                                    message.association_handle,
-                                    message.stream_id,
-                                ),
-                            });
                         }
                         Message::DataChannelThreshold(data_channel_threshold) => {
                             is_dcep_internal_control_message = true;
@@ -624,14 +664,16 @@ impl<'a>
                     }
                 }
 
-                let mut stream = conn.stream(message.stream_id)?;
-                if !is_dcep_internal_control_message && stream.is_writable() {
-                    // The payload is owned end-to-end (the DataChannel `send` API
-                    // takes the buffer by value), so hand it to SCTP zero-copy:
-                    // `freeze()` is O(1) and the enqueued chunks are refcounted
-                    // slices, eliminating a per-message alloc + full-payload memcpy.
-                    let payload = std::mem::take(&mut message.payload).freeze();
-                    stream.write_chunk_with_ppi(now, &payload, message.ppi)?;
+                if !is_dcep_internal_control_message {
+                    let mut stream = conn.stream(message.stream_id)?;
+                    if stream.is_writable() {
+                        // The payload is owned end-to-end (the DataChannel `send` API
+                        // takes the buffer by value), so hand it to SCTP zero-copy:
+                        // `freeze()` is O(1) and the enqueued chunks are refcounted
+                        // slices, eliminating a per-message alloc + full-payload memcpy.
+                        let payload = std::mem::take(&mut message.payload).freeze();
+                        stream.write_chunk_with_ppi(now, &payload, message.ppi)?;
+                    }
                 }
 
                 // Transmit flush is deferred to poll_write (batch-drain).
@@ -707,7 +749,27 @@ impl<'a>
     }
 
     fn poll_event(&mut self) -> Option<Self::Eout> {
-        self.ctx.event_outs.pop_front()
+        if let Some(event) = self.ctx.event_outs.pop_front() {
+            return Some(event);
+        }
+        // A timeout or transmit flush can release bytes with no incoming DATA
+        // to drive the read pipeline. Such lifecycle events may also leave via
+        // poll_event, but only from the head of the same FIFO: they must never
+        // pass older DATA, and are removed exactly once through either route.
+        if let Some(TaggedRTCMessageInternal {
+            message: RTCMessageInternal::Dtls(DTLSMessage::SctpEvent(event)),
+            now,
+            ..
+        }) = self.ctx.read_outs.front()
+        {
+            let event = TaggedRTCEventInternal {
+                now: *now,
+                event: event.into_internal(),
+            };
+            self.ctx.read_outs.pop_front();
+            return Some(event);
+        }
+        None
     }
 
     fn handle_timeout(&mut self, now: Instant) -> Result<()> {
@@ -729,6 +791,21 @@ impl<'a>
         let mut endpoint_events: Vec<(AssociationHandle, EndpointEvent)> = vec![];
         for (ch, conn) in sctp_associations.iter_mut() {
             conn.handle_timeout(now);
+            let mut messages = vec![];
+            while let Some(id) = Self::poll_association_events(conn, *ch, &mut messages) {
+                self.ctx.pending_readable.insert((*ch, id));
+            }
+            Self::enqueue_messages(
+                messages,
+                now,
+                self.ctx
+                    .association_transport
+                    .get(ch)
+                    .copied()
+                    .unwrap_or_default(),
+                &mut self.ctx.read_outs,
+                &mut self.ctx.write_outs,
+            );
 
             while let Some(event) = conn.poll_endpoint_event() {
                 endpoint_events.push((*ch, event));
@@ -744,6 +821,19 @@ impl<'a>
                 while let Some(x) = conn.poll_transmit(now) {
                     transmits.extend(split_transmit(x));
                 }
+                let mut messages = vec![];
+                while Self::poll_association_events(conn, *drained_ch, &mut messages).is_some() {}
+                Self::enqueue_messages(
+                    messages,
+                    now,
+                    self.ctx
+                        .association_transport
+                        .get(drained_ch)
+                        .copied()
+                        .unwrap_or_default(),
+                    &mut self.ctx.read_outs,
+                    &mut self.ctx.write_outs,
+                );
             }
         }
 
@@ -839,6 +929,826 @@ mod tests {
     use shared::{TransportProtocol, marshal::Marshal};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::time::Duration;
+
+    #[test]
+    fn reused_sid_survives_delayed_reset_response_and_handler_event_order() {
+        fn pump(
+            ctx: &mut SctpHandlerContext,
+            dcctx: &mut DataChannelHandlerContext,
+            registry: &mut DataChannelRegistry,
+            stats: &mut RTCStatsAccumulator,
+        ) {
+            // The production pipeline routes handle_read output first, then
+            // processes the SCTP lifecycle notifications on poll_event.
+            let mut handler =
+                DataChannelHandler::new(dcctx, registry, stats, None, RTCDtlsRole::Client, None);
+            for msg in ctx.read_outs.drain(..) {
+                handler.handle_read(msg).unwrap();
+            }
+            for event in ctx.event_outs.drain(..) {
+                handler.handle_event(event).unwrap();
+            }
+        }
+        let mut e = establish();
+        let now = Instant::now();
+        let ppi = PayloadProtocolIdentifier::Dcep;
+        let dcep = |label: &[u8]| {
+            Bytes::from(
+                Message::DataChannelOpen(DataChannelOpen {
+                    channel_type: ChannelType::Reliable,
+                    priority: CHANNEL_PRIORITY_NORMAL,
+                    reliability_parameter: 0,
+                    label: label.to_vec(),
+                    protocol: vec![],
+                })
+                .marshal()
+                .unwrap(),
+            )
+        };
+        let mut data_channel_ctx = DataChannelHandlerContext::new(now);
+        let mut data_channels = DataChannelRegistry::new();
+        let mut stats = RTCStatsAccumulator::new();
+        DataChannelHandler::new(
+            &mut data_channel_ctx,
+            &mut data_channels,
+            &mut stats,
+            None,
+            RTCDtlsRole::Client,
+            None,
+        )
+        .handle_read(TaggedRTCMessageInternal {
+            now,
+            transport: Default::default(),
+            message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(DataChannelMessage {
+                association_handle: e.client_ch.0,
+                stream_id: 1,
+                ppi,
+                payload: BytesMut::from(dcep(b"old").as_ref()),
+                negotiated: false,
+            })),
+        })
+        .unwrap();
+        data_channel_ctx.read_outs.clear();
+        data_channel_ctx.write_outs.clear();
+        data_channel_ctx.event_outs.clear();
+        data_channels.get_by_stream_mut(&1).unwrap().ready_state =
+            crate::data_channel::state::RTCDataChannelState::Closing;
+
+        e.client_conn
+            .open_stream(1, ppi)
+            .unwrap()
+            .close(now)
+            .unwrap();
+        e.server_conn.open_stream(1, ppi).unwrap();
+        for dgram in drain_transmits(&mut e.client_conn, now) {
+            if let Some((_, DatagramEvent::AssociationEvent(event))) =
+                e.server_ep.handle(now, client_addr(), None, dgram)
+            {
+                e.server_conn.handle_event(event);
+            }
+        }
+        let server_reset_packets = drain_transmits(&mut e.server_conn, now);
+        let mut delayed_response = None;
+        let mut ctx = client_ctx(now, e.client_ep, e.client_ch, e.client_conn);
+        for dgram in server_reset_packets {
+            if dgram.len() > 18 && dgram[12] == 130 && dgram[16..18] == [0, 16] {
+                delayed_response = Some(dgram);
+            } else {
+                SctpHandler::new(&mut ctx, 0)
+                    .handle_read(raw_read(now, dgram))
+                    .unwrap();
+                pump(
+                    &mut ctx,
+                    &mut data_channel_ctx,
+                    &mut data_channels,
+                    &mut stats,
+                );
+            }
+        }
+        {
+            let mut handler = SctpHandler::new(&mut ctx, 0);
+            while let Some(out) = handler.poll_write() {
+                if let RTCMessageInternal::Dtls(DTLSMessage::Raw(raw)) = out.message {
+                    if let Some((_, DatagramEvent::AssociationEvent(event))) =
+                        e.server_ep.handle(now, client_addr(), None, raw.freeze())
+                    {
+                        e.server_conn.handle_event(event);
+                    }
+                }
+            }
+        }
+        assert!(
+            e.server_conn.stream(1).is_err(),
+            "peer has completed both resets"
+        );
+        e.server_conn
+            .open_stream(1, ppi)
+            .unwrap()
+            .write_sctp(now, &dcep(b"new"), ppi)
+            .unwrap();
+        for dgram in drain_transmits(&mut e.server_conn, now) {
+            SctpHandler::new(&mut ctx, 0)
+                .handle_read(raw_read(now, dgram))
+                .unwrap();
+            pump(
+                &mut ctx,
+                &mut data_channel_ctx,
+                &mut data_channels,
+                &mut stats,
+            );
+        }
+        SctpHandler::new(&mut ctx, 0)
+            .handle_read(raw_read(now, delayed_response.unwrap()))
+            .unwrap();
+        pump(
+            &mut ctx,
+            &mut data_channel_ctx,
+            &mut data_channels,
+            &mut stats,
+        );
+        let reopened = data_channels
+            .get_by_stream_mut(&1)
+            .expect("reused SID must have a new channel after processing the old close");
+        assert_eq!("new", reopened.label);
+    }
+
+    #[test]
+    fn timed_abandonment_releases_buffers_without_inbound_packets() {
+        for size in [4, 12000] {
+            let mut e = establish();
+            let now = Instant::now();
+            let ppi = PayloadProtocolIdentifier::Binary;
+            let mut stream = e.client_conn.open_stream(1, ppi).unwrap();
+            stream
+                .set_reliability_params(false, sctp::ReliabilityType::Timed, 100)
+                .unwrap();
+            stream
+                .write_sctp(now, &Bytes::from(vec![0x55; size]), ppi)
+                .unwrap();
+            assert!(!drain_transmits(&mut e.client_conn, now).is_empty());
+            while e.client_conn.poll().is_some() {}
+            // Expiration can happen either in T3 or while flushing a pending tail.
+            let at = if size == 4 {
+                e.client_conn.poll_timeout().unwrap()
+            } else {
+                now + Duration::from_millis(100)
+            };
+            let ch = e.client_ch;
+            let mut ctx = client_ctx(now, e.client_ep, ch, e.client_conn);
+            let mut handler = SctpHandler::new(&mut ctx, 0);
+            handler.handle_timeout(at).unwrap();
+            let mut released = 0;
+            let mut low = 0;
+            let mut collect = |handler: &mut SctpHandler<'_>| {
+                while let Some(event) = handler.poll_event() {
+                    assert_eq!(at, event.now);
+                    match event.event {
+                        RTCEventInternal::SCTPBufferReleased(association, 1, n_bytes) => {
+                            assert_eq!(ch.0, association);
+                            released += n_bytes;
+                        }
+                        RTCEventInternal::SCTPBufferedAmountLow(association, 1) => {
+                            assert_eq!(ch.0, association);
+                            low += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            };
+            collect(&mut handler);
+            while handler.poll_write().is_some() {}
+            collect(&mut handler);
+            assert_eq!(size, released);
+            assert_eq!(1, low);
+            handler
+                .handle_timeout(at + Duration::from_millis(1))
+                .unwrap();
+            while handler.poll_write().is_some() {}
+            assert!(handler.poll_event().is_none());
+            assert_eq!(
+                0,
+                ctx.sctp_transport
+                    .sctp_associations
+                    .get_mut(&ch)
+                    .unwrap()
+                    .stream(1)
+                    .unwrap()
+                    .buffered_amount()
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn draining_saved_messages_preserves_the_reset_close_fence() {
+        let mut e = establish();
+        let now = Instant::now();
+        let ch = e.client_ch;
+        let data = server_datagrams_carrying(&mut e, 1, 2, now);
+        e.server_conn.stream(1).unwrap().stop(now).unwrap();
+        let resets = drain_transmits(&mut e.server_conn, now);
+        assert!(!resets.is_empty());
+        let mut ctx = client_ctx(now, e.client_ep, ch, e.client_conn);
+        {
+            let mut handler = SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT);
+            for packet in data.into_iter().chain(resets) {
+                handler.handle_read(raw_read(now, packet)).unwrap();
+            }
+        }
+        assert!(
+            ctx.read_outs.is_empty(),
+            "the two old messages remain in SCTP"
+        );
+        assert!(ctx.pending_readable.contains(&(ch, 1)));
+
+        let mut handler = SctpHandler::new(&mut ctx, 0);
+        for expected in [0, 1] {
+            assert!(
+                handler.poll_event().is_none(),
+                "the close fence cannot overtake an old message"
+            );
+            let read = handler
+                .poll_read()
+                .expect("saved message must survive the reset");
+            assert!(matches!(
+                read.message,
+                RTCMessageInternal::Dtls(DTLSMessage::Sctp(message))
+                    if message.stream_id == 1 && message.payload == vec![expected; 64]
+            ));
+        }
+        // The last read may retire the Stream object. The following read is
+        // EOF, not an error that discards the already collected messages.
+        let close = handler.poll_read().expect("old receiver's close fence");
+        assert!(matches!(
+            close.message,
+            RTCMessageInternal::Dtls(DTLSMessage::SctpEvent(SctpEvent::Closed(_, 1)))
+        ));
+        assert!(handler.poll_read().is_none());
+        assert!(
+            handler.poll_event().is_none(),
+            "a fence has only one delivery route"
+        );
+    }
+
+    #[test]
+    fn public_peer_reads_resume_saved_data_and_reset_without_network_input() {
+        use crate::data_channel::message::RTCDataChannelMessage;
+        use crate::peer_connection::RTCPeerConnectionBuilder;
+        use crate::peer_connection::event::RTCPeerConnectionEvent;
+        use crate::peer_connection::event::data_channel_event::RTCDataChannelEvent;
+        use crate::peer_connection::message::{RTCMessage, TaggedRTCMessage};
+
+        fn dcep(label: &[u8]) -> Bytes {
+            Message::DataChannelOpen(DataChannelOpen {
+                channel_type: ChannelType::Reliable,
+                priority: CHANNEL_PRIORITY_NORMAL,
+                reliability_parameter: 0,
+                label: label.to_vec(),
+                protocol: vec![],
+            })
+            .marshal()
+            .unwrap()
+            .into()
+        }
+
+        // Complete the wire exchange while the application backlog remains full.
+        // No network delivery or timer callback occurs during the public read phase.
+        fn settle(
+            ctx: &mut SctpHandlerContext,
+            peer_ep: &mut Endpoint,
+            peer: &mut Association,
+            now: &mut Instant,
+        ) {
+            for _ in 0..1000 {
+                let mut moved = false;
+                {
+                    let mut handler = SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT);
+                    while let Some(out) = handler.poll_write() {
+                        if let RTCMessageInternal::Dtls(DTLSMessage::Raw(raw)) = out.message {
+                            moved = true;
+                            if let Some((_, DatagramEvent::AssociationEvent(event))) =
+                                peer_ep.handle(*now, client_addr(), None, raw.freeze())
+                            {
+                                peer.handle_event(event);
+                            }
+                        }
+                    }
+                }
+                for packet in drain_transmits(peer, *now) {
+                    moved = true;
+                    SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .handle_read(raw_read(*now, packet))
+                        .unwrap();
+                }
+                while peer.poll().is_some() {}
+                if !moved {
+                    let next = SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .poll_timeout()
+                        .into_iter()
+                        .chain(peer.poll_timeout())
+                        .min();
+                    let Some(next) = next else { return };
+                    *now = next.max(*now);
+                    SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .handle_timeout(*now)
+                        .unwrap();
+                    peer.handle_timeout(*now);
+                }
+            }
+            panic!("wire reset failed to reach quiescence");
+        }
+
+        for split_read in [false, true] {
+            let mut e = establish();
+            let mut now = Instant::now();
+            let ch = e.client_ch;
+            let old_count = SCTP_PIPELINE_READ_BACKLOG_LIMIT + 44;
+            let data = server_datagrams_carrying(&mut e, 1, old_count, now);
+            e.server_conn.stream(1).unwrap().stop(now).unwrap();
+            let resets = drain_transmits(&mut e.server_conn, now);
+            let mut ctx = client_ctx(now, e.client_ep, ch, e.client_conn);
+            for packet in data.into_iter().chain(resets) {
+                SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                    .handle_read(raw_read(now, packet))
+                    .unwrap();
+            }
+            settle(&mut ctx, &mut e.server_ep, &mut e.server_conn, &mut now);
+            assert!(
+                e.server_conn.stream(1).is_err(),
+                "both reset directions completed"
+            );
+            assert!(ctx.read_outs.is_empty());
+            assert!(ctx.pending_readable.contains(&(ch, 1)));
+
+            let mut stream = e
+                .server_conn
+                .open_stream(1, PayloadProtocolIdentifier::Dcep)
+                .unwrap();
+            stream
+                .write_sctp(now, &dcep(b"new"), PayloadProtocolIdentifier::Dcep)
+                .unwrap();
+            stream
+                .write_sctp(
+                    now,
+                    &Bytes::from_static(b"new-data"),
+                    PayloadProtocolIdentifier::Binary,
+                )
+                .unwrap();
+            settle(&mut ctx, &mut e.server_ep, &mut e.server_conn, &mut now);
+
+            let mut pc = RTCPeerConnectionBuilder::new().build(now).unwrap();
+            pc.pipeline_context.sctp_handler_context = ctx;
+            // Model the channel that was already open when the application stalled.
+            pc.get_datachannel_handler()
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: Default::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::Sctp(DataChannelMessage {
+                        association_handle: ch.0,
+                        stream_id: 1,
+                        ppi: PayloadProtocolIdentifier::Dcep,
+                        payload: BytesMut::from(dcep(b"old").as_ref()),
+                        negotiated: false,
+                    })),
+                })
+                .unwrap();
+            let old_id = pc.data_channels.handle_of_stream(&1).unwrap();
+            pc.pipeline_context
+                .datachannel_handler_context
+                .read_outs
+                .clear();
+            pc.pipeline_context
+                .datachannel_handler_context
+                .write_outs
+                .clear();
+            pc.pipeline_context
+                .datachannel_handler_context
+                .event_outs
+                .clear();
+            for _ in 0..SCTP_PIPELINE_READ_BACKLOG_LIMIT {
+                pc.pipeline_context
+                    .data_read_outs
+                    .push_back(TaggedRTCMessage {
+                        now,
+                        message: RTCMessage::DataChannelMessage(
+                            old_id,
+                            RTCDataChannelMessage::default(),
+                        ),
+                    });
+            }
+            let read = |pc: &mut crate::peer_connection::RTCPeerConnection| {
+                if split_read {
+                    pc.poll_data_read()
+                } else {
+                    pc.poll_read()
+                }
+            };
+            for _ in 0..SCTP_PIPELINE_READ_BACKLOG_LIMIT {
+                assert!(matches!(read(&mut pc).unwrap().message,
+                    RTCMessage::DataChannelMessage(id, message) if id == old_id && message.data.is_empty()));
+            }
+            for index in 0..old_count {
+                let out = read(&mut pc).expect("public read must resume the parked SCTP receiver");
+                assert!(matches!(out.message,
+                    RTCMessage::DataChannelMessage(id, message)
+                        if id == old_id && message.data == vec![index as u8; 64]));
+                assert!(
+                    pc.pipeline_context.data_read_outs.len() < SCTP_PIPELINE_READ_BACKLOG_LIMIT
+                );
+                if index == 0 {
+                    assert!(
+                        pc.pipeline_context
+                            .sctp_handler_context
+                            .pending_readable
+                            .contains(&(ch, 1)),
+                        "one public read must not drain every saved SCTP message past the backlog bound"
+                    );
+                }
+            }
+            let new_id = pc
+                .data_channels
+                .handle_of_stream(&1)
+                .expect("new DCEP registers the reused SID");
+            assert_ne!(old_id, new_id);
+            assert_eq!(pc.data_channels.get_by_stream_mut(&1).unwrap().label, "new");
+            assert!(matches!(read(&mut pc).unwrap().message,
+                RTCMessage::DataChannelMessage(id, message) if id == new_id && message.data == b"new-data"[..]));
+            assert!(read(&mut pc).is_none());
+            assert!(
+                pc.pipeline_context
+                    .sctp_handler_context
+                    .pending_readable
+                    .is_empty()
+            );
+            let mut lifecycle = vec![];
+            while let Some(event) = pc.poll_event() {
+                if let RTCPeerConnectionEvent::OnDataChannel(event) = event {
+                    lifecycle.push(event);
+                }
+            }
+            assert!(
+                matches!(lifecycle.as_slice(),
+                [RTCDataChannelEvent::OnClose(old), RTCDataChannelEvent::OnOpen(new)]
+                    if *old == old_id && *new == new_id),
+                "lifecycle order: {lifecycle:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn old_dcep_ack_cannot_complete_new_fragmented_open() {
+        use crate::peer_connection::RTCPeerConnectionBuilder;
+        use datachannel::data_channel::{DataChannel, DataChannelConfig};
+
+        fn settle(
+            ctx: &mut SctpHandlerContext,
+            peer_ep: &mut Endpoint,
+            peer: &mut Association,
+            now: &mut Instant,
+        ) {
+            for _ in 0..1000 {
+                let mut moved = false;
+                {
+                    let mut handler = SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT);
+                    while let Some(out) = handler.poll_write() {
+                        if let RTCMessageInternal::Dtls(DTLSMessage::Raw(raw)) = out.message {
+                            moved = true;
+                            if let Some((_, DatagramEvent::AssociationEvent(event))) =
+                                peer_ep.handle(*now, client_addr(), None, raw.freeze())
+                            {
+                                peer.handle_event(event);
+                            }
+                        }
+                    }
+                }
+                for packet in drain_transmits(peer, *now) {
+                    moved = true;
+                    SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .handle_read(raw_read(*now, packet))
+                        .unwrap();
+                }
+                while peer.poll().is_some() {}
+                if !moved {
+                    let next = SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .poll_timeout()
+                        .into_iter()
+                        .chain(peer.poll_timeout())
+                        .min();
+                    let Some(next) = next else { return };
+                    *now = next.max(*now);
+                    SctpHandler::new(ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                        .handle_timeout(*now)
+                        .unwrap();
+                    peer.handle_timeout(*now);
+                }
+            }
+            panic!("wire reset failed to reach quiescence");
+        }
+
+        let mut e = establish();
+        let mut now = Instant::now();
+        let ch = e.client_ch;
+        let ppi = PayloadProtocolIdentifier::Dcep;
+        let old_open: Bytes = Message::DataChannelOpen(DataChannelOpen {
+            channel_type: ChannelType::Reliable,
+            priority: CHANNEL_PRIORITY_NORMAL,
+            reliability_parameter: 0,
+            label: b"already closed".to_vec(),
+            protocol: vec![],
+        })
+        .marshal()
+        .unwrap()
+        .into();
+        let mut stream = e.server_conn.open_stream(1, ppi).unwrap();
+        stream.write_sctp(now, &old_open, ppi).unwrap();
+        stream.stop(now).unwrap();
+        let mut ctx = client_ctx(now, e.client_ep, ch, e.client_conn);
+        settle(&mut ctx, &mut e.server_ep, &mut e.server_conn, &mut now);
+        assert!(
+            e.server_conn.stream(1).is_err(),
+            "both old protocol resets completed"
+        );
+        assert!(ctx.read_outs.is_empty(), "old OPEN remains parked in SCTP");
+
+        let mut pc = RTCPeerConnectionBuilder::new().build(now).unwrap();
+        pc.pipeline_context.sctp_handler_context = ctx;
+        assert!(pc.poll_read().is_none(), "DCEP has no application payload");
+        assert!(
+            pc.data_channels.handle_of_stream(&1).is_none(),
+            "old Open/Close lifecycle completed"
+        );
+        assert_eq!(
+            pc.pipeline_context
+                .datachannel_handler_context
+                .write_outs
+                .len(),
+            1,
+            "the old OPEN queued its DCEP ACK before its close fence"
+        );
+
+        // Reuse is now valid. Only the first fragment of the new OPEN arrives;
+        // its complete message, and therefore its parameters, are still unknown.
+        let mut opener = DataChannel::dial(
+            DataChannelConfig {
+                channel_type: ChannelType::ReliableUnordered,
+                priority: CHANNEL_PRIORITY_NORMAL,
+                label: "x".repeat(4000),
+                ..Default::default()
+            },
+            e.server_ch.0,
+            1,
+        )
+        .unwrap();
+        let new_open = opener.poll_write().unwrap();
+        assert!(!opener.is_handshake_complete());
+        e.server_conn
+            .open_stream(1, ppi)
+            .unwrap()
+            .write_sctp(now, &new_open.payload.freeze(), ppi)
+            .unwrap();
+        let packets = drain_transmits(&mut e.server_conn, now);
+        assert!(packets.len() >= 2, "new OPEN is fragmented");
+        let first = packets
+            .into_iter()
+            .find(|p| p.len() >= 29 && p[12] == 0 && p[13] & 1 == 0)
+            .unwrap();
+        pc.get_sctp_handler()
+            .handle_read(raw_read(now, first))
+            .unwrap();
+        assert!(pc.poll_read().is_none());
+        assert!(
+            pc.data_channels.handle_of_stream(&1).is_none(),
+            "new OPEN was not reassembled or accepted"
+        );
+
+        // The caller may poll writes after ingesting the next datagram. The old
+        // pending ACK must not attach to the newly created API stream for SID 1.
+        while let Some(out) = pc.get_datachannel_handler().poll_write() {
+            pc.get_sctp_handler().handle_write(out).unwrap();
+        }
+        while let Some(out) = pc.get_sctp_handler().poll_write() {
+            if let RTCMessageInternal::Dtls(DTLSMessage::Raw(raw)) = out.message {
+                if let Some((_, DatagramEvent::AssociationEvent(event))) =
+                    e.server_ep.handle(now, client_addr(), None, raw.freeze())
+                {
+                    e.server_conn.handle_event(event);
+                }
+            }
+        }
+        if let Some(chunks) = e.server_conn.stream(1).unwrap().read_sctp().unwrap() {
+            opener
+                .handle_read(DataChannelMessage {
+                    association_handle: e.server_ch.0,
+                    stream_id: 1,
+                    ppi: chunks.ppi,
+                    payload: chunks.to_payload(8192).unwrap(),
+                    negotiated: false,
+                })
+                .unwrap();
+        }
+        assert!(
+            !opener.is_handshake_complete(),
+            "ACK of an already reset channel completed a new handshake whose OPEN is incomplete at the receiver"
+        );
+    }
+
+    #[test]
+    fn lifecycle_event_poll_cannot_overtake_data_in_the_shared_queue() {
+        let e = establish();
+        let now = Instant::now();
+        let ch = e.client_ch;
+        let mut ctx = client_ctx(now, e.client_ep, ch, e.client_conn);
+        SctpHandler::enqueue_messages(
+            vec![
+                SctpMessage::Inbound(DataChannelMessage {
+                    association_handle: ch.0,
+                    stream_id: 1,
+                    ppi: PayloadProtocolIdentifier::Binary,
+                    payload: BytesMut::from(&b"old"[..]),
+                    negotiated: false,
+                }),
+                SctpMessage::Event(SctpEvent::BufferReleased(ch.0, 1, 3)),
+                SctpMessage::Event(SctpEvent::Closed(ch.0, 1)),
+            ],
+            now,
+            TransportContext::default(),
+            &mut ctx.read_outs,
+            &mut ctx.write_outs,
+        );
+        let mut handler = SctpHandler::new(&mut ctx, 0);
+        assert!(handler.poll_event().is_none());
+        assert!(matches!(handler.poll_read().unwrap().message,
+            RTCMessageInternal::Dtls(DTLSMessage::Sctp(message)) if message.payload == b"old"[..]));
+        assert!(matches!(
+            handler.poll_event().unwrap().event,
+            RTCEventInternal::SCTPBufferReleased(_, 1, 3)
+        ));
+        assert!(matches!(
+            handler.poll_read().unwrap().message,
+            RTCMessageInternal::Dtls(DTLSMessage::SctpEvent(SctpEvent::Closed(_, 1)))
+        ));
+        assert!(handler.poll_read().is_none());
+        assert!(handler.poll_event().is_none());
+    }
+
+    #[test]
+    fn old_message_close_and_reused_sid_open_keep_their_pipeline_order() {
+        fn forward_to_channels(
+            ctx: &mut SctpHandlerContext,
+            dcctx: &mut DataChannelHandlerContext,
+            registry: &mut DataChannelRegistry,
+            stats: &mut RTCStatsAccumulator,
+        ) {
+            let mut sctp = SctpHandler::new(ctx, 0);
+            let mut channels =
+                DataChannelHandler::new(dcctx, registry, stats, None, RTCDtlsRole::Client, None);
+            while let Some(message) = sctp.poll_read() {
+                channels.handle_read(message).unwrap();
+            }
+            assert!(
+                sctp.poll_event().is_none(),
+                "lifecycle was consumed exactly once"
+            );
+        }
+        let dcep = |label: &[u8]| {
+            Bytes::from(
+                Message::DataChannelOpen(DataChannelOpen {
+                    channel_type: ChannelType::Reliable,
+                    priority: CHANNEL_PRIORITY_NORMAL,
+                    reliability_parameter: 0,
+                    label: label.to_vec(),
+                    protocol: vec![],
+                })
+                .marshal()
+                .unwrap(),
+            )
+        };
+        let mut e = establish();
+        let now = Instant::now();
+        e.server_conn
+            .open_stream(1, PayloadProtocolIdentifier::Dcep)
+            .unwrap()
+            .write_sctp(now, &dcep(b"old"), PayloadProtocolIdentifier::Dcep)
+            .unwrap();
+        let mut ctx = client_ctx(now, e.client_ep, e.client_ch, e.client_conn);
+        for packet in drain_transmits(&mut e.server_conn, now) {
+            SctpHandler::new(&mut ctx, 0)
+                .handle_read(raw_read(now, packet))
+                .unwrap();
+        }
+        let mut dcctx = DataChannelHandlerContext::new(now);
+        let mut registry = DataChannelRegistry::new();
+        let mut stats = RTCStatsAccumulator::new();
+        forward_to_channels(&mut ctx, &mut dcctx, &mut registry, &mut stats);
+        let old_id = registry.handle_of_stream(&1).unwrap();
+        dcctx.read_outs.clear();
+        dcctx.write_outs.clear();
+        dcctx.event_outs.clear();
+
+        e.server_conn
+            .stream(1)
+            .unwrap()
+            .write_sctp(
+                now,
+                &Bytes::from_static(b"last old message"),
+                PayloadProtocolIdentifier::Binary,
+            )
+            .unwrap();
+        for packet in drain_transmits(&mut e.server_conn, now) {
+            SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                .handle_read(raw_read(now, packet))
+                .unwrap();
+        }
+        e.server_conn.stream(1).unwrap().stop(now).unwrap();
+        // Finish both protocol resets while the old application message remains
+        // unread. No loss or fabricated RSN is needed to expose the EOF fence.
+        for _ in 0..4 {
+            for packet in drain_transmits(&mut e.server_conn, now) {
+                SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                    .handle_read(raw_read(now, packet))
+                    .unwrap();
+            }
+            let mut handler = SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT);
+            while let Some(packet) = handler.poll_write() {
+                if let RTCMessageInternal::Dtls(DTLSMessage::Raw(raw)) = packet.message
+                    && let Some((_, DatagramEvent::AssociationEvent(event))) =
+                        e.server_ep.handle(now, client_addr(), None, raw.freeze())
+                {
+                    e.server_conn.handle_event(event);
+                }
+            }
+        }
+        assert!(ctx.read_outs.is_empty(), "the old message is still parked");
+        e.server_conn
+            .open_stream(1, PayloadProtocolIdentifier::Dcep)
+            .expect("peer may reuse SID after both protocol resets")
+            .write_sctp(now, &dcep(b"new"), PayloadProtocolIdentifier::Dcep)
+            .unwrap();
+        for packet in drain_transmits(&mut e.server_conn, now) {
+            SctpHandler::new(&mut ctx, SCTP_PIPELINE_READ_BACKLOG_LIMIT)
+                .handle_read(raw_read(now, packet))
+                .unwrap();
+        }
+
+        forward_to_channels(&mut ctx, &mut dcctx, &mut registry, &mut stats);
+        let new_id = registry.handle_of_stream(&1).unwrap();
+        assert_ne!(old_id, new_id);
+        assert_eq!(registry.get(&new_id).unwrap().label, "new");
+        let messages: Vec<_> = dcctx
+            .read_outs
+            .drain(..)
+            .map(|message| {
+                let RTCMessageInternal::Dtls(DTLSMessage::DataChannel(app)) = message.message
+                else {
+                    panic!("unexpected pipeline message");
+                };
+                (app.data_channel_id, app.data_channel_event)
+            })
+            .collect();
+        assert!(matches!(messages.as_slice(), [
+            (old_message_id, DataChannelEvent::Message(message)),
+            (closed_id, DataChannelEvent::Close),
+            (opened_id, DataChannelEvent::Open),
+        ] if *old_message_id == old_id && *closed_id == old_id && *opened_id == new_id
+            && message.data == b"last old message"[..]));
+        assert!(
+            dcctx.event_outs.is_empty(),
+            "close stays with the ordered read pipeline"
+        );
+        assert_eq!(stats.peer_connection.data_channels_closed, 1);
+
+        use crate::peer_connection::event::{RTCDataChannelEvent, RTCPeerConnectionEvent};
+        use crate::peer_connection::handler::endpoint::{EndpointHandler, EndpointHandlerContext};
+        use crate::peer_connection::message::internal::ApplicationMessage;
+        let mut endpoint_ctx = EndpointHandlerContext::default();
+        let mut transceivers = vec![];
+        let mut endpoint = EndpointHandler::new(&mut endpoint_ctx, &mut transceivers, &mut stats);
+        for (data_channel_id, data_channel_event) in messages {
+            endpoint
+                .handle_read(TaggedRTCMessageInternal {
+                    now,
+                    transport: TransportContext::default(),
+                    message: RTCMessageInternal::Dtls(DTLSMessage::DataChannel(
+                        ApplicationMessage {
+                            data_channel_id,
+                            data_channel_event,
+                        },
+                    )),
+                })
+                .unwrap();
+        }
+        assert!(
+            endpoint.poll_read().is_some(),
+            "old application payload remains available"
+        );
+        assert!(matches!(endpoint.poll_event().unwrap().event,
+            RTCEventInternal::RTCPeerConnectionEvent(RTCPeerConnectionEvent::OnDataChannel(
+                RTCDataChannelEvent::OnClose(id))) if id == old_id));
+        assert!(matches!(endpoint.poll_event().unwrap().event,
+            RTCEventInternal::RTCPeerConnectionEvent(RTCPeerConnectionEvent::OnDataChannel(
+                RTCDataChannelEvent::OnOpen(id))) if id == new_id));
+        assert!(endpoint.poll_event().is_none());
+    }
 
     /// A fixed nonce keeps test ids deterministic while still distinguishing the kinds.
     fn test_transport_id(kind: TransportKind) -> RTCTransportId {
@@ -1369,7 +2279,16 @@ mod tests {
             ctx.pending_readable.is_empty(),
             "the stream must be drained after SCTP becomes established"
         );
-        assert_eq!(ctx.read_outs.len(), 1, "early DCEP must be delivered once");
+        assert_eq!(
+            ctx.read_outs.len(),
+            2,
+            "establishment must precede the single DCEP"
+        );
+        let connected = ctx.read_outs.pop_front().expect("establishment event");
+        assert!(matches!(
+            connected.message,
+            RTCMessageInternal::Dtls(DTLSMessage::SctpEvent(SctpEvent::Connected(_)))
+        ));
         let inbound = ctx.read_outs.pop_front().expect("delivered DCEP");
         assert!(matches!(
             &inbound.message,
@@ -1392,6 +2311,7 @@ mod tests {
                 RTCDtlsRole::Client,
                 None,
             );
+            handler.handle_read(connected).expect("SCTP establishment");
             handler
                 .handle_read(inbound)
                 .expect("accept DCEP after SCTP handshake");

--- a/src/peer_connection/message/internal.rs
+++ b/src/peer_connection/message/internal.rs
@@ -1,6 +1,7 @@
 use crate::data_channel::RTCDataChannelId;
 use crate::data_channel::message::RTCDataChannelMessage;
 use crate::media_stream::track::MediaStreamTrackId;
+use crate::peer_connection::event::RTCEventInternal;
 use bytes::BytesMut;
 use datachannel::data_channel::DataChannelMessage;
 use interceptor::Packet;
@@ -36,7 +37,40 @@ pub(crate) enum STUNMessage {
 pub(crate) enum DTLSMessage {
     Raw(BytesMut),
     Sctp(DataChannelMessage),
+    SctpEvent(SctpEvent),
     DataChannel(ApplicationMessage),
+}
+
+/// SCTP lifecycle notifications share the incoming DATA queue. In particular,
+/// closing an old use of a stream must reach the channel registry before a new
+/// DCEP OPEN for that stream, including when reading releases the old receiver.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SctpEvent {
+    Connected(usize),
+    Closed(usize, u16),
+    BufferReleased(usize, u16, usize),
+    BufferedAmountLow(usize, u16),
+    BufferedAmountHigh(usize, u16),
+}
+
+impl SctpEvent {
+    pub(crate) fn into_internal(self) -> RTCEventInternal {
+        match self {
+            Self::Connected(association) => RTCEventInternal::SCTPHandshakeComplete(association),
+            Self::Closed(association, stream) => {
+                RTCEventInternal::SCTPStreamClosed(association, stream)
+            }
+            Self::BufferReleased(association, stream, bytes) => {
+                RTCEventInternal::SCTPBufferReleased(association, stream, bytes)
+            }
+            Self::BufferedAmountLow(association, stream) => {
+                RTCEventInternal::SCTPBufferedAmountLow(association, stream)
+            }
+            Self::BufferedAmountHigh(association, stream) => {
+                RTCEventInternal::SCTPBufferedAmountHigh(association, stream)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +97,7 @@ impl RTCMessageInternal {
             RTCMessageInternal::Dtls(msg) => match msg {
                 DTLSMessage::Raw(bytes) => bytes.len(),
                 DTLSMessage::Sctp(dcm) => dcm.payload.len(),
+                DTLSMessage::SctpEvent(_) => 0,
                 DTLSMessage::DataChannel(app_msg) => match &app_msg.data_channel_event {
                     DataChannelEvent::Open | DataChannelEvent::Close => 0,
                     DataChannelEvent::Message(rtc_dcm) => rtc_dcm.data.len(),


### PR DESCRIPTION
A lost DATA message with a 100 ms lifetime must not be retransmitted when T3 fires two seconds later. Check the queued message's immutable policy before assigning its first TSN and before every T3 or fast retransmission, including retries deferred by the send window. Closes #237.

A small deadline-only fix was not sufficient in the existing architecture. Reliability policy and buffer accounting depended on the live stream object, while stream reset was coupled to message delivery and SID reuse. Regression tests exposed lost policies after close, incorrect handling of late SACKs and fragmented messages, and incomplete reset recovery. Making #237 work through those transitions required separating message lifetime, peer acknowledgments, delivery ownership and RX/TX reset state. The PR therefore includes that internal restructuring and the tests for its dependencies; the public API is preserved.

Abandonment is one idempotent operation over a message identity: it covers sent fragments, advisory Gap-ACKed fragments and a pending tail, releases application buffer credit once, and retains the information needed to retransmit FORWARD-TSN. Actual peer acknowledgment, payload retention and congestion credit remain separate. Reliable messages and DCEP retain their reliability; `Timed(0)` preserves the existing API's initial-transmission behavior. These rules follow [RFC 3758 §§3.5 and 4.1](https://www.rfc-editor.org/rfc/rfc3758.html#section-3.5), [RFC 7496 §3.1](https://www.rfc-editor.org/rfc/rfc7496.html#section-3.1) and [RFC 9260 §§6–8](https://www.rfc-editor.org/rfc/rfc9260.html#section-6).

The close/reset dependencies are implemented explicitly. TX policy and SSN state outlive an API stream object. RX reset waits for its TSN boundary while complete unread messages remain in a separate delivery queue. An immutable outgoing reset stays serialized until its result is known: implicit receipt acknowledgment stops its timer without committing new SSNs, and recovery repeats the same request. Old DATA, EOF and the next DCEP OPEN pass through one lifecycle FIFO. See [RFC 6525 §5](https://www.rfc-editor.org/rfc/rfc6525.html#section-5) and [RFC 8831 §6.7](https://www.rfc-editor.org/rfc/rfc8831.html#section-6.7).

| Dependency and regression | Permanent coverage |
| --- | --- |
| Partial ACK → expiry → late ACK must release bytes once and keep T3 alive | `test_message_abandonment_is_idempotent_after_partial_and_late_acks`, `test_late_real_data_acks_keep_t3_alive`. |
| Lost fragments and FORWARD-TSN must not strand the pending tail | `test_timed_abandonment_covers_pending_tail_and_retries_forward_tsn`, `test_timed_zero_fragment_loss_restores_receive_window`. |
| `stop()` → write needs the reset SSN; another SID must keep sending | `test_write_after_stop_uses_reset_ssn`, `test_serialized_resets_and_reused_sid_do_not_block_other_streams`. |
| Implicit ACK and lost final result must not guess reset success | `test_same_reset_query_preserves_gates_timers_and_late_results`; external `forgotten_result_recovery` with both pinned peers. |
| Old messages, EOF and a new OPEN must reach the right DataChannel owner | `public_peer_reads_resume_saved_data_and_reset_without_network_input`, `old_dcep_ack_cannot_complete_new_fragmented_open`. |
| Duplicate/revoked Gap ACKs and TSN wrap must preserve recovery without scanning unrelated DATA | Eight `sack_recovery` scenarios; stale message selection after ACK and TSN reuse in `message_selection`. |
| A repeated Gap ACK must not repeat credit; a re-ACK after revocation must still update recovery | `duplicate_gap_ack_preserves_t3_and_does_not_repeat_credit`, `reack_after_gap_revocation_resets_t3_without_second_delivery_credit`. |
| Terminal abandonment must release retained payload storage before cumulative ACK | `final_abandonment_drops_payload_owner_before_cumulative_ack`; a separate tagged-allocation probe also checks physical backing release. |
| Gap-ACK overlap, cumulative advance, TSN wrap and close/reopen must not reuse stale state | `gap_range_overlap_matches_small_set_reference_across_cumulative_advance_and_wrap`, `closed_association_does_not_reuse_gap_ack_cache_after_cookie_echo`. |
| Due T3 must survive SACKs or new sends before timeout handling; actual earliest-DATA ACK still restarts it | Four `timer_deadline` regressions, including FORWARD-TSN-only recovery and repeated timeout at the same instant. |
| Releasing excess inflight capacity must preserve retained state, wraparound, revocation and byte credit | Two `shrink_test` regressions over busy, empty, physically wrapped and sparse queues. |

The PR is organized into six logical commits:

1. The SCTP/DataChannel fix, its regression tests and stateful tests.
2. Independent interop/performance tools and their CI workflow.
3. The targeted Gap-ACK and abandoned-payload ownership changes, with their regression tests.
4. Release read receive payloads and exhausted-Rexmit Gap-ACK backing while preserving recovery metadata, with ownership regression tests.
5. Avoid repeated Gap-ACK processing and SACK construction, and compact inflight storage, with independent boundary and queue-model tests.
6. Preserve overdue T3 recovery and release spare inflight storage after cumulative acknowledgments, with six regression tests.

### Performance

| Case | Master rate Mib/s | Updated PR rate Mib/s | Master RSS MiB | Updated PR RSS MiB | Master total CPU s/GiB | Updated PR total CPU s/GiB |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 KiB / N1 / ordered Reliable / default | 231.006 | 679.140 | 21.87 | 17.04 | 16.480 | 16.000 |
| 1 KiB / N1 / ordered Reliable / dedicated | 836.509 | 837.712 | 16.32 | 15.53 | 12.640 | 12.480 |
| 1 KiB / N1 / unordered Rexmit(0) / default | 1152.656 | 689.740 | 15.75 | 19.90 | 16.000 | 15.680 |
| 1 KiB / N1 / unordered Rexmit(0) / dedicated | 327.806 | 500.248 | 173.66 | 18.08 | 24.640 | 20.800 |
| 1 KiB / N10 / ordered Reliable / default | 2015.506 | 2249.952 | 97.54 | 70.04 | 22.848 | 21.056 |
| 1 KiB / N10 / ordered Reliable / dedicated | 755.495 | 803.647 | 159.50 | 128.86 | 12.784 | 11.904 |
| 1 KiB / N10 / unordered Rexmit(0) / default | 2336.300 | 2282.566 | 46.68 | 66.67 | 26.208 | 30.592 |
| 1 KiB / N10 / unordered Rexmit(0) / dedicated | 533.718 | 813.857 | 500.88 | 121.05 | 17.392 | 12.368 |
| 64 KiB / N1 / ordered Reliable / default | 151.821 | 165.147 | 23.93 | 23.12 | 8.480 | 7.840 |
| 64 KiB / N1 / ordered Reliable / dedicated | 287.806 | 287.319 | 14.07 | 12.78 | 8.640 | 8.640 |
| 64 KiB / N1 / unordered Rexmit(0) / default | 551.043 | 1070.900 | 174.04 | 25.18 | 18.560 | 8.000 |
| 64 KiB / N1 / unordered Rexmit(0) / dedicated | 517.075 | 1047.578 | 173.16 | 18.44 | 16.000 | 8.960 |
| 64 KiB / N10 / ordered Reliable / default | 2852.947 | 2855.815 | 106.45 | 103.73 | 15.792 | 14.976 |
| 64 KiB / N10 / ordered Reliable / dedicated | 980.695 | 989.540 | 105.77 | 77.85 | 8.416 | 8.064 |
| 64 KiB / N10 / unordered Rexmit(0) / default | 2537.431 | 2818.585 | 1041.89 | 121.05 | 26.384 | 21.088 |
| 64 KiB / N10 / unordered Rexmit(0) / dedicated | 851.305 | 1074.530 | 445.94 | 82.68 | 11.520 | 8.240 |
