### PR TITLE
feat(dtls): allow a server config to hold both a PSK callback and certificates

### DIFF
--- a/rtc-dtls/src/config.rs
+++ b/rtc-dtls/src/config.rs
@@ -367,6 +367,18 @@ pub enum ExtendedMasterSecretType {
 }
 
 impl ConfigBuilder {
+    fn offered_cipher_suites(&self, is_client: bool) -> Result<Vec<Box<dyn CipherSuite>>> {
+        // a client offers one family or the other, while a server can only offer them if
+        // it actually holds a certificate.
+        let exclude_certificate = if is_client {
+            self.psk.is_some()
+        } else {
+            self.certificates.is_empty()
+        };
+
+        parse_cipher_suites(&self.cipher_suites, self.psk.is_none(), exclude_certificate)
+    }
+
     fn validate(&self, is_client: bool) -> Result<()> {
         if is_client && self.psk.is_some() && self.psk_identity_hint.is_none() {
             return Err(Error::ErrPskAndIdentityMustBeSetForClient);
@@ -376,7 +388,8 @@ impl ConfigBuilder {
             return Err(Error::ErrServerMustHaveCertificate);
         }
 
-        if !self.certificates.is_empty() && self.psk.is_some() {
+        // A server may hold both and let each handshake pick
+        if is_client && !self.certificates.is_empty() && self.psk.is_some() {
             return Err(Error::ErrPskAndCertificate);
         }
 
@@ -384,7 +397,7 @@ impl ConfigBuilder {
             return Err(Error::ErrIdentityNoPsk);
         }
 
-        parse_cipher_suites(&self.cipher_suites, self.psk.is_none(), self.psk.is_some())?;
+        self.offered_cipher_suites(is_client)?;
 
         Ok(())
     }
@@ -405,12 +418,12 @@ impl ConfigBuilder {
         })?;
         self.validate(is_client)?;
 
-        let mut local_cipher_suites: Vec<CipherSuiteId> =
-            parse_cipher_suites(&self.cipher_suites, self.psk.is_none(), self.psk.is_some())?
-                .iter()
-                .map(|cs| cs.id())
-                .filter(|id| id.supported_by(crypto_provider.crypto()))
-                .collect();
+        let mut local_cipher_suites: Vec<CipherSuiteId> = self
+            .offered_cipher_suites(is_client)?
+            .iter()
+            .map(|cs| cs.id())
+            .filter(|id| id.supported_by(crypto_provider.crypto()))
+            .collect();
         if local_cipher_suites.is_empty() {
             return Err(Error::ErrNoAvailableCipherSuites);
         }

--- a/rtc-dtls/src/endpoint.rs
+++ b/rtc-dtls/src/endpoint.rs
@@ -336,27 +336,32 @@ mod tests {
         }
     }
 
+    /// Builds a config offering `suites`, with whichever credentials they need — pass both
+    /// families to get a server holding a psk callback and certificates both.
     fn config(
         provider: Arc<dyn RTCCryptoProvider>,
         is_client: bool,
-        suite: CipherSuiteId,
+        suites: &[CipherSuiteId],
     ) -> Result<Arc<HandshakeConfig>> {
         let mut builder = ConfigBuilder::default()
             .with_crypto_provider(provider.clone())
-            .with_cipher_suites(vec![suite])
+            .with_cipher_suites(suites.to_vec())
             .with_insecure_skip_verify(true);
-        let is_psk = matches!(
-            suite,
-            CipherSuiteId::Tls_Psk_With_Aes_128_Ccm
-                | CipherSuiteId::Tls_Psk_With_Aes_128_Ccm_8
-                | CipherSuiteId::Tls_Psk_With_Aes_128_Gcm_Sha256
-        );
-        if is_psk {
+        let is_psk = |suite: &CipherSuiteId| {
+            matches!(
+                suite,
+                CipherSuiteId::Tls_Psk_With_Aes_128_Ccm
+                    | CipherSuiteId::Tls_Psk_With_Aes_128_Ccm_8
+                    | CipherSuiteId::Tls_Psk_With_Aes_128_Gcm_Sha256
+            )
+        };
+        if suites.iter().any(is_psk) {
             builder = builder.with_psk(Some(Arc::new(|_| Ok(vec![0xab, 0xcd, 0xef]))));
             if is_client {
                 builder = builder.with_psk_identity_hint(Some(b"rtc-dtls-test".to_vec()));
             }
-        } else if !is_client {
+        }
+        if !is_client && suites.iter().any(|suite| !is_psk(suite)) {
             builder = builder.with_certificates(vec![Certificate::generate_self_signed(
                 vec!["localhost".to_owned()],
                 provider.crypto(),
@@ -385,10 +390,11 @@ mod tests {
     fn handshake_and_exchange(
         client_provider: Arc<dyn RTCCryptoProvider>,
         server_provider: Arc<dyn RTCCryptoProvider>,
-        suite: CipherSuiteId,
+        client_suite: CipherSuiteId,
+        server_suites: &[CipherSuiteId],
     ) -> Result<()> {
-        let client_config = config(client_provider, true, suite)?;
-        let server_config = config(server_provider, false, suite)?;
+        let client_config = config(client_provider, true, &[client_suite])?;
+        let server_config = config(server_provider, false, server_suites)?;
         let mut client = Endpoint::new(client_addr(), TransportProtocol::UDP, None);
         let mut server = Endpoint::new(server_addr(), TransportProtocol::UDP, Some(server_config));
         client.connect(Instant::now(), server_addr(), client_config, None)?;
@@ -408,7 +414,7 @@ mod tests {
         }
         assert!(
             client_complete && server_complete,
-            "DTLS handshake did not complete"
+            "DTLS handshake did not complete: client {client_suite:?}, server {server_suites:?}"
         );
 
         client.write(Instant::now(), server_addr(), b"provider-backed DTLS")?;
@@ -442,6 +448,7 @@ mod tests {
             provider.clone(),
             provider,
             CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256,
+            &[CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256],
         )
     }
 
@@ -454,6 +461,7 @@ mod tests {
             provider.clone(),
             provider,
             CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256,
+            &[CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256],
         )
     }
 
@@ -472,8 +480,8 @@ mod tests {
             CipherSuiteId::Tls_Psk_With_Aes_128_Ccm,
             CipherSuiteId::Tls_Psk_With_Aes_128_Ccm_8,
         ] {
-            handshake_and_exchange(ring.clone(), aws.clone(), suite)?;
-            handshake_and_exchange(aws.clone(), ring.clone(), suite)?;
+            handshake_and_exchange(ring.clone(), aws.clone(), suite, &[suite])?;
+            handshake_and_exchange(aws.clone(), ring.clone(), suite, &[suite])?;
         }
         Ok(())
     }
@@ -486,12 +494,33 @@ mod tests {
         let config = config(
             provider,
             true,
-            CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256,
+            &[CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256],
         )?;
         let mut endpoint = Endpoint::new(client_addr(), TransportProtocol::UDP, None);
 
         let result = endpoint.connect(Instant::now(), server_addr(), config, None);
         assert!(matches!(result, Err(Error::Crypto(_))));
+        Ok(())
+    }
+
+    #[cfg(feature = "crypto-ring")]
+    #[test]
+    fn one_server_config_serves_psk_and_certificate_clients() -> Result<()> {
+        let provider: Arc<dyn RTCCryptoProvider> = Arc::new(crypto::providers::RingProvider::new());
+        let certificate_and_psk_suites = [
+            CipherSuiteId::Tls_Ecdhe_Ecdsa_With_Aes_128_Gcm_Sha256,
+            CipherSuiteId::Tls_Psk_With_Aes_128_Ccm_8,
+        ];
+
+        for client_suite in certificate_and_psk_suites {
+            handshake_and_exchange(
+                provider.clone(),
+                provider.clone(),
+                client_suite,
+                &certificate_and_psk_suites,
+            )?;
+        }
+
         Ok(())
     }
 }

--- a/rtc-dtls/src/flight/flight0.rs
+++ b/rtc-dtls/src/flight/flight0.rs
@@ -196,7 +196,7 @@ impl Flight for Flight0 {
         state.remote_epoch = 0;
 
         state.named_curve = DEFAULT_NAMED_CURVE;
-        if cfg.local_psk_callback.is_none() {
+        if !state.is_cipher_suite_psk() {
             state.named_curve = cfg.local_named_curves[0];
         }
         if let Err(error) = state.local_random.populate(cfg.provider().random()) {

--- a/rtc-dtls/src/flight/flight4.rs
+++ b/rtc-dtls/src/flight/flight4.rs
@@ -290,7 +290,9 @@ impl Flight for Flight4 {
                 }
 
                 let mut pre_master_secret = vec![];
-                if let Some(local_psk_callback) = &cfg.local_psk_callback {
+                if state.is_cipher_suite_psk()
+                    && let Some(local_psk_callback) = &cfg.local_psk_callback
+                {
                     let psk = match local_psk_callback(&client_key_exchange.identity_hint) {
                         Ok(psk) => psk,
                         Err(err) => {
@@ -449,6 +451,12 @@ impl Flight for Flight4 {
             ));
         };
 
+        // A psk suite is sent no CertificateRequest (see `generate`), so skip `client_auth`
+        // rather than fail it for a certificate it was never asked for.
+        if state.is_cipher_suite_psk() {
+            return Ok(Box::new(Flight6 {}) as Box<dyn Flight>);
+        }
+
         match cfg.client_auth {
             ClientAuthType::RequireAnyClientCert => {
                 trace!(
@@ -529,7 +537,7 @@ impl Flight for Flight4 {
             }));
         }
 
-        if cfg.local_psk_callback.is_none() {
+        if !state.is_cipher_suite_psk() {
             extensions.extend_from_slice(&[
                 Extension::SupportedEllipticCurves(ExtensionSupportedEllipticCurves {
                     elliptic_curves: cfg.local_named_curves.clone(),
@@ -564,7 +572,7 @@ impl Flight for Flight4 {
             reset_local_sequence_number: false,
         }];
 
-        if cfg.local_psk_callback.is_none() {
+        if !state.is_cipher_suite_psk() {
             let certificate = match cfg.get_certificate(&cfg.server_name) {
                 Ok(cert) => cert,
                 Err(err) => {

--- a/rtc-dtls/src/state.rs
+++ b/rtc-dtls/src/state.rs
@@ -282,6 +282,13 @@ impl State {
         self.cipher_suite.as_deref()
     }
 
+    /// Whether the negotiated cipher suite authenticates with a pre-shared key.
+    pub fn is_cipher_suite_psk(&self) -> bool {
+        self.cipher_suite
+            .as_ref()
+            .is_some_and(|cipher_suite| cipher_suite.is_psk())
+    }
+
     /// Exports `length` bytes of keying material from an established session, as defined in
     /// RFC 5705.
     ///


### PR DESCRIPTION
## Problem

A DTLS server config could hold a PSK callback *or* certificates, never both: `validate` rejected the combination outright, and the flights decided which credential path a handshake took by asking the config (`cfg.local_psk_callback.is_none()`).

That forces one listening socket per credential type. A deployment whose peers are provisioned with a mixture of PSKs and certificates needs a separate server for each.

## Change

A server config may now carry both, and which credential a given handshake uses is settled by the cipher suite it negotiated rather than by what the config happens to hold.

- **`validate`**: `ErrPskAndCertificate` now applies to clients only. A client presents one credential, so for it the two remain exclusive; a server lets each handshake pick.
- **`State::is_cipher_suite_psk()`**: new accessor for the negotiated suite's family. flight0 and flight4 use it in place of `cfg.local_psk_callback.is_none()` when choosing the named curve, the ServerHello extensions, and whether to send a Certificate. The suite is chosen from the ClientHello in flight 0, so it is known at every point below.
- **`ConfigBuilder::offered_cipher_suites`**: centralises which families go into the offer. A client drops the certificate suites when it holds a PSK; a server drops them only when it holds no certificate — having a PSK callback is no longer the answer to whether it has a certificate.

Client behaviour is unchanged: it offers one family or the other, and its own certificate is optional either way.

## Test

`one_server_config_serves_psk_and_certificate_clients` builds a single server config holding both a PSK callback and a certificate, then drives a full handshake and record exchange against a PSK client and a certificate client in turn.

## Verification

`cargo test --workspace --all-features` — 1898 passed, 0 failed.
`cargo clippy --workspace --all-features --all-targets` — no new warnings.
